### PR TITLE
Document required transpile options for T1

### DIFF
--- a/docs/tutorials/t1.ipynb
+++ b/docs/tutorials/t1.ipynb
@@ -235,6 +235,17 @@
     "parallel_exp = ParallelExperiment([exp, exp_q1])\n",
     "parallel_data = parallel_exp.run(backend=backend)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: before running a T1 experiment on an IBM device, or a parallel experiment consisting of T1 sub-experiments, write:\n",
+    "```\n",
+    "<your experiment object>.set_transpile_options(alignment=16, scheduling_method=\"alap\")\n",
+    "```\n",
+    "(in the case of a parallel experiment, the experiment object is the parallel experiment, and not the sub-experiments)."
+   ]
   }
  ],
  "metadata": {

--- a/qiskit_experiments/characterization/t1.py
+++ b/qiskit_experiments/characterization/t1.py
@@ -43,6 +43,12 @@ class T1(BaseExperiment):
     3. Analysis of results: deduction of T\ :sub:`1`\ , based on the outcomes,
     by fitting to an exponential curve.
 
+    Note: before running a T1 experiment on an IBM device, or a parallel experiment
+    consisting of T1 sub-experiments, write:
+    <your experiment object>.set_transpile_options(alignment=16, scheduling_method="alap")
+    (in the case of a parallel experiment, the experiment object is the parallel
+    experiment, and not the sub-experiments).
+
     """
 
     __analysis_class__ = T1Analysis


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Added the following text to T1 doc string and tutorial:
```
    Note: before running a T1 experiment on an IBM device, or a parallel experiment
    consisting of T1 sub-experiments, write:
    <your experiment object>.set_transpile_options(alignment=16, scheduling_method="alap")
    (in the case of a parallel experiment, the experiment object is the parallel
    experiment, and not the sub-experiments).
```
Will do the same for T2Ramsey in a subsequent PR, once T2Ramsey has doc strings and tutorial.

