### PR TITLE
Rework experiment options

### DIFF
--- a/qiskit_experiments/analysis/plotting.py
+++ b/qiskit_experiments/analysis/plotting.py
@@ -35,7 +35,7 @@ def plot_curve_fit(
 ):
     """Generate plot of a curve fit analysis result.
 
-    Wraps ``matplotlib.pyplot.plot``.
+    Wraps :func:`matplotlib.pyplot.plot`.
 
     Args:
         func: the fit function for curve_fit.

--- a/qiskit_experiments/base_analysis.py
+++ b/qiskit_experiments/base_analysis.py
@@ -24,56 +24,34 @@ from .experiment_data import ExperimentData, AnalysisResult
 
 
 class BaseAnalysis(ABC):
-    """Base Analysis class for analyzing Experiment data."""
+    """Base Analysis class for analyzing Experiment data.
+
+    When designing Analysis subclasses default values for any kwarg
+    analysis options of the `run` method should be set by overriding
+    the `_default_options` class method. When calling `run` these
+    default values will combined with all other option kwargs in the
+    run method and passed to the `_run_analysis` function.
+    """
 
     # Expected experiment data container for analysis
     __experiment_data__ = ExperimentData
-
-    def __init__(self, **options):
-        """Initialize a base analysis class
-
-        Args:
-            options: kwarg options for analysis.
-        """
-        self._options = self._default_options()
-        self.set_options(**options)
 
     @classmethod
     def _default_options(cls) -> Options:
         return Options()
 
-    def set_options(self, **fields):
-        """Set the analysis options.
+    def run(self, experiment_data, save=True, return_figures=False, **options):
+        """Run analysis and update ExperimentData with analysis result.
 
         Args:
-            fields: The fields to update the options
-        """
-        self._options.update_options(**fields)
-
-    @property
-    def options(self) -> Options:
-        """Return the analysis options.
-
-        The options of an analysis class are used to provide kwarg values for
-        the :meth:`run` method.
-        """
-        return self._options
-
-    def run(self,
-            experiment_data: ExperimentData,
-            save: bool = True,
-            return_figures: bool = False,
-            **options):
-        """Run analysis and update stored ExperimentData with analysis result.
-
-        Args:
-            experiment_data: the experiment data to analyze.
-            save: if True save analysis results and figures to the
-                  :class:`ExperimentData`.
-            return_figures: if true return a pair of ``(analysis_results, figures)``,
-                            otherwise return only analysis_results.
-            options: additional analysis options. Any values set here will
-                     override the value from :meth:`options` for the current run.
+            experiment_data (ExperimentData): the experiment data to analyze.
+            save (bool): if True save analysis results and figures to the
+                         :class:`ExperimentData`.
+            return_figures (bool): if true return a pair of
+                                   ``(analysis_results, figures)``,
+                                    otherwise return only analysis_results.
+            options: additional analysis options. See class documentation for
+                     supported options.
 
         Returns:
             AnalysisResult: the output of the analysis that produces a
@@ -93,9 +71,8 @@ class BaseAnalysis(ABC):
                 f"Invalid experiment data type, expected {self.__experiment_data__.__name__}"
                 f" but received {type(experiment_data).__name__}"
             )
-
-        # Get runtime analysis options
-        analysis_options = copy.copy(self.options)
+        # Get analysis options
+        analysis_options = self._default_options()
         analysis_options.update_options(**options)
         analysis_options = analysis_options.__dict__
 

--- a/qiskit_experiments/base_analysis.py
+++ b/qiskit_experiments/base_analysis.py
@@ -15,12 +15,14 @@ Base analysis class.
 
 from abc import ABC, abstractmethod
 from typing import List, Tuple
-import copy
 
 from qiskit.providers.options import Options
 from qiskit.exceptions import QiskitError
 
-from .experiment_data import ExperimentData, AnalysisResult
+from qiskit_experiments.experiment_data import ExperimentData, AnalysisResult
+
+# pylint: disable = unused-import
+from qiskit_experiments.matplotlib import pyplot
 
 
 class BaseAnalysis(ABC):
@@ -40,25 +42,29 @@ class BaseAnalysis(ABC):
     def _default_options(cls) -> Options:
         return Options()
 
-    def run(self, experiment_data, save=True, return_figures=False, **options):
+    def run(
+        self,
+        experiment_data: ExperimentData,
+        save: bool = True,
+        return_figures: bool = False,
+        **options,
+    ):
         """Run analysis and update ExperimentData with analysis result.
 
         Args:
-            experiment_data (ExperimentData): the experiment data to analyze.
-            save (bool): if True save analysis results and figures to the
-                         :class:`ExperimentData`.
-            return_figures (bool): if true return a pair of
-                                   ``(analysis_results, figures)``,
-                                    otherwise return only analysis_results.
+            experiment_data: the experiment data to analyze.
+            save: if True save analysis results and figures to the
+                  :class:`ExperimentData`.
+            return_figures: if true return a pair of
+                            ``(analysis_results, figures)``,
+                            otherwise return only analysis_results.
             options: additional analysis options. See class documentation for
                      supported options.
 
         Returns:
-            AnalysisResult: the output of the analysis that produces a
-                            single result.
             List[AnalysisResult]: the output for analysis that produces
                                   multiple results.
-            tuple: If ``return_figures=True`` the output is a pair
+            Tuple: If ``return_figures=True`` the output is a pair
                    ``(analysis_results, figures)`` where  ``analysis_results``
                    may be a single or list of :class:`AnalysisResult` objects, and
                    ``figures`` may be None, a single figure, or a list of figures.
@@ -101,8 +107,8 @@ class BaseAnalysis(ABC):
 
     @abstractmethod
     def _run_analysis(
-        self, data: ExperimentData, **options
-    ) -> Tuple[List[AnalysisResult], List["matplotlib.figure.Figure"]]:
+        self, experiment_data: ExperimentData, **options
+    ) -> Tuple[List[AnalysisResult], List["pyplot.Figure"]]:
         """Run analysis on circuit data.
 
         Args:

--- a/qiskit_experiments/base_analysis.py
+++ b/qiskit_experiments/base_analysis.py
@@ -28,10 +28,16 @@ from qiskit_experiments.matplotlib import pyplot
 class BaseAnalysis(ABC):
     """Base Analysis class for analyzing Experiment data.
 
