### PR TITLE
Fit model doc generation

### DIFF
--- a/docs/_ext/custom_styles/example/example_experiment.py
+++ b/docs/_ext/custom_styles/example/example_experiment.py
@@ -44,7 +44,13 @@ class DocumentedCurveAnalysis(CurveAnalysis):
         In addition to above sections, analysis template provides following extra sections.
 
     # section: fit_model
-        Here you can describe your fitting model.
+        Optional. Here you can describe your fitting model.
+        If you are documenting a CurveAnalysis subclass, Sphinx automatically  generates
+        the fit model descriptions based on descriptions in the SeriesDef.
+        However you can still override this section.
+        If you want to provide the fit model description for other analysis classes,
+        please write this section.
+
         Standard reStructuredText directives can be used. For example:
 
         .. math::

--- a/docs/_ext/custom_styles/formatter.py
+++ b/docs/_ext/custom_styles/formatter.py
@@ -181,8 +181,7 @@ class AnalysisSectionFormatter(DocstringSectionFormatter):
         format_lines = [
             ".. rubric:: Fit Model",
             "",
-            "This is the curve fitting analysis. ",
-            "Following equation(s) are used to represent curve(s).",
+            "Following fit models are used to represent the experimental result.",
             "",
         ]
         format_lines.extend(lines)

--- a/docs/_ext/custom_styles/utils.py
+++ b/docs/_ext/custom_styles/utils.py
@@ -21,6 +21,8 @@ from sphinx.config import Config as SphinxConfig
 from sphinx.ext.napoleon.docstring import GoogleDocstring
 from sphinx.util.docstrings import prepare_docstring
 
+from qiskit_experiments.curve_analysis import SeriesDef
+
 
 def _trim_empty_lines(docstring_lines: List[str]) -> List[str]:
     """A helper function to remove redundant line feeds."""
