### PR TITLE
Fix CI branch trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
   push:
-    branches: [ master, 'stable/*' ]
+    branches: [ main, 'stable/*' ]
   pull_request:
-    branches: [ master, 'stable/*' ]
+    branches: [ main, 'stable/*' ]
 jobs:
   tests:
     name: tests-python${{ matrix.python-version }}-${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@ requires = ["setuptools", "wheel"]
 
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py36', 'py37', 'py38']


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The main branch for development is named 'main' not 'master'. This
commit migrates the ci trigger to use the proper branch name.

### Details and comments


