### PR TITLE
Fix calibrations save test

### DIFF
--- a/qiskit_experiments/calibration/calibrations.py
+++ b/qiskit_experiments/calibration/calibrations.py
@@ -899,7 +899,13 @@ class Calibrations:
 
         return data
 
-    def save(self, file_type: str = "csv", folder: str = None, overwrite: bool = False):
+    def save(
+        self,
+        file_type: str = "csv",
+        folder: str = None,
+        overwrite: bool = False,
+        file_prefix: str = ""
+    ):
         """Save the parameterized schedules and parameter value.
 
         The schedules and parameter values can be stored in csv files. This method creates
@@ -919,6 +925,8 @@ class Calibrations:
             folder: The folder in which to save the calibrations.
             overwrite: If the files already exist then they will not be overwritten
                 unless overwrite is set to True.
+            file_prefix: A prefix to add to the name of the files such as a date tag or a
+                UUID.
 
         Raises:
             CalibrationError: if the files exist and overwrite is not set to True.
@@ -929,14 +937,18 @@ class Calibrations:
         if folder:
             os.chdir(folder)
 
-        if os.path.isfile("parameter_config.csv") and not overwrite:
-            raise CalibrationError("parameter_config.csv already exists. Set overwrite to True.")
+        parameter_config_file = file_prefix + "parameter_config.csv"
+        parameter_value_file = file_prefix + "parameter_values.csv"
+        schedule_file = file_prefix + "schedules.csv"
 
-        if os.path.isfile("parameter_values.csv") and not overwrite:
-            raise CalibrationError("parameter_values.csv already exists. Set overwrite to True.")
+        if os.path.isfile(parameter_config_file) and not overwrite:
+            raise CalibrationError(f"{parameter_config_file} already exists. Set overwrite to True.")
 
-        if os.path.isfile("parameter_values.csv") and not overwrite:
-            raise CalibrationError("schedules.csv already exists. Set overwrite to True.")
+        if os.path.isfile(parameter_value_file) and not overwrite:
+            raise CalibrationError(f"{parameter_value_file} already exists. Set overwrite to True.")
+
+        if os.path.isfile(schedule_file) and not overwrite:
+            raise CalibrationError(f"{schedule_file} already exists. Set overwrite to True.")
 
         # Write the parameter configuration.
         header_keys = ["parameter.name", "parameter unique id", "schedule", "qubits"]
@@ -954,7 +966,7 @@ class Calibrations:
                 )
 
         if file_type == "csv":
-            with open("parameter_config.csv", "w", newline="", encoding="utf-8") as output_file:
+            with open(parameter_config_file, "w", newline="", encoding="utf-8") as output_file:
                 dict_writer = csv.DictWriter(output_file, header_keys)
                 dict_writer.writeheader()
                 dict_writer.writerows(body)
@@ -964,7 +976,7 @@ class Calibrations:
             if len(values) > 0:
                 header_keys = values[0].keys()
 
-                with open("parameter_values.csv", "w", newline="", encoding="utf-8") as output_file:
+                with open(parameter_value_file, "w", newline="", encoding="utf-8") as output_file:
                     dict_writer = csv.DictWriter(output_file, header_keys)
                     dict_writer.writeheader()
                     dict_writer.writerows(values)
@@ -977,7 +989,7 @@ class Calibrations:
                     {"name": key.schedule, "qubits": key.qubits, "schedule": str(sched)}
                 )
 
-            with open("schedules.csv", "w", newline="", encoding="utf-8") as output_file:
+            with open(schedule_file, "w", newline="", encoding="utf-8") as output_file:
                 dict_writer = csv.DictWriter(output_file, header_keys)
                 dict_writer.writeheader()
                 dict_writer.writerows(schedules)

--- a/qiskit_experiments/calibration/calibrations.py
+++ b/qiskit_experiments/calibration/calibrations.py
@@ -904,7 +904,7 @@ class Calibrations:
         file_type: str = "csv",
         folder: str = None,
         overwrite: bool = False,
-        file_prefix: str = ""
+        file_prefix: str = "",
     ):
         """Save the parameterized schedules and parameter value.
 
@@ -942,7 +942,9 @@ class Calibrations:
         schedule_file = file_prefix + "schedules.csv"
 
         if os.path.isfile(parameter_config_file) and not overwrite:
-            raise CalibrationError(f"{parameter_config_file} already exists. Set overwrite to True.")
+            raise CalibrationError(
+                f"{parameter_config_file} already exists. Set overwrite to True."
+            )
 
         if os.path.isfile(parameter_value_file) and not overwrite:
             raise CalibrationError(f"{parameter_value_file} already exists. Set overwrite to True.")

--- a/test/calibration/test_calibrations.py
+++ b/test/calibration/test_calibrations.py
@@ -1313,7 +1313,7 @@ class TestSavingAndLoading(CrossResonanceTest):
             self.cals.get_parameter_value("amp", (3,), "xp")
 
         # Load the parameters, check value and type.
-        self.cals.load_parameter_values(prefix+"parameter_values.csv")
+        self.cals.load_parameter_values(prefix + "parameter_values.csv")
 
         val = self.cals.get_parameter_value("amp", (3,), "xp")
         self.assertEqual(val, 0.1 + 0.01j)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Calibration tests can fail due to non-unique file names. See #136 

### Details and comments

This is now fixed by adding a prefix methodology to the name of the saved files and by changing the clean-up after tests.