+    The data produced by experiments (i.e. subclasses of BaseExperiment)
+    are analyzed with subclasses of BaseExperiment. The analysis is
+    typically run after the data has been gathered by the experiment.
+    For example, an analysis may perform some data processing of the
+    measured data and a fit to a function to extract a parameter.
+
     When designing Analysis subclasses default values for any kwarg
     analysis options of the `run` method should be set by overriding
     the `_default_options` class method. When calling `run` these
-    default values will combined with all other option kwargs in the
+    default values will be combined with all other option kwargs in the
     run method and passed to the `_run_analysis` function.
     """
 

--- a/qiskit_experiments/base_experiment.py
+++ b/qiskit_experiments/base_experiment.py
@@ -142,17 +142,13 @@ class BaseExperiment(ABC):
         Raises:
             QiskitError: if experiment_data container is not valid for analysis.
         """
-        if self.__analysis_class__ is None:
-            raise QiskitError(f"Experiment {self._type} does not have a default Analysis class")
-
         # Get analysis options
         analysis_options = copy.copy(self.analysis_options)
         analysis_options.update_options(**options)
         analysis_options = analysis_options.__dict__
 
         # Run analysis
-        # pylint: disable = not-callable
-        analysis = self.__analysis_class__()
+        analysis = self.analysis()
         analysis.run(experiment_data, save=True, return_figures=False, **analysis_options)
         return experiment_data
 
@@ -167,12 +163,12 @@ class BaseExperiment(ABC):
         return self._physical_qubits
 
     @classmethod
-    def analysis(cls, **kwargs):
+    def analysis(cls):
         """Return the default Analysis class for the experiment."""
         if cls.__analysis_class__ is None:
             raise QiskitError(f"Experiment {cls.__name__} does not have a default Analysis class")
         # pylint: disable = not-callable
-        return cls.__analysis_class__(**kwargs)
+        return cls.__analysis_class__()
 
     @abstractmethod
     def circuits(self, backend: Optional[Backend] = None) -> List[QuantumCircuit]:

--- a/qiskit_experiments/base_experiment.py
+++ b/qiskit_experiments/base_experiment.py
@@ -71,7 +71,7 @@ class BaseExperiment(ABC):
                 raise QiskitError("Duplicate qubits in physical qubits list.")
 
         # Experiment options
-        self._options = self._default_options()
+        self._experiment_options = self._default_experiment_options()
         self._transpile_options = self._default_transpile_options()
         self._run_options = self._default_run_options()
         self._analysis_options = self._default_analysis_options()
@@ -194,7 +194,7 @@ class BaseExperiment(ABC):
         # generation
 
     @classmethod
-    def _default_options(cls) -> Options:
+    def _default_experiment_options(cls) -> Options:
         """Default kwarg options for experiment"""
         # Experiment subclasses should override this method to return
         # an `Options` object containing all the supported options for
@@ -203,11 +203,11 @@ class BaseExperiment(ABC):
         return Options()
 
     @property
-    def options(self) -> Options:
+    def experiment_options(self) -> Options:
         """Return the options for the experiment."""
-        return self._options
+        return self._experiment_options
 
-    def set_options(self, **fields):
+    def set_experiment_options(self, **fields):
         """Set the experiment options.
 
         Args:
@@ -217,18 +217,18 @@ class BaseExperiment(ABC):
             AttributeError: If the field passed in is not a supported options
         """
         for field in fields:
-            if not hasattr(self._options, field):
+            if not hasattr(self._experiment_options, field):
                 raise AttributeError(
                     f"Options field {field} is not valid for {type(self).__name__}"
                 )
-        self._options.update_options(**fields)
+        self._experiment_options.update_options(**fields)
 
     @classmethod
     def _default_transpile_options(cls) -> Options:
         """Default transpiler options for transpilation of circuits"""
         # Experiment subclasses can override this method if they need
-        # to set specific transpiler options defaults for running the
-        # experiment.
+        # to set specific default transpiler options to transpile the
+        # experiment circuits.
         return Options(optimization_level=0)
 
     @property

--- a/qiskit_experiments/base_experiment.py
+++ b/qiskit_experiments/base_experiment.py
@@ -14,18 +14,15 @@ Base Experiment class.
 """
 
 from abc import ABC, abstractmethod
-from typing import Union, Iterable, Optional, Tuple, List
+from typing import Iterable, Optional, Tuple, List
 import copy
 from numbers import Integral
-from typing import List, Optional, Iterable, Tuple, Union
 
 from qiskit import transpile, assemble, QuantumCircuit
 from qiskit.providers.options import Options
 from qiskit.providers.backend import Backend
 from qiskit.providers.basebackend import BaseBackend as LegacyBackend
 from qiskit.exceptions import QiskitError
-from qiskit.providers.backend import Backend
-from qiskit.providers.basebackend import BaseBackend as LegacyBackend
 
 from .experiment_data import ExperimentData
 
@@ -107,9 +104,7 @@ class BaseExperiment(ABC):
             experiment_data = self.__experiment_data__(self, backend=backend)
 
         # Generate and transpile circuits
-        circuits = self._transpile(
-            self.circuits(backend), backend, **self.transpile_options.__dict__
-        )
+        circuits = transpile(self.circuits(backend), backend, **self.transpile_options.__dict__)
 
         # Run circuits on backend
         run_opts = copy.copy(self.run_options)
@@ -172,7 +167,7 @@ class BaseExperiment(ABC):
         return self._physical_qubits
 
     @classmethod
-    def analysis(cls, **kwargs) -> "BaseAnalysis":
+    def analysis(cls, **kwargs):
         """Return the default Analysis class for the experiment."""
         if cls.__analysis_class__ is None:
             raise QiskitError(f"Experiment {cls.__name__} does not have a default Analysis class")
@@ -187,7 +182,7 @@ class BaseExperiment(ABC):
             backend: Optional, a backend object.
 
         Returns:
-            A list of :class:`QuantumCircuit`s.
+            A list of :class:`QuantumCircuit`.
 
         .. note::
             These circuits should be on qubits ``[0, .., N-1]`` for an
@@ -197,20 +192,6 @@ class BaseExperiment(ABC):
         # NOTE: Subclasses should override this method using the `options`
         # values for any explicit experiment options that effect circuit
         # generation
-
-    def _transpile(
-        self,
-        circuits: Union[QuantumCircuit, List[QuantumCircuit]],
-        backend: Optional[Backend] = None,
-        **transpile_options,
-    ) -> List[QuantumCircuit]:
-        """Custom transpilation of circuits for running on backend.
-
-        Subclasses may modify this method if they need to customize how
-        transpilation is done, for example to update metadata in the
-        transpiled circuits.
-        """
-        return transpile(circuits, backend=backend, **transpile_options)
 
     @classmethod
     def _default_options(cls) -> Options:

--- a/qiskit_experiments/base_experiment.py
+++ b/qiskit_experiments/base_experiment.py
@@ -132,18 +132,11 @@ class BaseExperiment(ABC):
         # Return the ExperimentData future
         return experiment_data
 
-    def run_analysis(
-        self, experiment_data, save=True, return_figures=False, **options
-    ) -> ExperimentData:
+    def run_analysis(self, experiment_data, **options) -> ExperimentData:
         """Run analysis and update ExperimentData with analysis result.
 
         Args:
             experiment_data (ExperimentData): the experiment data to analyze.
