### PR TITLE
Add AnalysisError exception and handling

### DIFF
--- a/qiskit_experiments/analysis/curve_fitting.py
+++ b/qiskit_experiments/analysis/curve_fitting.py
@@ -117,7 +117,9 @@ def curve_fit(
             fit_func, xdata, ydata, sigma=sigma, p0=param_p0, bounds=param_bounds, **kwargs
         )
     except Exception as ex:
-        raise AnalysisError("scipy.optimize.curve_fit failed") from ex
+        raise AnalysisError(
+            "scipy.optimize.curve_fit failed with error: {}".format(str(ex))
+        ) from ex
 
     popt_err = np.sqrt(np.diag(pcov))
 

--- a/qiskit_experiments/base_analysis.py
+++ b/qiskit_experiments/base_analysis.py
@@ -20,9 +20,7 @@ from qiskit.providers.options import Options
 from qiskit.exceptions import QiskitError
 
 from qiskit_experiments.experiment_data import ExperimentData, AnalysisResult
-
-# pylint: disable = unused-import
-from qiskit_experiments.matplotlib import pyplot
+from qiskit_experiments.exceptions import AnalysisError
 
 
 class BaseAnalysis(ABC):
@@ -93,7 +91,7 @@ class BaseAnalysis(ABC):
         try:
             analysis_results, figures = self._run_analysis(experiment_data, **analysis_options)
             analysis_results["success"] = True
-        except Exception as ex:
+        except AnalysisError as ex:
             analysis_results = AnalysisResult(success=False, error_message=ex)
             figures = None
 
@@ -114,7 +112,7 @@ class BaseAnalysis(ABC):
     @abstractmethod
     def _run_analysis(
         self, experiment_data: ExperimentData, **options
-    ) -> Tuple[List[AnalysisResult], List["pyplot.Figure"]]:
+    ) -> Tuple[List[AnalysisResult], List["matplotlib.figure.Figure"]]:
         """Run analysis on circuit data.
 
         Args:
@@ -127,5 +125,8 @@ class BaseAnalysis(ABC):
             A pair ``(analysis_results, figures)`` where ``analysis_results``
             may be a single or list of AnalysisResult objects, and ``figures``
             is a list of any figures for the experiment.
+
+        Raises:
+            AnalysisError: if the analysis fails.
         """
         pass

--- a/qiskit_experiments/characterization/t1_experiment.py
+++ b/qiskit_experiments/characterization/t1_experiment.py
@@ -89,6 +89,9 @@ class T1Analysis(BaseAnalysis):
 
         Returns:
             The analysis result with the estimated T1
+
+        Raises:
+            AnalysisError: if the analysis fails.
         """
         data = experiment_data.data()
         unit = data[0]["metadata"]["unit"]

--- a/qiskit_experiments/exceptions.py
+++ b/qiskit_experiments/exceptions.py
@@ -1,0 +1,19 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Exceptions for errors raised by Qiskit Experiments."""
+
+from qiskit.exceptions import QiskitError
+
+
+class AnalysisError(QiskitError):
+    """Class for errors raised by experiment analysis."""

--- a/qiskit_experiments/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/randomized_benchmarking/rb_analysis.py
@@ -52,16 +52,21 @@ class RBAnalysis(BaseAnalysis):
         ax: Optional["plotting.pyplot.AxesSubplot"] = None,
     ):
         """Run analysis on circuit data.
+
         Args:
             experiment_data: the experiment data to analyze.
             p0: Optional, initial parameter values for curve_fit.
             plot: If True generate a plot of fitted data.
             ax: Optional, matplotlib axis to add plot to.
+
         Returns:
             tuple: A pair ``(analysis_result, figures)`` where
                    ``analysis_results`` may be a single or list of
                    AnalysisResult objects, and ``figures`` may be
                    None, a single figure, or a list of figures.
+
+        Raises:
+            AnalysisError: if the analysis fails.
         """
         data = experiment_data.data()
         num_qubits = len(data[0]["metadata"]["qubits"])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Adds an `AnalysisError` exception class that can be caught by `BaseAnalysis.run` to return an analysis result object containing the error message.
* Updates the `curve_fit` function to throw an analysis error if `scipy.optimize.curve_fit` fails (which handles the exception raising for T1 and RB fitters based off this function).

### Details and comments

This is to avoid catching overly broad exceptions in the current implementation. After this change any exception raised during analysis other than AnalysisError will still throw like a regular python exception.