### PR TITLE
Update `block_for_results` to return `self`

### DIFF
--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -781,16 +781,20 @@ class DbExperimentDataV1(DbExperimentData):
                 except Exception as err:  # pylint: disable=broad-except
                     LOG.info("Unable to cancel job %s: %s", job.job_id(), err)
 
-    def block_for_results(self, timeout: Optional[float] = None) -> None:
+    def block_for_results(self, timeout: Optional[float] = None) -> "DbExperimentDataV1":
         """Block until all pending jobs and their post processing finish.
 
         Args:
             timeout: Timeout waiting for results.
+
+        Returns:
+            The experiment data with finished jobs and post-processing.
         """
         for job, fut in self._job_futures.copy():
             LOG.info("Waiting for job %s and its post processing to finish.", job.job_id())
             with contextlib.suppress(Exception):
                 fut.result(timeout)
+        return self
 
     def status(self) -> str:
         """Return the data processing status.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Update the `DbExperimentDataV1.block_for_results` function to return self rather than `None` so it can be used as

```python
expdata = experiment.run(backend).block_for_results()
```


### Details and comments