-            save (bool): if True save analysis results and figures to the
-                         :class:`ExperimentData`.
-            return_figures (bool): if true return a pair of
-                                   ``(analysis_results, figures)``,
-                                    otherwise return only analysis_results.
             options: additional analysis options. Any values set here will
                      override the value from :meth:`analysis_options`
                      for the current run.
@@ -163,8 +156,9 @@ class BaseExperiment(ABC):
         analysis_options = analysis_options.__dict__
 
         # Run analysis
+        # pylint: disable = not-callable
         analysis = self.__analysis_class__()
-        analysis.run(experiment_data, **analysis_options)
+        analysis.run(experiment_data, save=True, return_figures=False, **analysis_options)
         return experiment_data
 
     @property

--- a/qiskit_experiments/base_experiment.py
+++ b/qiskit_experiments/base_experiment.py
@@ -191,6 +191,10 @@ class BaseExperiment(ABC):
     @classmethod
     def _default_options(cls) -> Options:
         """Default kwarg options for experiment"""
+        # Experiment subclasses should override this method to return
+        # an `Options` object containing all the supported options for
+        # that experiment and their default values. Only options listed
+        # here can be modified later by the `set_options` method.
         return Options()
 
     @property
@@ -217,6 +221,9 @@ class BaseExperiment(ABC):
     @classmethod
     def _default_transpile_options(cls) -> Options:
         """Default transpiler options for transpilation of circuits"""
+        # Experiment subclasses can override this method if they need
+        # to set specific transpiler options defaults for running the
+        # experiment.
         return Options(optimization_level=0)
 
     @property
@@ -260,8 +267,10 @@ class BaseExperiment(ABC):
 
     @classmethod
     def _default_analysis_options(cls) -> Options:
-        """Default transpiler options for transpilation of circuits"""
-        # These should typically be set by the analysis class default options
+        """Default options for analysis of experiment results."""
+        # Experiment subclasses can override this method if they need
+        # to set specific analysis options defaults that are different
+        # from the Analysis subclass `_default_options` values.
         if cls.__analysis_class__:
             return cls.__analysis_class__._default_options()
         return None

--- a/qiskit_experiments/characterization/__init__.py
+++ b/qiskit_experiments/characterization/__init__.py
@@ -23,6 +23,7 @@ Experiments
     :toctree: ../stubs/
 
     T1Experiment
+    T2StarExperiment
 
 
 Analysis
@@ -32,6 +33,7 @@ Analysis
     :toctree: ../stubs/
 
     T1Analysis
+    T2StarAnalysis
 """
 from .t1_experiment import T1Experiment, T1Analysis
-from .t2star_experiment import T2StarExperiment
+from .t2star_experiment import T2StarExperiment, T2StarAnalysis

--- a/qiskit_experiments/characterization/t1_experiment.py
+++ b/qiskit_experiments/characterization/t1_experiment.py
@@ -221,7 +221,7 @@ class T1Experiment(BaseExperiment):
     __analysis_class__ = T1Analysis
 
     @classmethod
-    def _default_options(cls) -> Options:
+    def _default_experiment_options(cls) -> Options:
         return Options(delays=None, unit="s")
 
     def __init__(
@@ -249,7 +249,7 @@ class T1Experiment(BaseExperiment):
         super().__init__([qubit])
 
         # Set experiment options
-        self.set_options(delays=delays, unit=unit)
+        self.set_experiment_options(delays=delays, unit=unit)
 
     def circuits(self, backend: Optional[Backend] = None) -> List[QuantumCircuit]:
         """
@@ -264,7 +264,7 @@ class T1Experiment(BaseExperiment):
         Raises:
             AttributeError: if unit is dt but dt parameter is missing in the backend configuration
         """
-        if self.options.unit == "dt":
+        if self.experiment_options.unit == "dt":
             try:
                 dt_factor = getattr(backend.configuration(), "dt")
             except AttributeError as no_dt:
@@ -272,11 +272,11 @@ class T1Experiment(BaseExperiment):
 
         circuits = []
 
-        for delay in self.options.delays:
+        for delay in self.experiment_options.delays:
             circ = QuantumCircuit(1, 1)
             circ.x(0)
             circ.barrier(0)
-            circ.delay(delay, 0, self.options.unit)
+            circ.delay(delay, 0, self.experiment_options.unit)
             circ.barrier(0)
             circ.measure(0, 0)
 
@@ -284,10 +284,10 @@ class T1Experiment(BaseExperiment):
                 "experiment_type": self._type,
                 "qubit": self.physical_qubits[0],
                 "xval": delay,
-                "unit": self.options.unit,
+                "unit": self.experiment_options.unit,
             }
 
-            if self.options.unit == "dt":
+            if self.experiment_options.unit == "dt":
                 circ.metadata["dt_factor"] = dt_factor
 
             circuits.append(circ)

--- a/qiskit_experiments/characterization/t1_experiment.py
+++ b/qiskit_experiments/characterization/t1_experiment.py
@@ -33,12 +33,17 @@ class T1Analysis(BaseAnalysis):
     """T1 Experiment result analysis class.
 
     Analysis Options:
-        t1_guess (float): Optional, an initial guess of T1
-        amplitude_guess (float): Optional, an initial guess of the coefficient of the exponent
-        offset_guess (float): Optional, an initial guess of the offset
-        t1_bounds (list of two floats): Optional, lower bound and upper bound to T1
-        amplitude_bounds (list of two floats): Optional, lower bound and upper bound to the amplitude
-        offset_bounds (list of two floats): Optional, lower bound and upper bound to the offset
+
+        * t1_guess (float): Optional, an initial guess of T1.
+        * amplitude_guess (float): Optional, an initial guess of the
+                                   coefficient of the exponent.
+        * offset_guess (float): Optional, an initial guess of the offset.
+        * t1_bounds (list of two floats): Optional, lower bound and upper
+                                          bound to T1.
+        * amplitude_bounds (list of two floats): Optional, lower bound and upper
+                                                 bound to the amplitude.
+        * offset_bounds (list of two floats): Optional, lower bound and
+                                              upper bound to the offset.
     """
 
     @classmethod
@@ -64,7 +69,6 @@ class T1Analysis(BaseAnalysis):
         offset_bounds=None,
         plot=True,
         ax=None,
-        **kwargs,
     ) -> Tuple[AnalysisResult, List["matplotlib.figure.Figure"]]:
         """
         Calculate T1
@@ -73,17 +77,24 @@ class T1Analysis(BaseAnalysis):
             experiment_data (ExperimentData): the experiment data to analyze
             t1_guess (float): Optional, an initial guess of T1
             amplitude_guess (float): Optional, an initial guess of the coefficient
-                of the exponent
+                                     of the exponent
             offset_guess (float): Optional, an initial guess of the offset
             t1_bounds (list of two floats): Optional, lower bound and upper bound to T1
-            amplitude_bounds (list of two floats): Optional, lower bound and upper bound to the amplitude
-            offset_bounds (list of two floats): Optional, lower bound and upper bound to the offset
+            amplitude_bounds (list of two floats): Optional, lower bound and upper
+                                                   bound to the amplitude
+            offset_bounds (list of two floats): Optional, lower bound and upper
+                                                bound to the offset
+            plot (bool): Generator plot of exponential fit.
+            ax (AxesSubplot): Optional, axes to add figure to.
 
         Returns:
             The analysis result with the estimated T1
         """
-        unit = experiment_data._data[0]["metadata"]["unit"]
-        conversion_factor = experiment_data._data[0]["metadata"].get("dt_factor", None)
+        data = experiment_data.data()
+        unit = data[0]["metadata"]["unit"]
+        conversion_factor = data[0]["metadata"].get("dt_factor", None)
+        qubit = data[0]["metadata"]["qubit"]
+
         if conversion_factor is None:
             conversion_factor = 1 if unit == "s" else apply_prefix(1, unit)
 
@@ -202,9 +213,9 @@ class T1Experiment(BaseExperiment):
     """T1 experiment class.
 
     Experiment Options:
-        delays: delay times of the experiments
-        unit: Optional, unit of the delay times. Supported units are
-              's', 'ms', 'us', 'ns', 'ps', 'dt'.
+        * delays: delay times of the experiments
+        * unit: Optional, unit of the delay times. Supported units are
+                's', 'ms', 'us', 'ns', 'ps', 'dt'.
     """
 
     __analysis_class__ = T1Analysis
@@ -240,7 +251,7 @@ class T1Experiment(BaseExperiment):
         # Set experiment options
         self.set_options(delays=delays, unit=unit)
 
-    def circuits(self, backend: Optional["Backend"] = None) -> List[QuantumCircuit]:
+    def circuits(self, backend: Optional[Backend] = None) -> List[QuantumCircuit]:
         """
         Return a list of experiment circuits
 

--- a/qiskit_experiments/characterization/t1_experiment.py
+++ b/qiskit_experiments/characterization/t1_experiment.py
@@ -199,7 +199,13 @@ class T1Analysis(BaseAnalysis):
 
 
 class T1Experiment(BaseExperiment):
-    """T1 experiment class"""
+    """T1 experiment class.
+
+    Experiment Options:
+        delays: delay times of the experiments
+        unit: Optional, unit of the delay times. Supported units are
+              's', 'ms', 'us', 'ns', 'ps', 'dt'.
+    """
 
     __analysis_class__ = T1Analysis
 

--- a/qiskit_experiments/characterization/t1_experiment.py
+++ b/qiskit_experiments/characterization/t1_experiment.py
@@ -233,7 +233,12 @@ class T1Experiment(BaseExperiment):
         """
         if len(delays) < 3:
             raise ValueError("T1 experiment: number of delays must be at least 3")
-        super().__init__([qubit], delays=delays, unit=unit)
+
+        # Initialize base experiment
+        super().__init__([qubit])
+
+        # Set experiment options
+        self.set_options(delays=delays, unit=unit)
 
     def circuits(self, backend: Optional["Backend"] = None) -> List[QuantumCircuit]:
         """

--- a/qiskit_experiments/characterization/t1_experiment.py
+++ b/qiskit_experiments/characterization/t1_experiment.py
@@ -19,6 +19,7 @@ import numpy as np
 from qiskit.providers import Backend
 from qiskit.circuit import QuantumCircuit
 from qiskit.utils import apply_prefix
+from qiskit.providers.options import Options
 
 from qiskit_experiments.base_experiment import BaseExperiment
 from qiskit_experiments.base_analysis import BaseAnalysis
@@ -29,9 +30,29 @@ from qiskit_experiments import AnalysisResult
 
 
 class T1Analysis(BaseAnalysis):
