### PR TITLE
Use stdlib regular expression module instead of regex package

### DIFF
--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Set, Tuple, Union, List, Optional
 import csv
 import dataclasses
 import warnings
-import regex as re
+import re
 
 from qiskit.pulse import (
     ScheduleBlock,


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit changes the usage in the calibrations module to use the
stdlib re module instead of the external regex package. For the usage in
calibrations they behave identically and this avoids needing an
additional external depdency.

### Details and comments

Fixes #228
