### PR TITLE
Rename data to result data

### DIFF
--- a/qiskit_experiments/database_service/database_service.py
+++ b/qiskit_experiments/database_service/database_service.py
@@ -184,7 +184,7 @@ class DatabaseServiceV1(DatabaseService, ABC):
     def create_analysis_result(
         self,
         experiment_id: str,
-        data: Dict,
+        result_data: Dict,
         result_type: str,
         device_components: Optional[Union[str, DeviceComponent]] = None,
         tags: Optional[List[str]] = None,
@@ -197,7 +197,7 @@ class DatabaseServiceV1(DatabaseService, ABC):
 
         Args:
             experiment_id: ID of the experiment this result is for.
-            data: Result data to be stored.
+            result_data: Result data to be stored.
             result_type: Analysis result type.
             device_components: Target device components, such as qubits.
             tags: Tags to be associated with the analysis result.
@@ -219,7 +219,7 @@ class DatabaseServiceV1(DatabaseService, ABC):
     def update_analysis_result(
         self,
         result_id: str,
-        data: Optional[Dict] = None,
+        result_data: Optional[Dict] = None,
         tags: Optional[List[str]] = None,
         quality: Optional[str] = None,
         verified: bool = None,
@@ -229,7 +229,7 @@ class DatabaseServiceV1(DatabaseService, ABC):
 
         Args:
             result_id: Analysis result ID.
-            data: Result data to be stored.
+            result_data: Result data to be stored.
             quality: Quality of this analysis.
             verified: Whether the result quality has been verified.
             tags: Tags to be associated with the analysis result.

--- a/qiskit_experiments/database_service/db_analysis_result.py
+++ b/qiskit_experiments/database_service/db_analysis_result.py
@@ -172,7 +172,7 @@ class DbAnalysisResultV1(DbAnalysisResult):
         }
         update_data = {
             "result_id": self.result_id,
-            "data": _result_data,
+            "result_data": _result_data,
             "tags": self.tags(),
             "chisq": self._chisq,
             "quality": self.quality,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
@chriseclectic noticed that the `update_analysis_result` and `create_analysis_result` accept `data` as the input, when `result_data` is used everywhere else. 


### Details and comments


