### PR TITLE
Seed for the T2star test

### DIFF
--- a/test/test_t2star.py
+++ b/test/test_t2star.py
@@ -22,10 +22,6 @@ from qiskit_experiments.composite import ParallelExperiment
 from qiskit_experiments.characterization import T2StarExperiment
 
 
-# Fix seed for simulations
-SEED = 9000
-
-
 class T2starBackend(BaseBackend):
     """
     A simple and primitive backend, to be run by the T2Star tests
@@ -149,6 +145,8 @@ class TestT2Star(QiskitTestCase):
         Run the T2 backend on all possible units
         """
         # For some reason, 'ps' was not precise enough - need to check this
+        np.random.seed(0)
+
         for unit in ["s", "ms", "us", "ns", "dt"]:
             if unit in ("s", "dt"):
                 dt_factor = 1
@@ -228,6 +226,8 @@ class TestT2Star(QiskitTestCase):
         """
         Test parallel experiments of T2* using a simulator.
         """
+
+        np.random.seed(0)
 
         t2star = [30, 25]
         estimated_freq = [0.1, 0.12]

--- a/test/test_t2star.py
+++ b/test/test_t2star.py
@@ -59,6 +59,7 @@ class T2starBackend(BaseBackend):
         self._readout0to1 = readout0to1
         self._readout1to0 = readout1to0
         self._dt_factor = dt_factor
+        self._rng = np.random.default_rng(0)
         super().__init__(configuration)
 
     # pylint: disable = arguments-differ
@@ -111,7 +112,7 @@ class T2starBackend(BaseBackend):
 
                     if op.name == "measure":
                         # we measure in |+> basis which is the same as measuring |0>
-                        meas_res = np.random.binomial(
+                        meas_res = self._rng.binomial(
                             1,
                             (1 - prob_plus[qubit]) * (1 - ro10[qubit])
                             + prob_plus[qubit] * ro01[qubit],
@@ -145,7 +146,6 @@ class TestT2Star(QiskitTestCase):
         Run the T2 backend on all possible units
         """
         # For some reason, 'ps' was not precise enough - need to check this
-        np.random.seed(0)
 
         for unit in ["s", "ms", "us", "ns", "dt"]:
             if unit in ("s", "dt"):
@@ -226,8 +226,6 @@ class TestT2Star(QiskitTestCase):
         """
         Test parallel experiments of T2* using a simulator.
         """
-
-        np.random.seed(0)
 
         t2star = [30, 25]
         estimated_freq = [0.1, 0.12]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

T2star test seems to fail.

### Details and comments

There was a global variable `SEED` which has been removed and each test now uses `np.random.seed(0)`.
