### PR TITLE
Add fixed parameter to curve analysis

### DIFF
--- a/qiskit_experiments/analysis/curve_analysis.py
+++ b/qiskit_experiments/analysis/curve_analysis.py
@@ -17,6 +17,7 @@ Analysis class for curve fitting.
 
 import dataclasses
 import inspect
+import functools
 from typing import Any, Dict, List, Tuple, Callable, Union, Optional
 
 import numpy as np
@@ -37,10 +38,19 @@ from qiskit_experiments.experiment_data import AnalysisResult, ExperimentData
 class SeriesDef:
     """Description of curve."""
 
+    # Arbitrary callback to define the fit function. First argument should be x.
     fit_func: Callable
+
+    # Keyword dictionary to define the series with circuit metadata
     filter_kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    # Name of this series. This name will appear in the figure and raw x-y value report.
     name: str = "Series-0"
+
+    # Color of this line.
     plot_color: str = "black"
+
+    # Symbol to represent data points of this line.
     plot_symbol: str = "o"
 
 
@@ -137,7 +147,7 @@ class CurveAnalysis(BaseAnalysis):
         Both series have same fit function in this example.
 
         A fitting for two trigonometric curves with the same parameter
-        =============================================================
+        ==============================================================
 
         In this type of experiment, the analysis deals with two different curves.
         However the parameters are shared with both functions.
@@ -169,6 +179,33 @@ class CurveAnalysis(BaseAnalysis):
         all parameters. However, these series have different fit curves, i.e.
         `my_experiment1` (`my_experiment2`) uses the `cos` (`sin`) fit function.
 
+
+        A fitting with fixed parameter
+        ==============================
+
+        In this type of experiment, we can provide fixed fit function parameter.
+        This parameter should be assigned via analysis options
+        and not passed to the fitter function.
+
+        .. code-block::
+
+            class AnalysisExample(CurveAnalysis):
+
+                __series__ = [
+                    SeriesDef(
+                        fit_func=lambda x, p0, p1, p2:
+                            exponential_decay(x, amp=p0, lamb=p1, baseline=p2),
+                    ),
+                ]
+
+                __fixed_parameters__ = ["p1"]
+
+        You can add arbitrary number of parameters to the class variable
+        ``__fixed_parameters__`` from the fit function arguments.
+        This parameter should be defined with the fit functions otherwise the analysis
+        instance cannot be created. In above example, parameter ``p1`` should be also
+        defined in the analysis options. This parameter will be excluded from the fit parameters
+        and thus will not appear in the analysis result.
 
     Notes:
         This CurveAnalysis class provides several private methods that subclasses can override.
@@ -203,6 +240,9 @@ class CurveAnalysis(BaseAnalysis):
     #: List[SeriesDef]: List of mapping representing a data series
     __series__ = None
 
