### PR TITLE
[RFC] Promote AnalysisResultData to a dataclass.

### DIFF
--- a/qiskit_experiments/curve_analysis/curve_analysis_result_data.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis_result_data.py
@@ -15,7 +15,7 @@ Curve analysis result data class.
 from qiskit_experiments.framework import AnalysisResultData
 
 
-class CurveAnalysisResultData(AnalysisResultData):
+class CurveAnalysisResultData(dict):
     """Analysis data container for curve fit analysis.
 
     Class Attributes:

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -13,27 +13,43 @@
 Experiment Data class
 """
 import logging
-from typing import Dict
+from typing import List, Union
 from datetime import datetime
+from dataclasses import dataclass
 
 from qiskit_experiments.database_service import DbExperimentDataV1
+from qiskit_experiments.database_service.device_component import DeviceComponent
 
 
 LOG = logging.getLogger(__name__)
 
-
-class AnalysisResultData(dict):
+@dataclass
+class AnalysisResultData:
     """Placeholder class"""
+    result_data: dict
+    result_type: str
+    device_components: List[Union[DeviceComponent, str]]
+    chisq: float = None
+    quality: str = None
+    verified: bool = False
 
     __keys_not_shown__ = tuple()
     """Data keys of analysis result which are not directly shown in `__str__` method"""
 
     def __str__(self):
-        out = ""
+        out = f"AnalysisResultData"
+        out += f"\n- result_type: {self.result_type}"
+        out += f"\n- device_components: {self.device_components}"
+        if self.chisq:
+            out += f"\n- chisq: {self.chisq}"
+        if self.quality:
+            out += f"\n- quality: {self.quality}"
+        out += f"\n- verified: {self.verified}"
+        out += f"\n- result_data:"
         for key, value in self.items():
             if key in self.__keys_not_shown__:
                 continue
-            out += f"\n- {key}: {value}"
+            out += f"\n  - {key}: {value}"
         return out
 
 


### PR DESCRIPTION
Shows an example path for a more strongly structured `AnalysisResultData`. This forces values to exist that **must exist** for conversion to a DB-backed analysis result, while retaining freedom in the parts that can be free.

Note that by using a `dataclass` we either need to drop python 3.6 support or add the `dataclasses` package as a dependency for python 3.6.

