### PR TITLE
Add missing VERSION.txt file to the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE.txt
 include requirements.txt
+include qiskit_experiments/VERSION.txt


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The version.txt file is necessary to build qiskit-experiments from
source since it's used by the setup.py to determing the version in the
package metadata. However this wasn't being included in the packaged
sdist because it was missing from the manifest. This causes builds from
sdist to fail because setup.py can't find the version file. This commit
fixes this oversight and adds the missing entry to the manifest so that
we're including all the necessary components in the sdist.

### Details and comments