-    """T1 Experiment result analysis class."""
+    """T1 Experiment result analysis class.
 
-    # pylint: disable=arguments-differ, unused-argument
+    Analysis Options:
+        t1_guess (float): Optional, an initial guess of T1
+        amplitude_guess (float): Optional, an initial guess of the coefficient of the exponent
+        offset_guess (float): Optional, an initial guess of the offset
+        t1_bounds (list of two floats): Optional, lower bound and upper bound to T1
+        amplitude_bounds (list of two floats): Optional, lower bound and upper bound to the amplitude
+        offset_bounds (list of two floats): Optional, lower bound and upper bound to the offset
+    """
+
+    @classmethod
+    def _default_options(cls):
+        return Options(
+            t1_guess=None,
+            amplitude_guess=None,
+            offset_guess=None,
+            t1_bounds=None,
+            amplitude_bounds=None,
+            offset_bounds=None,
+        )
+
+    # pylint: disable=arguments-differ
     def _run_analysis(
         self,
         experiment_data,
@@ -54,23 +75,15 @@ class T1Analysis(BaseAnalysis):
             amplitude_guess (float): Optional, an initial guess of the coefficient
                 of the exponent
             offset_guess (float): Optional, an initial guess of the offset
-            t1_bounds (list of two floats): Optional, lower bound and upper
-                bound to T1
-            amplitude_bounds (list of two floats): Optional, lower bound and
-                upper bound to the amplitude
-            offset_bounds (list of two floats): Optional, lower bound and upper
-                bound to the offset
-            plot: If True generate a plot of fitted data.
-            ax: Optional, matplotlib axis to add plot to.
-            kwargs: Trailing unused function parameters
+            t1_bounds (list of two floats): Optional, lower bound and upper bound to T1
+            amplitude_bounds (list of two floats): Optional, lower bound and upper bound to the amplitude
+            offset_bounds (list of two floats): Optional, lower bound and upper bound to the offset
 
         Returns:
             The analysis result with the estimated T1
         """
-        data = experiment_data.data()
-        unit = data[0]["metadata"]["unit"]
-        conversion_factor = data[0]["metadata"].get("dt_factor", None)
-        qubit = data[0]["metadata"]["qubit"]
+        unit = experiment_data._data[0]["metadata"]["unit"]
+        conversion_factor = experiment_data._data[0]["metadata"].get("dt_factor", None)
         if conversion_factor is None:
             conversion_factor = 1 if unit == "s" else apply_prefix(1, unit)
 
@@ -190,6 +203,10 @@ class T1Experiment(BaseExperiment):
 
     __analysis_class__ = T1Analysis
 
+    @classmethod
+    def _default_options(cls) -> Options:
+        return Options(delays=None, unit="s")
+
     def __init__(
         self,
         qubit: int,
@@ -210,13 +227,9 @@ class T1Experiment(BaseExperiment):
         """
         if len(delays) < 3:
             raise ValueError("T1 experiment: number of delays must be at least 3")
+        super().__init__([qubit], delays=delays, unit=unit)
 
-        self._delays = delays
-        self._unit = unit
-        super().__init__([qubit])
-
-    # pylint: disable=arguments-differ
-    def circuits(self, backend: Optional[Backend] = None) -> List[QuantumCircuit]:
+    def circuits(self, backend: Optional["Backend"] = None) -> List[QuantumCircuit]:
         """
         Return a list of experiment circuits
 
@@ -229,8 +242,7 @@ class T1Experiment(BaseExperiment):
         Raises:
             AttributeError: if unit is dt but dt parameter is missing in the backend configuration
         """
-
-        if self._unit == "dt":
+        if self.options.unit == "dt":
             try:
                 dt_factor = getattr(backend.configuration(), "dt")
             except AttributeError as no_dt:
@@ -238,11 +250,11 @@ class T1Experiment(BaseExperiment):
 
         circuits = []
 
-        for delay in self._delays:
+        for delay in self.options.delays:
             circ = QuantumCircuit(1, 1)
             circ.x(0)
             circ.barrier(0)
-            circ.delay(delay, 0, self._unit)
+            circ.delay(delay, 0, self.options.unit)
             circ.barrier(0)
             circ.measure(0, 0)
 
@@ -250,10 +262,10 @@ class T1Experiment(BaseExperiment):
                 "experiment_type": self._type,
                 "qubit": self.physical_qubits[0],
                 "xval": delay,
-                "unit": self._unit,
+                "unit": self.options.unit,
             }
 
-            if self._unit == "dt":
+            if self.options.unit == "dt":
                 circ.metadata["dt_factor"] = dt_factor
 
             circuits.append(circ)

--- a/qiskit_experiments/composite/batch_experiment.py
+++ b/qiskit_experiments/composite/batch_experiment.py
@@ -41,7 +41,7 @@ class BatchExperiment(CompositeExperiment):
         qubits = tuple(self._qubit_map.keys())
         super().__init__(experiments, qubits)
 
-    def circuits(self, backend=None, **circuit_options):
+    def circuits(self, backend=None):
 
         batch_circuits = []
 
@@ -51,7 +51,7 @@ class BatchExperiment(CompositeExperiment):
                 qubit_mapping = None
             else:
                 qubit_mapping = [self._qubit_map[qubit] for qubit in expr.physical_qubits]
