### PR TITLE
[WIP] Spectroscopy and calibrations integration V2

### DIFF
--- a/qiskit_experiments/calibration/backend_calibrations.py
+++ b/qiskit_experiments/calibration/backend_calibrations.py
@@ -53,6 +53,11 @@ class BackendCalibrations(Calibrations):
         self._qubits = set(range(backend.configuration().n_qubits))
         self._backend = backend
 
+    @property
+    def backend(self) -> Backend:
+        """Return the backend instance."""
+        return self._backend
+
     def _get_frequencies(
         self,
         element: FrequencyElement,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is a WIP PR designed to show and discuss how calibrations and experiments could be integrated through the analysis class. An alternative option is shown in #80.

### Details and comments

The user would run the calibration experiment as follows:
```python
calibrations = BackendCalibrations(backend)
...
qubit = 5
qubit_freq = calibrations.get_qubit_frequencies()[qubit]
frequences = np.linspace(qubit_freq - 10e6, qubit_freq + 10e6)
spec = QubitSpectroscopy(qubit, frequencies)
spec.set_analysis_options(calibrations=calibrations, force_update=True, calibration_group="my_group")
spec.run(backend)
```

The pros of this integration are:
* The `BackendCalibrations` class will remain lightweight.

The cons of this integration are:
* The analysis class may not be reusable for other types of peak fits unless extra logic will be needed to support other peak-fit experiments such as spectroscopy on 1<->2.
* The user needs to write a lot of code.