@@ -121,6 +123,34 @@ def _generate_options_documentation(
         return _trim_empty_lines(options_docstring_lines)
 
     return options_docstring_lines
+
+
+def _generate_fit_model_documentation(series_defs: List[SeriesDef], indent: str = "") -> List[str]:
+    """Automatically generate fit model documentation from the series definition."""
+    n_curves = len(series_defs)
+
+    fit_model_docstring_lines = []
+    for idx, series_def in enumerate(series_defs):
+        if series_def.model_description is None:
+            continue
+        if n_curves > 1:
+            fit_model_docstring_lines.extend([
+                f"- Fit model for the curve ``{series_def.name}``:",
+                ""
+            ])
+        math_block = [
+            ".. math::",
+            "",
+            indent + f"F(x) = {series_def.model_description} \\tag{idx + 1}",
+            "",
+        ]
+        fit_model_docstring_lines.extend(math_block)
+
+    fit_model_docstring_lines.append(
+        "The information about the fit model is also stored in the analysis result metadata."
+    )
+
+    return fit_model_docstring_lines
 
 
 def _format_default_options(defaults: Dict[str, Any], indent: str = "") -> List[str]:

--- a/docs/_static/gallery.css
+++ b/docs/_static/gallery.css
@@ -193,3 +193,7 @@ p.sphx-glr-signature a.reference.external {
 a.sphx-glr-backref-instance {
   text-decoration: none;
 }
+
+span.eqno {
+    float: right;
+}

--- a/qiskit_experiments/curve_analysis/curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis.py
@@ -867,6 +867,11 @@ class CurveAnalysis(BaseAnalysis, ABC):
         """
         result_data = CurveAnalysisResultData()
         result_data["analysis_type"] = self.__class__.__name__
+
+        # add model description
+        result_data["fit_models"] = {
+            series_def.name: series_def.model_description for series_def in self.__series__
+        }
         figures = list()
 
         #

--- a/qiskit_experiments/curve_analysis/curve_data.py
+++ b/qiskit_experiments/curve_analysis/curve_data.py
@@ -41,6 +41,9 @@ class SeriesDef:
     # Whether to plot fit uncertainty for this line.
     plot_fit_uncertainty: bool = False
 
+    # Latex description of this fit model
+    model_description: str = "no description"
+
 
 @dataclasses.dataclass(frozen=True)
 class CurveData:

--- a/qiskit_experiments/curve_analysis/fit_function.py
+++ b/qiskit_experiments/curve_analysis/fit_function.py
@@ -45,7 +45,7 @@ def sin(
     .. math::
         y = {\rm amp} \sin\left(2 \pi {\fm freq} x + {\rm phase}\right) + {\rm baseline}
     """
-    return amp * np.cos(2 * np.pi * freq * x + phase) + baseline
+    return amp * np.sin(2 * np.pi * freq * x + phase) + baseline
 
 
 def exponential_decay(

--- a/qiskit_experiments/library/calibration/analysis/drag_analysis.py
+++ b/qiskit_experiments/library/calibration/analysis/drag_analysis.py
@@ -35,7 +35,7 @@ class DragCalAnalysis(CurveAnalysis):
 
     .. math::
 
-        y = {\rm amp} \cos\left(2 \pi {\rm freq}_i x - 2 \pi {\rm beta}\right) + {\rm base}
+        y = {\rm amp} \cos\left(2 \pi {\rm freq}_i x - 2 \pi {\rm beta}\right) + b
 
     Fit Parameters
         - :math:`{\rm amp}`: Amplitude of all series.
@@ -65,6 +65,7 @@ class DragCalAnalysis(CurveAnalysis):
             name="series-0",
             filter_kwargs={"series": 0},
             plot_symbol="o",
+            model_description=r"{\rm amp} \cos(2 \pi f_0 (x - beta)) + b",
         ),
         SeriesDef(
             fit_func=lambda x, amp, freq0, freq1, freq2, beta, base: cos(
@@ -74,6 +75,7 @@ class DragCalAnalysis(CurveAnalysis):
             name="series-1",
             filter_kwargs={"series": 1},
             plot_symbol="^",
+            model_description=r"{\rm amp} \cos(2 \pi f_1 (x - beta)) + b",
         ),
         SeriesDef(
             fit_func=lambda x, amp, freq0, freq1, freq2, beta, base: cos(
@@ -83,6 +85,7 @@ class DragCalAnalysis(CurveAnalysis):
             name="series-2",
             filter_kwargs={"series": 2},
             plot_symbol="v",
+            model_description=r"{\rm amp} \cos(2 \pi f_2 (x - beta)) + b",
         ),
     ]
 

--- a/qiskit_experiments/library/calibration/analysis/fine_amplitude_analysis.py
+++ b/qiskit_experiments/library/calibration/analysis/fine_amplitude_analysis.py
@@ -35,7 +35,7 @@ class FineAmplitudeAnalysis(CurveAnalysis):
     The fit function is
 
     .. math::
-        y = {\rm amp}/2\cos\left(x[{\rm d}\theta + {\rm apg} ]+{\rm phase\_offset}\right)+baseline
+        y = {\rm amp}/2\cos\left(x[{\rm d}\theta + {\rm apg} ]+{\rm phase\_offset}\right)+b
 
     Fit Parameters
         - :math:`amp`: Amplitude of the oscillation.
@@ -60,14 +60,16 @@ class FineAmplitudeAnalysis(CurveAnalysis):
 
     __series__ = [
         SeriesDef(
-            fit_func=lambda x, amp, d_theta, phase_offset, baseline, angle_per_gate: fit_function.cos(
+            fit_func=lambda x, amp, d_theta, phase_offset, base, angle_per_gate: fit_function.cos(
                 x,
                 amp=0.5 * amp,
                 freq=(d_theta + angle_per_gate) / (2 * np.pi),
                 phase=phase_offset,
-                baseline=baseline,
+                baseline=base,
             ),
             plot_color="blue",
+            model_description=r"{\rm amp} \cos(({\rm d}\theta + {\rm apg}) x "
+                              r"+ \theta_{\rm offset}) + b",
         )
     ]
 
@@ -82,8 +84,8 @@ class FineAmplitudeAnalysis(CurveAnalysis):
         descriptions of analysis options.
         """
         default_options = super()._default_options()
-        default_options.p0 = {"amp": None, "d_theta": None, "phase": None, "baseline": None}
-        default_options.bounds = {"amp": None, "d_theta": None, "phase": None, "baseline": None}
+        default_options.p0 = {"amp": None, "d_theta": None, "phase": None, "base": None}
+        default_options.bounds = {"amp": None, "d_theta": None, "phase": None, "base": None}
         default_options.fit_reports = {"d_theta": "d_theta"}
         default_options.xlabel = "Number of gates (n)"
         default_options.ylabel = "Population"
@@ -115,18 +117,17 @@ class FineAmplitudeAnalysis(CurveAnalysis):
         guess_range = max(abs(angle_per_gate), np.pi / 2)
 
         fit_options = []
-
         for angle in np.linspace(-guess_range, guess_range, n_guesses):
             fit_option = {
                 "p0": {
                     "amp": user_p0["amp"] or a_guess,
                     "d_theta": angle,
-                    "baseline": b_guess,
+                    "base": b_guess,
                 },
                 "bounds": {
                     "amp": user_bounds.get("amp", None) or (-2 * max_abs_y, 2 * max_abs_y),
                     "d_theta": user_bounds.get("d_theta", None) or (-np.pi, np.pi),
-                    "baseline": user_bounds.get("d_theta", None) or (-1 * max_abs_y, 1 * max_abs_y),
+                    "base": user_bounds.get("base", None) or (-1 * max_abs_y, 1 * max_abs_y),
                 },
             }
 

--- a/qiskit_experiments/library/calibration/analysis/fine_amplitude_analysis.py
+++ b/qiskit_experiments/library/calibration/analysis/fine_amplitude_analysis.py
@@ -69,7 +69,7 @@ class FineAmplitudeAnalysis(CurveAnalysis):
             ),
             plot_color="blue",
             model_description=r"{\rm amp} \cos(({\rm d}\theta + {\rm apg}) x "
-                              r"+ \theta_{\rm offset}) + b",
+            r"+ \theta_{\rm offset}) + b",
         )
     ]
 

--- a/qiskit_experiments/library/calibration/analysis/oscillation_analysis.py
+++ b/qiskit_experiments/library/calibration/analysis/oscillation_analysis.py
@@ -62,6 +62,7 @@ class OscillationAnalysis(CurveAnalysis):
                 x, amp=amp, freq=freq, phase=phase, baseline=baseline
             ),
             plot_color="blue",
+            model_description=r"{\rm amp} \cos(2 \pi f x + \theta) + b",
         )
     ]
 

--- a/qiskit_experiments/library/characterization/resonance_analysis.py
+++ b/qiskit_experiments/library/characterization/resonance_analysis.py
@@ -71,6 +71,7 @@ class ResonanceAnalysis(CurveAnalysis):
                 x, amp=a, sigma=sigma, x0=freq, baseline=b
             ),
             plot_color="blue",
+            model_description=r"a \exp(-(x-f)^2/(2\sigma^2)) + b",
         )
     ]
 

--- a/qiskit_experiments/library/randomized_benchmarking/__init__.py
+++ b/qiskit_experiments/library/randomized_benchmarking/__init__.py
@@ -31,9 +31,14 @@ Analysis
 
 .. autosummary::
     :toctree: ../stubs/
+    :template: autosummary/analysis.rst
 
     RBAnalysis
     InterleavedRBAnalysis
+
+.. autosummary::
+    :toctree: ../stubs/
+
     RBUtils
 """
 from .rb_experiment import StandardRB

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
@@ -107,6 +107,7 @@ class InterleavedRBAnalysis(RBAnalysis):
             plot_color="red",
             plot_symbol=".",
             plot_fit_uncertainty=True,
+            model_description=r"a \alpha^{x} + b",
         ),
         SeriesDef(
             name="Interleaved",
@@ -117,6 +118,7 @@ class InterleavedRBAnalysis(RBAnalysis):
             plot_color="orange",
             plot_symbol="^",
             plot_fit_uncertainty=True,
+            model_description=r"a (\alpha_c\alpha)^{x} + b",
         ),
     ]
 

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
@@ -29,13 +29,12 @@ from .rb_analysis import RBAnalysis
 class InterleavedRBAnalysis(RBAnalysis):
     r"""A class to analyze interleaved randomized benchmarking experiment.
 
-    Overview
+    # section: overview
         This analysis takes only two series for standard and interleaved RB curve fitting.
         From the fit :math:`\alpha` and :math:`\alpha_c` value this analysis estimates
         the error per Clifford (EPC) of the interleaved gate.
 
         The EPC estimate is obtained using the equation
-
 
         .. math::
 
@@ -57,44 +56,30 @@ class InterleavedRBAnalysis(RBAnalysis):
 
         See Ref. [1] for more details.
 
+    # section: fit_parameters
+        defpar a:
+            desc: Height of decay curve.
+            init_guess: Determined by the average :math:`a` of the standard and interleaved RB.
+            bounds: [0, 1]
+        defpar b:
+            desc: Base line.
+            init_guess: Determined by the average :math:`b` of the standard and interleaved RB.
+                Usually equivalent to :math:`(1/2)^n` where :math:`n` is number of qubit.
+            bounds: [0, 1]
+        defpar \alpha:
+            desc: Depolarizing parameter.
+            init_guess: Determined by the slope of :math:`(y - b)^{-x}` of the first and the
+                second data point of the standard RB.
+            bounds: [0, 1]
+        defpar \alpha_c:
+            desc: Ratio of the depolarizing parameter of interleaved RB to standard RB curve.
+            init_guess: Estimate :math:`\alpha' = \alpha_c \alpha` from the
+                interleaved RB curve, then divide this by the initial guess of :math:`\alpha`.
+            bounds: [0, 1]
 
+    # section: reference
+        .. ref_arxiv:: 1 1203.4550
 
-    Fit Model
-        The fit is based on the following decay functions:
-
-        .. math::
-
-            F_1(x_1) &= a \alpha^{x_1} + b  \quad {\rm for standard RB} \\
-            F_2(x_2) &= a (\alpha_c \alpha)^{x_2} + b \quad {\rm for interleaved RB}
-
-    Fit Parameters
-        - :math:`a`: Height of decay curve.
-        - :math:`b`: Base line.
-        - :math:`\alpha`: Depolarizing parameter.
-        - :math:`\alpha_c`: Ratio of the depolarizing parameter of
-          interleaved RB to standard RB curve.
-
-    Initial Guesses
-        - :math:`a`: Determined by the average :math:`a` of the standard and interleaved RB.
-        - :math:`b`: Determined by the average :math:`b` of the standard and interleaved RB.
-          Usually equivalent to :math:`(1/2)**n` where :math:`n` is number of qubit.
-        - :math:`\alpha`: Determined by the slope of :math:`(y_1 - b)**(-x_1)` of the first and the
-          second data point of the standard RB.
-        - :math:`\alpha_c`: Estimate :math:`\alpha' = \alpha_c * \alpha` from the
-          interleaved RB curve, then divide this by the initial guess of :math:`\alpha`.
-
-    Bounds
-        - :math:`a`: [0, 1]
-        - :math:`b`: [0, 1]
-        - :math:`\alpha`: [0, 1]
-        - :math:`\alpha_c`: [0, 1]
-
-    References
-        1. Easwar Magesan, Jay M. Gambetta, B. R. Johnson, Colm A. Ryan, Jerry M. Chow,
-           Seth T. Merkel, Marcus P. da Silva, George A. Keefe, Mary B. Rothwell, Thomas A. Ohki,
-           Mark B. Ketchen, M. Steffen, Efficient measurement of quantum gate error by
-           interleaved randomized benchmarking,
-           `arXiv:quant-ph/1203.4550 <https://arxiv.org/pdf/1203.4550>`_
     """
 
     __series__ = [
@@ -124,10 +109,7 @@ class InterleavedRBAnalysis(RBAnalysis):
 
     @classmethod
     def _default_options(cls):
-        """Return default data processing options.
-
-        See :meth:`~qiskit_experiment.curve_analysis.CurveAnalysis._default_options` for
-        descriptions of analysis options.
+        """Return default analysis options.
         """
         default_options = super()._default_options()
         default_options.p0 = {"a": None, "alpha": None, "alpha_c": None, "b": None}

--- a/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
@@ -25,34 +25,26 @@ from .rb_utils import RBUtils
 class RBAnalysis(curve.CurveAnalysis):
     r"""A class to analyze randomized benchmarking experiments.
 
-    Overview
+    # section: overview
         This analysis takes only single series.
         This series is fit by the exponential decay function.
         From the fit :math:`\alpha` value this analysis estimates the error per Clifford (EPC).
 
-    Fit Model
-        The fit is based on the following decay function:
-
-        .. math::
-
-            F(x) = a \alpha^x + b
-
-    Fit Parameters
-        - :math:`a`: Height of decay curve.
-        - :math:`b`: Base line.
-        - :math:`\alpha`: Depolarizing parameter. This is the fit parameter of main interest.
-
-    Initial Guesses
-        - :math:`a`: Determined by :math:`(y_0 - b) / \alpha^x_0`
-          where :math:`b` and :math:`\alpha` are initial guesses.
-        - :math:`b`: Determined by :math:`(1/2)^n` where :math:`n` is the number of qubit.
-        - :math:`\alpha`: Determined by the slope of :math:`(y - b)^{-x}` of the first and the
-          second data point.
-
-    Bounds
-        - :math:`a`: [0, 1]
-        - :math:`b`: [0, 1]
-        - :math:`\alpha`: [0, 1]
+    # section: fit_parameters
+        defpar a:
+            desc: Height of decay curve.
+            init_guess: Determined by :math:`(y - b) / \alpha^x`.
+            bounds: [0, 1]
+        defpar b:
+            desc: Base line.
+            init_guess: Determined by the average :math:`b` of the standard and interleaved RB.
+                Usually equivalent to :math:`(1/2)^n` where :math:`n` is number of qubit.
+            bounds: [0, 1]
+        defpar \alpha:
+            desc: Depolarizing parameter.
+            init_guess: Determined by the slope of :math:`(y - b)^{-x}` of the first and the
+                second data point.
+            bounds: [0, 1]
 
     """
 
@@ -69,10 +61,18 @@ class RBAnalysis(curve.CurveAnalysis):
 
     @classmethod
     def _default_options(cls):
-        """Return default options.
+        """Return default analysis options.
 
-        See :meth:`~qiskit_experiment.curve_analysis.CurveAnalysis._default_options` for
-        descriptions of analysis options.
+        Analysis Options:
+            error_dict (Dict[Tuple[Iterable[int], str], float]): Optional.
+                Error estimates for gates from the backend properties.
+            epg_1_qubit (Dict[int, Dict[str, float]]) : Optional.
+                EPG data for the 1-qubit gate involved,
+                assumed to have been obtained from previous experiments.
+                This is used to estimate the 2-qubit EPG.
+            gate_error_ratio (Dict[str, float]): An estimate for the ratios
+                between errors on different gates.
+
         """
         default_options = super()._default_options()
         default_options.p0 = {"a": None, "alpha": None, "b": None}

--- a/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
@@ -63,6 +63,7 @@ class RBAnalysis(curve.CurveAnalysis):
             ),
             plot_color="blue",
             plot_fit_uncertainty=True,
+            model_description=r"a \alpha^x + b",
         )
     ]
 