-            for circuit in expr.circuits(**circuit_options):
+            for circuit in expr.circuits(backend):
                 # Update metadata
                 circuit.metadata = {
                     "experiment_type": self._type,

--- a/qiskit_experiments/composite/composite_analysis.py
+++ b/qiskit_experiments/composite/composite_analysis.py
@@ -40,8 +40,16 @@ class CompositeAnalysis(BaseAnalysis):
             QiskitError: if analysis is attempted on non-composite
                          experiment data.
         """
-        # Run analysis for sub-experiments and add sub-experiment metadata
-        # as result of batch experiment
+        if not isinstance(experiment_data, CompositeExperimentData):
+            raise QiskitError("CompositeAnalysis must be run on CompositeExperimentData.")
+
+        # Run analysis for sub-experiments
+        for expr, expr_data in zip(
+            experiment_data._experiment._experiments, experiment_data._composite_expdata
+        ):
+            expr.analysis(**expr.analysis_options.__dict__).run(expr_data, **options)
+
+        # Add sub-experiment metadata as result of batch experiment
         # Note: if Analysis results had ID's these should be included here
         # rather than just the sub-experiment IDs
         sub_types = []

--- a/qiskit_experiments/composite/composite_analysis.py
+++ b/qiskit_experiments/composite/composite_analysis.py
@@ -47,7 +47,7 @@ class CompositeAnalysis(BaseAnalysis):
         for expr, expr_data in zip(
             experiment_data._experiment._experiments, experiment_data._composite_expdata
         ):
-            expr.analysis(**expr.analysis_options.__dict__).run(expr_data, **options)
+            expr.run_analysis(expr_data, **options)
 
         # Add sub-experiment metadata as result of batch experiment
         # Note: if Analysis results had ID's these should be included here

--- a/qiskit_experiments/composite/composite_analysis.py
+++ b/qiskit_experiments/composite/composite_analysis.py
@@ -13,6 +13,7 @@
 Composite Experiment Analysis class.
 """
 
+from qiskit.exceptions import QiskitError
 from qiskit_experiments.base_analysis import BaseAnalysis, AnalysisResult
 from .composite_experiment_data import CompositeExperimentData
 
@@ -45,7 +46,7 @@ class CompositeAnalysis(BaseAnalysis):
 
         # Run analysis for sub-experiments
         for expr, expr_data in zip(
-            experiment_data._experiment._experiments, experiment_data._composite_expdata
+            experiment_data._experiment._experiments, experiment_data._components
         ):
             expr.run_analysis(expr_data, **options)
 

--- a/qiskit_experiments/composite/composite_experiment.py
+++ b/qiskit_experiments/composite/composite_experiment.py
@@ -26,7 +26,7 @@ class CompositeExperiment(BaseExperiment):
     __analysis_class__ = CompositeAnalysis
     __experiment_data__ = CompositeExperimentData
 
-    def __init__(self, experiments, qubits, experiment_type=None, circuit_options=None):
+    def __init__(self, experiments, qubits, experiment_type=None):
         """Initialize the composite experiment object.
 
         Args:
@@ -34,16 +34,13 @@ class CompositeExperiment(BaseExperiment):
             qubits (int or Iterable[int]): the number of qubits or list of
                                            physical qubits for the experiment.
             experiment_type (str): Optional, composite experiment subclass name.
-            circuit_options (str): Optional, Optional, dictionary of allowed
-                                   kwargs and default values for the `circuit`
-                                   method.
         """
         self._experiments = experiments
         self._num_experiments = len(experiments)
-        super().__init__(qubits, experiment_type=experiment_type, circuit_options=circuit_options)
+        super().__init__(qubits, experiment_type=experiment_type)
 
     @abstractmethod
-    def circuits(self, backend=None, **circuit_options):
+    def circuits(self, backend=None):
         pass
 
     @property
@@ -55,6 +52,6 @@ class CompositeExperiment(BaseExperiment):
         """Return the component Experiment object"""
         return self._experiments[index]
 
-    def component_analysis(self, index, **kwargs):
+    def component_analysis(self, index, **analysis_options):
         """Return the component experiment Analysis object"""
-        return self.component_experiment(index).analysis(**kwargs)
+        return self.component_experiment(index).analysis(**analysis_options)

--- a/qiskit_experiments/composite/parallel_experiment.py
+++ b/qiskit_experiments/composite/parallel_experiment.py
@@ -32,7 +32,7 @@ class ParallelExperiment(CompositeExperiment):
             qubits += exp.physical_qubits
         super().__init__(experiments, qubits)
 
-    def circuits(self, backend=None, **circuit_options):
+    def circuits(self, backend=None):
 
         sub_circuits = []
         sub_qubits = []
@@ -42,7 +42,7 @@ class ParallelExperiment(CompositeExperiment):
         # Generate data for combination
         for expr in self._experiments:
             # Add subcircuits
-            circs = expr.circuits(**circuit_options)
+            circs = expr.circuits(backend)
             sub_circuits.append(circs)
             sub_size.append(len(circs))
 

--- a/qiskit_experiments/randomized_benchmarking/clifford_utils.py
+++ b/qiskit_experiments/randomized_benchmarking/clifford_utils.py
@@ -52,20 +52,6 @@ class WGate(Gate):
         self.definition = qc
 
 
-def v(self, q):
-    """Apply V to q."""
-    return self.append(VGate(), [q], [])
-
-
-def w(self, q):
-    """Apply W to q."""
-    return self.append(WGate(), [q], [])
-
-
-QuantumCircuit.v = v
-QuantumCircuit.v = w
-
-
 class CliffordUtils:
     """Utilities for generating 1 and 2 qubit clifford circuits and elements"""
 
@@ -143,9 +129,9 @@ class CliffordUtils:
         if i == 1:
             qc.h(0)
         if j == 1:
-            qc.v(0)
+            qc.append(VGate(), [0])
         if j == 2:
-            qc.w(0)
+            qc.append(WGate(), [0])
         if p == 1:
             qc.x(0)
         if p == 2:
@@ -170,13 +156,13 @@ class CliffordUtils:
         if i1 == 1:
             qc.h(1)
         if j0 == 1:
-            qc.v(0)
+            qc.append(VGate(), [0])
         if j0 == 2:
-            qc.w(0)
+            qc.append(WGate(), [0])
         if j1 == 1:
-            qc.v(1)
+            qc.append(VGate(), [1])
         if j1 == 2:
-            qc.w(1)
+            qc.append(WGate(), [1])
         if form in (1, 2, 3):
             qc.cx(0, 1)
         if form in (2, 3):
@@ -185,14 +171,14 @@ class CliffordUtils:
             qc.cx(0, 1)
         if form in (1, 2):
             if k0 == 1:
-                qc.v(0)
+                qc.append(VGate(), [0])
             if k0 == 2:
-                qc.w(0)
+                qc.append(WGate(), [0])
             if k1 == 1:
-                qc.v(1)
+                qc.append(VGate(), [1])
             if k1 == 2:
-                qc.v(1)
-                qc.v(1)
+                qc.append(VGate(), [1])
+                qc.append(VGate(), [1])
         if p0 == 1:
             qc.x(0)
         if p0 == 2:

--- a/qiskit_experiments/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/randomized_benchmarking/rb_analysis.py
@@ -16,18 +16,14 @@ Standard RB analysis class.
 from typing import Optional, List
 
 from qiskit.providers.options import Options
-from qiskit_experiments.base_analysis import BaseAnalysis, ExperimentData
+from qiskit_experiments.experiment_data import ExperimentData
+from qiskit_experiments.base_analysis import BaseAnalysis
 from qiskit_experiments.analysis.curve_fitting import curve_fit, process_curve_data
 from qiskit_experiments.analysis.data_processing import (
     level2_probability,
     mean_xy_data,
 )
-from qiskit_experiments.analysis.plotting import (
-    HAS_MATPLOTLIB,
-    plot_curve_fit,
-    plot_scatter,
-    plot_errorbar,
-)
+from qiskit_experiments.analysis import plotting
 
 
 class RBAnalysis(BaseAnalysis):
@@ -53,7 +49,7 @@ class RBAnalysis(BaseAnalysis):
         experiment_data: ExperimentData,
         p0: Optional[List[float]] = None,
         plot: bool = True,
-        ax: Optional["AxesSubplot"] = None,
+        ax: Optional["plotting.pyplot.AxesSubplot"] = None,
     ):
         """Run analysis on circuit data.
         Args:
@@ -95,10 +91,10 @@ class RBAnalysis(BaseAnalysis):
         analysis_result["EPC"] = scale * (1 - popt[1])
         analysis_result["EPC_err"] = scale * popt_err[1] / popt[1]
 
-        if plot and HAS_MATPLOTLIB:
-            ax = plot_curve_fit(fit_fun, analysis_result, ax=ax)
-            ax = plot_scatter(x_raw, y_raw, ax=ax)
-            ax = plot_errorbar(xdata, ydata, ydata_sigma, ax=ax)
+        if plot and plotting.HAS_MATPLOTLIB:
+            ax = plotting.plot_curve_fit(fit_fun, analysis_result, ax=ax)
+            ax = plotting.plot_scatter(x_raw, y_raw, ax=ax)
+            ax = plotting.plot_errorbar(xdata, ydata, ydata_sigma, ax=ax)
             self._format_plot(ax, analysis_result)
             figures = [ax.get_figure()]
         else:

--- a/qiskit_experiments/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/randomized_benchmarking/rb_analysis.py
@@ -14,7 +14,9 @@ Standard RB analysis class.
 """
 
 from typing import Optional, List
