### PR TITLE
[WIP] Update `BaseExperiment.run` behavior for existing experiment data

### DIFF
--- a/test/quantum_volume/test_qv.py
+++ b/test/quantum_volume/test_qv.py
@@ -103,21 +103,20 @@ class TestQuantumVolume(QiskitTestCase):
         qv_exp = QuantumVolume(num_of_qubits, seed=SEED)
         # set number of trials to a low number to make the test faster
         qv_exp.set_experiment_options(trials=2)
-        expdata = qv_exp.run(backend)
-        expdata.block_for_results()
-        expdata = qv_exp.run(backend, experiment_data=expdata)
-        expdata.block_for_results()
+        expdata1 = qv_exp.run(backend)
+        expdata1.block_for_results()
+        result_data1 = expdata1.analysis_results(0).data()
+        expdata2 = qv_exp.run(backend, experiment_data=expdata1)
+        expdata2.block_for_results()
+        result_data2 = expdata2.analysis_results(0).data()
 
+        self.assertTrue(result_data1["trials"] == 2, "number of trials is incorrect")
         self.assertTrue(
-            expdata.analysis_results(0).data()["trials"] == 2, "number of trials is incorrect"
-        )
-        self.assertTrue(
-            expdata.analysis_results(1).data()["trials"] == 4,
+            result_data2["trials"] == 4,
             "number of trials is incorrect" " after adding more trials",
         )
         self.assertTrue(
-            expdata.analysis_results(1).data()["sigma"]
-            <= expdata.analysis_results(0).data()["sigma"],
+            result_data2["sigma"] <= result_data1["sigma"],
             "sigma did not decreased after adding more trials",
         )
 

--- a/test/test_t2ramsey.py
+++ b/test/test_t2ramsey.py
@@ -298,6 +298,7 @@ class TestT2Ramsey(QiskitTestCase):
         # run circuits
         expdata0 = exp0.run(backend=backend, shots=1000)
         expdata0.block_for_results()
+        results0 = expdata0.analysis_results()
 
         # second experiment
         delays1 = list(range(2, 65, 2))
@@ -305,14 +306,15 @@ class TestT2Ramsey(QiskitTestCase):
         exp1.set_analysis_options(user_p0=default_p0)
         expdata1 = exp1.run(backend=backend, experiment_data=expdata0, shots=1000)
         expdata1.block_for_results()
-        result = expdata1.analysis_results()
+        results1 = expdata1.analysis_results()
+
         self.assertAlmostEqual(
-            result[2].data()["value"],
+            results1[0].data()["value"],
             estimated_t2ramsey * dt_factor,
             delta=3 * dt_factor,
         )
         self.assertAlmostEqual(
-            result[3].data()["value"], estimated_freq / dt_factor, delta=3 / dt_factor
+            results1[1].data()["value"], estimated_freq / dt_factor, delta=3 / dt_factor
         )
-        self.assertLessEqual(result[2].data()["stderr"], result[0].data()["stderr"])
+        self.assertLessEqual(results1[0].data()["stderr"], results0[0].data()["stderr"])
         self.assertEqual(len(expdata1.data()), len(delays0) + len(delays1))


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This addresses one of the issues from #230 for what should happen if you call `experiment.run(backend, experiment_data)` to append additional data to an existing experiment. 

### Details and comments

This PR updates the `BaseExperiment.run` function so that if an existing experiment data container is passed it will return a new experiment data with a new experiment ID that contains the jobs and result data from the previous experiment, along with the new jobs and data. It will not contain the previous analysis results or figures, only the new analysis output from running on the combined set of existing and new data.

### Example

This can be run as:

```python
qv_exp = QuantumVolume(3)

# Run once
expdata1 = qv_exp.run(backend)
expdata1.block_for_results()
expdata1.save()

# Add extra data
expdata2 = qv_exp.run(backend, experiment_data=expdata1)
expdata2.block_for_results()
expdata2.save()
```

`expdata1` will contain the data and result of the first set of circuits, while `expdata2` will contain the circuit data from `expdata1` plus the extra circuits, and the analysis result of the analysis on the combined set.

Both `expdata1` and `expdata2` will be saved as separate entries in the DB with their own analysis result, though in this case expdata1s result is on 100 trials, while expdata2 is on 200 trials.