--- a/test/curve_analysis/test_curve_fit.py
+++ b/test/curve_analysis/test_curve_fit.py
@@ -86,6 +86,7 @@ class TestCurveAnalysisUnit(QiskitTestCase):
                         x, amp=p0, lamb=p1, baseline=p4
                     ),
                     filter_kwargs={"type": 1, "valid": True},
+                    model_description=r"p_0 * \exp(p_1 x) + p4",
                 ),
                 SeriesDef(
                     name="curve2",
@@ -93,6 +94,7 @@ class TestCurveAnalysisUnit(QiskitTestCase):
                         x, amp=p0, lamb=p2, baseline=p4
                     ),
                     filter_kwargs={"type": 2, "valid": True},
+                    model_description=r"p_0 * \exp(p_2 x) + p4",
                 ),
                 SeriesDef(
                     name="curve3",
@@ -100,6 +102,7 @@ class TestCurveAnalysisUnit(QiskitTestCase):
                         x, amp=p0, lamb=p3, baseline=p4
                     ),
                     filter_kwargs={"type": 3, "valid": True},
+                    model_description=r"p_0 * \exp(p_3 x) + p4",
                 ),
             ],
         )
@@ -282,6 +285,7 @@ class TestCurveAnalysisIntegration(QiskitTestCase):
                     fit_func=lambda x, p0, p1, p2, p3: fit_function.exponential_decay(
                         x, amp=p0, lamb=p1, x0=p2, baseline=p3
                     ),
