### PR TITLE
Fix random seed in T1 tests

### DIFF
--- a/test/test_t1.py
+++ b/test/test_t1.py
@@ -59,6 +59,7 @@ class T1Backend(BaseBackend):
         self._readout0to1 = readout0to1
         self._readout1to0 = readout1to0
         self._dt_factor = dt_factor
+        self._rng = np.random.default_rng(0)
         super().__init__(configuration)
 
     # pylint: disable = arguments-differ
@@ -108,7 +109,7 @@ class T1Backend(BaseBackend):
                         delay = op.params[0]
                         prob1[qubit] = prob1[qubit] * np.exp(-delay / self._t1[qubit])
                     elif op.name == "measure":
-                        meas_res = np.random.binomial(
+                        meas_res = self._rng.binomial(
                             1, prob1[qubit] * (1 - ro10[qubit]) + (1 - prob1[qubit]) * ro01[qubit]
                         )
                         clbits[op.memory[0]] = meas_res


### PR DESCRIPTION
Identical to #69, but for T1 tests.
Are randomized benchmarking tests deterministic?  Considering that the experiment itself involves randomizations. @ItamarGoldman @gadial @ShellyGarion 