### PR TITLE
Set minimum python version to 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.17
 scipy>=1.4
-qiskit-terra>=0.16.0
+qiskit-terra>=0.18.0

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -62,7 +61,7 @@ setup(
     packages=find_packages(exclude=['test*']),
     install_requires=REQUIREMENTS,
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit-experiments/issues",
         "Documentation": "https://qiskit.org/documentation/",

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ setenv =
   QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
 deps =
   -r{toxinidir}/requirements-dev.txt
-  git+https://github.com/Qiskit/qiskit-terra
 commands = stestr run {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit changes the minimum supported python version from 3.6 to
3.7. qiskit-experiments uses dataclasses internally which was a
python feature introduced in 3.7 and the code as packaged doesn't
actually work on 3.6. This hasn't been caught in CI because a test
dependency of qiskit-experiments is installing the dataclasses backport
package as a dependency which is masking this issue. While we can list
that package as a depedency of qiskit-experiments too to resolve this,
python 3.6 is deprecated in the upstream qiskit packages and the next
qiskit-terra minor version release (0.19.0) will be the last to support
it. At this point it just makes more sense to drop 3.6 support.

At the same time the minimum supported version of the qiskit-terra
package is bumped to the latest release 0.18.0 which is actually the
minimum version needed (we were installing from git in CI to workaround
this pre-0.18.0 release) and 0.17.0 was the release which deprecated
python 3.6 in qiskit which lines up well with dropping 3.6 support here.

### Details and comments


Closes #222 