### PR TITLE
[WIP] Injecting cals in calibration experiment

### DIFF
--- a/qiskit_experiments/calibration/management/transpiler.py
+++ b/qiskit_experiments/calibration/management/transpiler.py
@@ -1,0 +1,129 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Transpiler functionality for calibrations."""
+
+from typing import Dict, List, Optional, Tuple, Union
+
+from qiskit.transpiler.passes import SetLayout
+from qiskit.transpiler.passes import (
+    TrivialLayout,
+    FullAncillaAllocation,
+    EnlargeWithAncilla,
+    ApplyLayout
+)
+from qiskit.transpiler.layout import Layout
+from qiskit.transpiler.passmanager import PassManager
+from qiskit.transpiler.coupling import CouplingMap
+from qiskit.circuit.quantumregister import QuantumRegister
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.pulse.schedule import ScheduleBlock
+from qiskit.transpiler.basepasses import TransformationPass
+
+from qiskit_experiments.calibration.management.calibrations import Calibrations
+
+class CalibrationAdder(TransformationPass):
+    """Transformation pass to inject calibrations into circuits."""
+
+    def __init__(
+            self,
+            calibrations: Calibrations,
+            gate_schedule_map: Optional[Dict[str, str]] = None,
+    ):
+        """
+        TODO Discuss: we could give calibrations as Dict[str, Dict[Tuple, ScheduleBlock]]
+        TODO but this means that we need to export all the calibrations which may not scale well
+        TODO using cas.get_schedule(name, qubits) on an as needed basis seems better.
+
+        Args:
+            calibrations:
+            gate_schedule_map:
+        """
+        super().__init__()
+        self._cals = calibrations
+        self._gate_schedule_map = gate_schedule_map or dict()
+
+    def get_calibration(
+            self,
+            gate_name: str,
+            qubits: Tuple[int, ...]
+    ) -> Union[ScheduleBlock, None]:
+        """Gets the calibrated schedule
+
+        Args:
+            gate_name: Name of the gate for which to get the schedule.
+            params: The parameters of the gate if any.
+            qubits: The qubits for which to get the parameters.
+
+        Returns:
+            The schedule if one is found otherwise return None.
+        """
+        name = self._gate_schedule_map.get(gate_name, gate_name)
+        try:
+            return self._cals.get_schedule(name, qubits)
+        except KeyError:
+            return None
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Run the calibration adder pass on `dag`.
+
+        Args:
+            dag: DAG to schedule.
+
+        Returns:
+            A DAG with calibrations added to it.
+        """
+        bit_indices = {bit: index for index, bit in enumerate(dag.qubits)}
+
+        for node in dag.nodes():
+            if node.type == "op":
+                params = node.op.params
+                qubits = tuple(bit_indices[qarg] for qarg in node.qargs)
+
+                schedule = self.get_calibration(node.op.name, qubits)
+
+                if schedule is not None:
+                    dag.add_calibration(node.op, qubits, schedule, params=params)
+
+        return dag
+
+
+def get_calibration_pass_manager(
+        initial_layout: List[int],
+        coupling_map: List[List[int]],
+        calibrations: Optional[Calibrations]
+) -> PassManager:
+    """Get a calibrations experiment pass manager.
+
+    Args:
+        initial_layout:
+        coupling_map:
+        calibrations:
+
+    Returns:
+         An instance of :class:`PassManager` tailored to calibration experiments.
+    """
+    initial_layout = Layout.from_intlist(initial_layout, QuantumRegister(len(initial_layout), "q"))
+    coupling_map = CouplingMap(coupling_map)
+
+    def _choose_layout_condition(property_set):
+        return not property_set["layout"]
+
+    pm = PassManager()
+    pm.append(SetLayout(initial_layout))
+    pm.append(TrivialLayout(coupling_map), condition=_choose_layout_condition)
+    pm.append([FullAncillaAllocation(coupling_map), EnlargeWithAncilla(), ApplyLayout()])
+
+    if calibrations is not None:
+        pm.append(CalibrationAdder(calibrations))
+
+    return pm

--- a/qiskit_experiments/calibration/management/transpiler.py
+++ b/qiskit_experiments/calibration/management/transpiler.py
@@ -31,6 +31,8 @@ from qiskit.transpiler.basepasses import TransformationPass
 
 from qiskit_experiments.calibration.management.calibrations import Calibrations
 
+# TODO: need to show how this might work in an experiment. E.g. Rabi?
+
 class CalibrationAdder(TransformationPass):
     """Transformation pass to inject calibrations into circuits."""
 
@@ -98,9 +100,10 @@ class CalibrationAdder(TransformationPass):
 
 
 def get_calibration_pass_manager(
-        initial_layout: List[int],
-        coupling_map: List[List[int]],
-        calibrations: Optional[Calibrations]
+    initial_layout: List[int],
+    coupling_map: List[List[int]],
+    calibrations: Optional[Calibrations],
+    gate_schedule_map: Optional[Dict[str, str]],
 ) -> PassManager:
     """Get a calibrations experiment pass manager.
 
@@ -108,6 +111,7 @@ def get_calibration_pass_manager(
         initial_layout:
         coupling_map:
         calibrations:
+        gate_schedule_map:
 
     Returns:
          An instance of :class:`PassManager` tailored to calibration experiments.
@@ -124,6 +128,6 @@ def get_calibration_pass_manager(
     pm.append([FullAncillaAllocation(coupling_map), EnlargeWithAncilla(), ApplyLayout()])
 
     if calibrations is not None:
-        pm.append(CalibrationAdder(calibrations))
+        pm.append(CalibrationAdder(calibrations, gate_schedule_map))
 
     return pm


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR is intended to be a basis for a discussion on how to inject calibrations into experiments. Many calibration experiments require default gates such as `x` and `sx`. However, if calibrations are not provided the backend defaults will be used which leads to an inconsistent calibration framework. This is the issue that this PR addresses.

### Details and comments
 Comments on the design choices:
 * To avoid giving the transpiler a custom PassManager in the base experiment class we run a light-weight pass in the circuits method to inject schedules for standard gates.
 * The transpiler pass uses an instance of `Calibrations` which means that it needs to live in `qiskit-experiments`. This allows the pass to query for the calibrated schedules on an as needed basis. Alternatively we could have exported the entire calibrations to the pass to have a `CalibrationAdder` that is independent of `qiskit-experiments` and could live in terra. However, this seems inefficient for large settings when in calibrations we typically only need a few schedules on a couple of qubits.

A good place to look at first is the new EFRabi test.