+import numpy as np
 
+from qiskit.providers.options import Options
 from qiskit_experiments.base_analysis import BaseAnalysis, ExperimentData
 from qiskit_experiments.analysis.curve_fitting import curve_fit, process_curve_data
 from qiskit_experiments.analysis.data_processing import (
@@ -30,7 +32,21 @@ from qiskit_experiments.analysis.plotting import (
 
 
 class RBAnalysis(BaseAnalysis):
-    """RB Analysis class."""
+    """RB Analysis class.
+
+    Analysis Options:
+        p0: Optional, initial parameter values for curve_fit.
+        plot: If True generate a plot of fitted data.
+        ax: Optional, matplotlib axis to add plot to.
+    """
+
+    @classmethod
+    def _default_options(cls):
+        return Options(
+            p0=None,
+            plot=True,
+            ax=None,
+        )
 
     # pylint: disable = arguments-differ, invalid-name
     def _run_analysis(

--- a/qiskit_experiments/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/randomized_benchmarking/rb_analysis.py
@@ -14,7 +14,6 @@ Standard RB analysis class.
 """
 
 from typing import Optional, List
-import numpy as np
 
 from qiskit.providers.options import Options
 from qiskit_experiments.base_analysis import BaseAnalysis, ExperimentData

--- a/qiskit_experiments/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/randomized_benchmarking/rb_experiment.py
@@ -64,7 +64,7 @@ class RBExperiment(BaseExperiment):
         super().__init__(qubits)
 
         # Set configurable options
-        self.set_options(lengths=list(lengths), num_samples=num_samples)
+        self.set_experiment_options(lengths=list(lengths), num_samples=num_samples)
 
         # Set fixed options
         self._full_sampling = full_sampling
@@ -88,8 +88,8 @@ class RBExperiment(BaseExperiment):
             A list of :class:`QuantumCircuit`.
         """
         circuits = []
-        for _ in range(self.options.num_samples):
-            circuits += self._sample_circuits(self.options.lengths, seed=self._rng)
+        for _ in range(self.experiment_options.num_samples):
+            circuits += self._sample_circuits(self.experiment_options.lengths, seed=self._rng)
         return circuits
 
     def _sample_circuits(

--- a/qiskit_experiments/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/randomized_benchmarking/rb_experiment.py
@@ -20,6 +20,7 @@ from numpy.random import Generator, default_rng
 from qiskit import QuantumCircuit
 from qiskit.providers import Backend
 from qiskit.quantum_info import Clifford
+from qiskit.providers.options import Options
 
 from qiskit_experiments.base_experiment import BaseExperiment
 from .rb_analysis import RBAnalysis
@@ -27,7 +28,12 @@ from .clifford_utils import CliffordUtils
 
 
 class RBExperiment(BaseExperiment):
-    """RB Experiment class"""
+    """RB Experiment class.
+    
+    Experiment Options:
+        lengths: A list of RB sequences lengths.
+        num_samples: number of samples to generate for each sequence length.
+    """
 
     # Analysis class for experiment
     __analysis_class__ = RBAnalysis
@@ -46,8 +52,7 @@ class RBExperiment(BaseExperiment):
             qubits: the number of qubits or list of
                     physical qubits for the experiment.
             lengths: A list of RB sequences lengths.
-            num_samples: number of samples to generate for each
-                         sequence length
+            num_samples: number of samples to generate for each sequence length.
             seed: Seed or generator object for random number
                   generation. If None default_rng will be used.
             full_sampling: If True all Cliffords are independently sampled for
@@ -59,11 +64,13 @@ class RBExperiment(BaseExperiment):
             self._rng = default_rng(seed=seed)
         else:
             self._rng = seed
-        self._lengths = list(lengths)
-        self._num_samples = num_samples
         self._full_sampling = full_sampling
         self._clifford_utils = CliffordUtils()
-        super().__init__(qubits)
+        super().__init__(qubits, lengths=list(lengths), num_samples=num_samples)
+
+    @classmethod
+    def _default_options(cls):
+        return Options(lengths=None, num_samples=None)
 
     # pylint: disable = arguments-differ
     def circuits(self, backend: Optional[Backend] = None) -> List[QuantumCircuit]:
@@ -74,8 +81,8 @@ class RBExperiment(BaseExperiment):
             A list of :class:`QuantumCircuit`.
         """
         circuits = []
-        for _ in range(self._num_samples):
-            circuits += self._sample_circuits(self._lengths, seed=self._rng)
+        for _ in range(self.options.num_samples):
+            circuits += self._sample_circuits(self.options.lengths, seed=self._rng)
         return circuits
 
     def _sample_circuits(

--- a/qiskit_experiments/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/randomized_benchmarking/rb_experiment.py
@@ -78,27 +78,6 @@ class RBExperiment(BaseExperiment):
             circuits += self._sample_circuits(self._lengths, seed=self._rng)
         return circuits
 
-    def transpiled_circuits(
-        self, backend: Optional[Backend] = None, **kwargs
-    ) -> List[QuantumCircuit]:
-        """Return a list of transpiled RB circuits.
-
-        Args:
-            backend: Optional, a backend object to use as the
-                     argument for the :func:`qiskit.transpile` function.
-            kwargs: kwarg options for the :func:`qiskit.transpile` function.
-
-        Returns:
-            A list of :class:`QuantumCircuit`.
-
-        Raises:
-            QiskitError: if an initial layout is specified in the
-                         kwarg options for transpilation. The initial
-                         layout must be generated from the experiment.
-        """
-        circuits = super().transpiled_circuits(backend=backend, **kwargs)
-        return circuits
-
     def _sample_circuits(
         self, lengths: Iterable[int], seed: Optional[Union[int, Generator]] = None
     ) -> List[QuantumCircuit]:

--- a/qiskit_experiments/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/randomized_benchmarking/rb_experiment.py
@@ -29,7 +29,7 @@ from .clifford_utils import CliffordUtils
 
 class RBExperiment(BaseExperiment):
     """RB Experiment class.
-    
+
     Experiment Options:
         lengths: A list of RB sequences lengths.
         num_samples: number of samples to generate for each sequence length.
@@ -60,13 +60,20 @@ class RBExperiment(BaseExperiment):
                            sequences are constructed by appending additional
                            Clifford samples to shorter sequences.
         """
+        # Initialize base experiment
+        super().__init__(qubits)
+
+        # Set configurable options
+        self.set_options(lengths=list(lengths), num_samples=num_samples)
+
+        # Set fixed options
+        self._full_sampling = full_sampling
+        self._clifford_utils = CliffordUtils()
+
         if not isinstance(seed, Generator):
             self._rng = default_rng(seed=seed)
         else:
             self._rng = seed
-        self._full_sampling = full_sampling
-        self._clifford_utils = CliffordUtils()
-        super().__init__(qubits, lengths=list(lengths), num_samples=num_samples)
 
     @classmethod
     def _default_options(cls):

--- a/qiskit_experiments/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/randomized_benchmarking/rb_experiment.py
@@ -76,7 +76,7 @@ class RBExperiment(BaseExperiment):
             self._rng = seed
 
     @classmethod
-    def _default_options(cls):
+    def _default_experiment_options(cls):
         return Options(lengths=None, num_samples=None)
 
     # pylint: disable = arguments-differ

--- a/test/data_processing/fake_experiment.py
+++ b/test/data_processing/fake_experiment.py
@@ -25,7 +25,7 @@ class FakeExperiment(BaseExperiment):
         self._type = None
         super().__init__((0,), "fake_test_experiment")
 
-    def circuits(self, backend=None, **circuit_options):
+    def circuits(self, backend=None):
         """Fake circuits."""
         return []
 

--- a/test/test_t2star.py
+++ b/test/test_t2star.py
@@ -175,6 +175,15 @@ class TestT2Star(QiskitTestCase):
             ]
 
             exp = T2StarExperiment(qubit, delays, unit=unit)
+            exp.set_analysis_options(
+                user_p0={
+                    "A": 0.5,
+                    "t2star": estimated_t2star,
+                    "f": estimated_freq,
+                    "phi": 0,
+                    "B": 0.5,
+                }
+            )
 
             backend = T2starBackend(
                 p0={
@@ -193,20 +202,14 @@ class TestT2Star(QiskitTestCase):
                 dt_factor = getattr(backend._configuration, "dt")
 
             # run circuits
-            result = exp.run(
+
+            expdata = exp.run(
                 backend=backend,
-                user_p0={
-                    "A": 0.5,
-                    "t2star": estimated_t2star,
-                    "f": estimated_freq,
-                    "phi": 0,
-                    "B": 0.5,
-                },
-                user_bounds=None,
                 # plot=False,
                 instruction_durations=instruction_durations,
                 shots=2000,
-            ).analysis_result(0)
+            )
+            result = expdata.analysis_result(0)
             self.assertAlmostEqual(
                 result["t2star_value"],
                 estimated_t2star * dt_factor,
@@ -244,8 +247,6 @@ class TestT2Star(QiskitTestCase):
         backend = T2starBackend(p0)
         res = par_exp.run(
             backend=backend,
-            user_p0=None,
-            user_bounds=None,
             # plot=False,
             shots=1000,
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently it is difficult to set custom options for an experiment. This is in part due to the different layers of options that are involved including:
* Experiment options (which effect circuit generation)
* Transpilation options
* Backend / execution options
* Analysis options

This PR attempts to improve how options are handled for both experiment design (for documenting available options and setting default values), and for the user (for customizing options when running experiments). This is done by adding set options methods in the same way that it is currently done for configurable Qiskit backends (Aer, IBMQ).

Note that this uses the same `Options` class as backends from terra, which currently is not mappable (so you need to do `**options.__dict__` for example), however there is currently a PR open to make this class mappable.

### Details and comments

The main changes here are:

* Adds `options`, `transpile_options`, `backend_options`, and `analysis_options` properties to the BaseExperiment class. These contain all default/set options for the current experiment and will be used by the `run` method to allow customizing execution. When designing an experiment default values for each of these are set by overriding the  corresponding `_default_options` methods. For users to update options they use the corresponding `set_options`, `set_transpiler_options` etc methods.
* Removed kwargs from `BaseExperiments.circuits`, these are intended to all be handled with `options/set_options`.
* Adds `**options` to `BaseExperiment.__init__` for setting custom option values at initialization.
* Removes `transpiled_circuits` method: this method should intead be done using a call to the terra `transpile` function with the experiments `transpile_options` as `qiskit.transpile(expr.circuits(backend), backend, **exp.transpile_options)`. 

With these changes an example of using custom options for running an experiment might look something like:
```python
qubits = [0, 2]
expr = MyExperiment(qubits, param=val, seed=1)
expr.set_transpile_options(optimization_level=3, scheduling_method='asap')
expr.set_analysis_options(method=something)

# Run experiment
expdata = expr.run(backend, shots=2000)
```