+    #: List[str]: Fixed parameter in fit function. Value should be set to the analysis options.
+    __fixed_parameters__ = None
+
     def __new__(cls) -> "CurveAnalysis":
         """Parse series data if all fit functions have the same argument.
 
@@ -224,7 +264,22 @@ class CurveAnalysis(BaseAnalysis):
                 "different function signature. They should receive "
                 "the same parameter set for multi-objective function fit."
             )
-        obj.__fit_params = list(list(fsigs)[0].parameters.keys())[1:]
+
+        # remove the first function argument. this is usually x, i.e. not a fit parameter.
+        fit_params = list(list(fsigs)[0].parameters.keys())[1:]
+
+        # remove fixed parameters
+        if obj.__fixed_parameters__ is not None:
+            for fixed_param in obj.__fixed_parameters__:
+                try:
+                    fit_params.remove(fixed_param)
+                except ValueError:
+                    raise AnalysisError(
+                        f"Defined fixed parameter {fixed_param} is not a fit function argument."
+                        "Update series definition to ensure the parameter name is defined with "
+                        f"fit functions. Currently available parameters are {fit_params}."
+                    )
+        obj.__fit_params = fit_params
 
         return obj
 
@@ -781,7 +836,28 @@ class CurveAnalysis(BaseAnalysis):
         analysis_result["analysis_type"] = self.__class__.__name__
         figures = list()
 
-        # pop arguments that are not given to fitter
+        #
+        # 1. Parse arguments
+        #
+        if self.__fixed_parameters__ is not None and len(self.__fixed_parameters__) > 0:
+            assigned_params = dict()
+            # Extract fixed parameter value from analysis options
+            for pname in self.__fixed_parameters__:
+                try:
+                    assigned_params[pname] = options.pop(pname)
+                except KeyError:
+                    raise AnalysisError(
+                        f"Argument for the fixed parameter {pname} is not found. "
+                        "This value should be provided by analysis option to run this analysis."
+                    )
+            # Override series definition with assigned fit functions.
+            assigned_series = []
+            for series_def in self.__series__:
+                dict_def = dataclasses.asdict(series_def)
+                dict_def["fit_func"] = functools.partial(series_def.fit_func, **assigned_params)
+                assigned_series.append(SeriesDef(**dict_def))
+            self.__series__ = assigned_series
+
         extra_options = self._arg_parse(**options)
 
         # TODO update this with experiment metadata PR #67
@@ -791,7 +867,7 @@ class CurveAnalysis(BaseAnalysis):
             pass
 
         #
-        # 1. Setup data processor
+        # 2. Setup data processor
         #
         data_processor = self._get_option("data_processor")
         if isinstance(data_processor, DataProcessor) and not data_processor.is_trained:
@@ -804,7 +880,7 @@ class CurveAnalysis(BaseAnalysis):
                 ) from ex
 
         #
-        # 2. Extract curve entries from experiment data
+        # 3. Extract curve entries from experiment data
         #
         try:
             self._extract_curves(experiment_data=experiment_data, data_processor=data_processor)
@@ -814,7 +890,7 @@ class CurveAnalysis(BaseAnalysis):
             ) from ex
 
         #
-        # 3. Run fitting
+        # 4. Run fitting
         #
         try:
             curve_fitter = self._get_option("curve_fitter")
@@ -870,19 +946,19 @@ class CurveAnalysis(BaseAnalysis):
 
         else:
             #
-            # 4. Post-process analysis data
+            # 5. Post-process analysis data
             #
             analysis_result = self._post_analysis(analysis_result=analysis_result)
 
         finally:
             #
-            # 5. Create figures
+            # 6. Create figures
             #
             if self._get_option("plot"):
                 figures.extend(self._create_figures(analysis_results=analysis_result))
 
             #
-            # 6. Optionally store raw data points
+            # 7. Optionally store raw data points
             #
             if self._get_option("return_data_points"):
                 raw_data_dict = dict()

--- a/qiskit_experiments/analysis/curve_analysis.py
+++ b/qiskit_experiments/analysis/curve_analysis.py
@@ -847,8 +847,9 @@ class CurveAnalysis(BaseAnalysis):
                     assigned_params[pname] = options.pop(pname)
                 except KeyError as ex:
                     raise AnalysisError(
-                        f"Argument for the fixed parameter {pname} is not found. "
-                        "This value should be provided by analysis option to run this analysis."
+                        f"The value of the fixed-value parameter {pname} for the fit function "
+                        f"of {self.__class__.__name__} was not found. "
+                        "This value must be provided by the analysis options to run this analysis."
                     ) from ex
             # Override series definition with assigned fit functions.
             assigned_series = []

--- a/qiskit_experiments/analysis/curve_analysis.py
+++ b/qiskit_experiments/analysis/curve_analysis.py
@@ -273,12 +273,12 @@ class CurveAnalysis(BaseAnalysis):
             for fixed_param in obj.__fixed_parameters__:
                 try:
                     fit_params.remove(fixed_param)
-                except ValueError:
+                except ValueError as ex:
                     raise AnalysisError(
                         f"Defined fixed parameter {fixed_param} is not a fit function argument."
                         "Update series definition to ensure the parameter name is defined with "
                         f"fit functions. Currently available parameters are {fit_params}."
-                    )
+                    ) from ex
         obj.__fit_params = fit_params
 
         return obj
@@ -845,11 +845,11 @@ class CurveAnalysis(BaseAnalysis):
             for pname in self.__fixed_parameters__:
                 try:
                     assigned_params[pname] = options.pop(pname)
-                except KeyError:
+                except KeyError as ex:
                     raise AnalysisError(
                         f"Argument for the fixed parameter {pname} is not found. "
                         "This value should be provided by analysis option to run this analysis."
-                    )
+                    ) from ex
             # Override series definition with assigned fit functions.
             assigned_series = []
             for series_def in self.__series__:

--- a/test/analysis/test_curve_fit.py
+++ b/test/analysis/test_curve_fit.py
@@ -20,7 +20,6 @@ from qiskit.test import QiskitTestCase
 
 from qiskit_experiments import ExperimentData
 from qiskit_experiments.analysis import CurveAnalysis, SeriesDef, fit_function
-from qiskit_experiments.analysis.curve_fitting import multi_curve_fit
 from qiskit_experiments.analysis.data_processing import probability
 from qiskit_experiments.base_experiment import BaseExperiment
 from qiskit_experiments.exceptions import AnalysisError
@@ -58,13 +57,14 @@ def simulate_output_data(func, xvals, param_dict, **metadata):
     return expdata
 
 
-def create_new_analysis(series: List[SeriesDef]) -> CurveAnalysis:
+def create_new_analysis(series: List[SeriesDef], fixed_params: List[str] = None) -> CurveAnalysis:
     """A helper function to create a mock analysis class instance."""
 
     class TestAnalysis(CurveAnalysis):
         """A mock analysis class to test."""
 
         __series__ = series
+        __fixed_parameters__ = fixed_params
 
     return TestAnalysis()
 
@@ -125,6 +125,19 @@ class TestCurveAnalysisUnit(QiskitTestCase):
         ]
         with self.assertRaises(AnalysisError):
             create_new_analysis(series=invalid_series)  # fit1 has param p0 while fit2 has p1
+
+    def test_cannot_create_invalid_fixed_parameter(self):
+        """Test we cannot create invalid analysis instance with wrong fixed value name."""
+        valid_series = [
+            SeriesDef(
+                fit_func=lambda x, p0, p1: fit_function.exponential_decay(x, amp=p0, lamb=p1),
+            ),
+        ]
+        with self.assertRaises(AnalysisError):
+            create_new_analysis(
+                series=valid_series,
+                fixed_params=["not_existing_parameter"]  # this parameter is not defined
+            )
 
     def test_arg_parse_and_get_option(self):
         """Test if option parsing works correctly."""
@@ -288,19 +301,10 @@ class TestCurveAnalysisIntegration(QiskitTestCase):
             xvals=self.xvalues,
             param_dict={"amp": ref_p0, "lamb": ref_p1, "x0": ref_p2, "baseline": ref_p3},
         )
-        results, _ = analysis._run_analysis(
-            test_data,
-            p0={"p0": ref_p0, "p1": ref_p1, "p2": ref_p2, "p3": ref_p3},
-            curve_fitter=multi_curve_fit,
-            data_processor=probability(outcome="1"),
-            x_key="xval",
-            plot=False,
-            axis=None,
-            xlabel="x value",
-            ylabel="y value",
-            fit_reports=None,
-            return_data_points=False,
-        )
+        default_opts = analysis._default_options()
+        default_opts.p0 = {"p0": ref_p0, "p1": ref_p1, "p2": ref_p2, "p3": ref_p3}
+
+        results, _ = analysis._run_analysis(test_data, **default_opts.__dict__)
         result = results[0]
 
         ref_popt = np.asarray([ref_p0, ref_p1, ref_p2, ref_p3])
@@ -333,22 +337,13 @@ class TestCurveAnalysisIntegration(QiskitTestCase):
             xvals=self.xvalues,
             param_dict={"amp": ref_p0, "lamb": ref_p1, "x0": ref_p2, "baseline": ref_p3},
         )
+        default_opts = analysis._default_options()
+        default_opts.p0 = {"p0": ref_p0, "p1": ref_p1, "p2": ref_p2, "p3": ref_p3}
+        default_opts.bounds = {"p0": [-10, 0], "p1": [-10, 0], "p2": [-10, 0], "p3": [-10, 0]}
+        default_opts.return_data_points = True
 
         # Try to fit with infeasible parameter boundary. This should fail.
-        results, _ = analysis._run_analysis(
-            test_data,
-            p0={"p0": ref_p0, "p1": ref_p1, "p2": ref_p2, "p3": ref_p3},
-            bounds={"p0": [-10, 0], "p1": [-10, 0], "p2": [-10, 0], "p3": [-10, 0]},
-            curve_fitter=multi_curve_fit,
-            data_processor=probability(outcome="1"),
-            x_key="xval",
-            plot=False,
-            axis=None,
-            xlabel="x value",
-            ylabel="y value",
-            fit_reports=None,
-            return_data_points=True,
-        )
+        results, _ = analysis._run_analysis(test_data, **default_opts.__dict__)
         result = results[0]
 
         self.assertFalse(result["success"])
@@ -400,19 +395,10 @@ class TestCurveAnalysisIntegration(QiskitTestCase):
         for datum in test_data1.data():
             test_data0.add_data(datum)
 
-        results, _ = analysis._run_analysis(
-            test_data0,
-            p0={"p0": ref_p0, "p1": ref_p1, "p2": ref_p2, "p3": ref_p3, "p4": ref_p4},
-            curve_fitter=multi_curve_fit,
-            data_processor=probability(outcome="1"),
-            x_key="xval",
-            plot=False,
-            axis=None,
-            xlabel="x value",
-            ylabel="y value",
-            fit_reports=None,
-            return_data_points=False,
-        )
+        default_opts = analysis._default_options()
+        default_opts.p0 = {"p0": ref_p0, "p1": ref_p1, "p2": ref_p2, "p3": ref_p3, "p4": ref_p4}
+
+        results, _ = analysis._run_analysis(test_data0, **default_opts.__dict__)
         result = results[0]
 
         ref_popt = np.asarray([ref_p0, ref_p1, ref_p2, ref_p3, ref_p4])
@@ -463,22 +449,82 @@ class TestCurveAnalysisIntegration(QiskitTestCase):
         for datum in test_data1.data():
             test_data0.add_data(datum)
 
-        results, _ = analysis._run_analysis(
-            test_data0,
-            p0={"p0": ref_p0, "p1": ref_p1, "p2": ref_p2, "p3": ref_p3},
-            curve_fitter=multi_curve_fit,
-            data_processor=probability(outcome="1"),
-            x_key="xval",
-            plot=False,
-            axis=None,
-            xlabel="x value",
-            ylabel="y value",
-            fit_reports=None,
-            return_data_points=False,
-        )
+        default_opts = analysis._default_options()
+        default_opts.p0 = {"p0": ref_p0, "p1": ref_p1, "p2": ref_p2, "p3": ref_p3}
+
+        results, _ = analysis._run_analysis(test_data0, **default_opts.__dict__)
         result = results[0]
 
         ref_popt = np.asarray([ref_p0, ref_p1, ref_p2, ref_p3])
 
         # check result data
         np.testing.assert_array_almost_equal(result["popt"], ref_popt, decimal=self.err_decimal)
+
+    def test_run_fixed_parameters(self):
+        """Test analysis when some of parameters are fixed."""
+        analysis = create_new_analysis(
+            series=[
+                SeriesDef(
+                    name="curve1",
+                    fit_func=lambda x, p0, p1, fixed_p2, p3: fit_function.cos(
+                        x, amp=p0, freq=p1, phase=fixed_p2, baseline=p3
+                    ),
+                ),
+            ],
+            fixed_params=["fixed_p2"]
+        )
+
+        ref_p0 = 0.1
+        ref_p1 = 2
+        ref_p2 = -0.3
+        ref_p3 = 0.5
+
+        test_data = simulate_output_data(
+            func=fit_function.cos,
+            xvals=self.xvalues,
+            param_dict={"amp": ref_p0, "freq": ref_p1, "phase": ref_p2, "baseline": ref_p3},
+        )
+
+        default_opts = analysis._default_options()
+        default_opts.p0 = {"p0": ref_p0, "p1": ref_p1, "p3": ref_p3}
+        default_opts.fixed_p2 = ref_p2
+
+        results, _ = analysis._run_analysis(test_data, **default_opts.__dict__)
+        result = results[0]
+
+        ref_popt = np.asarray([ref_p0, ref_p1, ref_p3])
+
+        # check result data
+        np.testing.assert_array_almost_equal(result["popt"], ref_popt, decimal=self.err_decimal)
+
+    def test_fixed_param_is_missing(self):
+        """Test raising an analysis error when fixed parameter is missing."""
+        analysis = create_new_analysis(
+            series=[
+                SeriesDef(
+                    name="curve1",
+                    fit_func=lambda x, p0, p1, fixed_p2, p3: fit_function.cos(
+                        x, amp=p0, freq=p1, phase=fixed_p2, baseline=p3
+                    ),
+                ),
+            ],
+            fixed_params=["fixed_p2"]
+        )
+
+        ref_p0 = 0.1
+        ref_p1 = 2
+        ref_p2 = -0.3
+        ref_p3 = 0.5
+
+        test_data = simulate_output_data(
+            func=fit_function.cos,
+            xvals=self.xvalues,
+            param_dict={"amp": ref_p0, "freq": ref_p1, "phase": ref_p2, "baseline": ref_p3},
+        )
+
+        default_opts = analysis._default_options()
+        default_opts.p0 = {"p0": ref_p0, "p1": ref_p1, "p3": ref_p3}
+        # do not define fixed_p2 here
+
+        with self.assertRaises(AnalysisError):
+            analysis._run_analysis(test_data, **default_opts.__dict__)

--- a/test/analysis/test_curve_fit.py
+++ b/test/analysis/test_curve_fit.py
@@ -136,7 +136,7 @@ class TestCurveAnalysisUnit(QiskitTestCase):
         with self.assertRaises(AnalysisError):
             create_new_analysis(
                 series=valid_series,
-                fixed_params=["not_existing_parameter"]  # this parameter is not defined
+                fixed_params=["not_existing_parameter"],  # this parameter is not defined
             )
 
     def test_arg_parse_and_get_option(self):
@@ -471,7 +471,7 @@ class TestCurveAnalysisIntegration(QiskitTestCase):
                     ),
                 ),
             ],
-            fixed_params=["fixed_p2"]
+            fixed_params=["fixed_p2"],
         )
 
         ref_p0 = 0.1
@@ -508,7 +508,7 @@ class TestCurveAnalysisIntegration(QiskitTestCase):
                     ),
                 ),
             ],
-            fixed_params=["fixed_p2"]
+            fixed_params=["fixed_p2"],
         )
 
         ref_p0 = 0.1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR allows the `CurveAnalysis` base class to define fixed parameter (requested by @eggerdj ).

For example:
```python
    class AnalysisExample(CurveAnalysis):

        __series__ = [
            SeriesDef(
                fit_func=lambda x, p0, p1, p2:
                    exponential_decay(x, amp=p0, lamb=p1, baseline=p2),
            ),
        ]

        __fixed_parameters__ = ["p1"]
```
The parameter "p1" is excluded from the fit parameters and provided by the analysis options.

This is often useful to define a family of analysis classes which are slightly different from some fit coefficients.
Fine amplitude calibration is good example.

### Details and comments


