### PR TITLE
Update plot_curve_fit to work with or without popt_keys and popt_err fields

### DIFF
--- a/qiskit_experiments/analysis/plotting.py
+++ b/qiskit_experiments/analysis/plotting.py
@@ -57,11 +57,6 @@ def plot_curve_fit(
         figure = pyplot.figure()
         ax = figure.subplots()
 
-    # Result data
-    fit_params = dict(zip(result["popt_keys"], result["popt"]))
-    fit_errors = dict(zip(result["popt_keys"], result["popt_err"]))
-    xmin, xmax = result["xrange"]
-
     # Default plot options
     plot_opts = kwargs.copy()
     if "color" not in plot_opts:
@@ -71,17 +66,35 @@ def plot_curve_fit(
     if "linewidth" not in plot_opts:
         plot_opts["linewidth"] = 2
 
+    # Result data
+    fit_params = result["popt"]
+    param_keys = result.get("popt_keys")
+    fit_errors = result.get("popt_err")
+    xmin, xmax = result["xrange"]
+
     # Plot fit data
     xs = np.linspace(xmin, xmax, num_fit_points)
-    ys_fit = func(xs, **fit_params)
+    if param_keys:
+        ys_fit = func(xs, **dict(zip(param_keys, fit_params)))
+    else:
+        ys_fit = func(xs, *fit_params)
     ax.plot(xs, ys_fit, **plot_opts)
 
     # Plot standard error interval
-    if confidence_interval:
-        params_upper = {key: fit_params[key] + fit_errors[key] for key in result["popt_keys"]}
-        params_lower = {key: fit_params[key] - fit_errors[key] for key in result["popt_keys"]}
-        ys_upper = func(xs, **params_upper)
-        ys_lower = func(xs, **params_lower)
+    if confidence_interval and fit_errors is not None:
+        if param_keys:
+            params_upper = {}
+            params_lower = {}
+            for key, param, error in zip(param_keys, fit_params, fit_errors):
+                params_upper[key] = param + error
+                params_lower[key] = param - error
+            ys_upper = func(xs, **params_upper)
+            ys_lower = func(xs, **params_lower)
+        else:
+            params_upper = [param + error for param, error in zip(fit_params, fit_errors)]
+            params_lower = [param - error for param, error in zip(fit_params, fit_errors)]
+            ys_upper = func(xs, *params_upper)
+            ys_lower = func(xs, *params_lower)
         ax.fill_between(xs, ys_lower, ys_upper, alpha=0.1, color=plot_opts["color"])
 
     # Formatting


### PR DESCRIPTION
Improve robustness of `plot_curve_fit` so it work with position args if popt_keys is None in AnalysisResult, and will skip confidence interval plot if popt_err is None.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes `plot_curve_fit` to work if curve fit analysis results contains `popt_keys = None` or `popt_err = None`.

### Details and comments

* If popt_keys is None the fit params will be passed to the fit function via positional args rather than kwargs
* If popt_err is None the confidence interval plotting will be skipped