+                    model_description=r"p_0 \exp(p_1 x + p_2) + p_3",
                 )
             ],
         )
@@ -308,6 +312,7 @@ class TestCurveAnalysisIntegration(QiskitTestCase):
         self.assertEqual(result["dof"], 46)
         self.assertListEqual(result["xrange"], [0.1, 1.0])
         self.assertListEqual(result["popt_keys"], ["p0", "p1", "p2", "p3"])
+        self.assertDictEqual(result["fit_models"], {"curve1": r"p_0 \exp(p_1 x + p_2) + p_3"})
 
     def test_run_single_curve_fail(self):
         """Test analysis returns status when it fails."""
@@ -342,7 +347,7 @@ class TestCurveAnalysisIntegration(QiskitTestCase):
 
         self.assertFalse(result["success"])
 
-        ref_result_keys = ["analysis_type", "error_message", "success", "raw_data"]
+        ref_result_keys = ["analysis_type", "fit_models", "error_message", "success", "raw_data"]
         self.assertSetEqual(set(result.keys()), set(ref_result_keys))
 
     def test_run_two_curves_with_same_fitfunc(self):

--- a/test/randomized_benchmarking/test_rb_analysis.py
+++ b/test/randomized_benchmarking/test_rb_analysis.py
@@ -175,6 +175,8 @@ class TestRBAnalysis(QiskitTestCase):
                                 calculated_analysis_sample_data.data()[key],
                                 expected_analysis_samples_data[idx][key],
                             )
+                        elif key == "fit_models":
+                            pass
                         else:
                             self.assertTrue(
                                 np.allclose(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is follow-up of #238 (has dependency on it)

### Details and comments

With #238 fit model description is moved from docstring to `SeriesDef` so that it can pass the model description to the analysis result. This PR allows a `CurveAnalysis` subclass docstring to automatically generate the fit model documentation by taking series definitions.

As an example, I only updated RB and IRB analysis documentation since they are ready for migration. You can check appearance of documentation by running 

```
rm docs/stubs/*RB*
tox -edocs
```
please try `tox -r -edocs` if you haven't run docs generation after #116 