### PR TITLE
Configure docs publishing job for test branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,7 @@
 name: Docs Publish
 on:
   push:
-    tags:
-      - "*"
+    branches: [ test ]
 
 jobs:
   deploy:

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -29,4 +29,4 @@ pwd
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
-rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/experiments
+rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/experiments/test


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit tweaks the docs publishing job to publish the documentation
for the test branch to https://qiskit.org/documentation/experiments/test
on every merged commit to the test branch. When we release
qiskit-experiments the docs job from the main branch will be triggered
deleting these published docs from cloud object storage as the publish
job runs 'rclone sync' which deletes files in target not in source. This
should give us the desired state where the test docs only exist as long
as the test branch does prior to the first release of
qiskit-experiments.

### Details and comments


