### PR TITLE
Allow returning analysis results by name

### DIFF
--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -637,9 +637,19 @@ class DbExperimentDataV1(DbExperimentData):
         if isinstance(index, (int, slice)):
             return self._analysis_results.values()[index]
         if isinstance(index, str):
-            if index not in self._analysis_results:
+            # Check by result ID
+            if index in self._analysis_results:
+                return self._analysis_results[index]
+            # Check by name
+            filtered = [
+                result for result in self._analysis_results.values() if result.name == index
+            ]
+            if not filtered:
                 raise DbExperimentEntryNotFound(f"Analysis result {index} not found.")
-            return self._analysis_results[index]
+            if len(filtered) == 1:
+                return filtered[0]
+            else:
+                return filtered
 
         raise TypeError(f"Invalid index type {type(index)}.")
 

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -620,7 +620,7 @@ class DbExperimentDataV1(DbExperimentData):
                     * None: Return all analysis results.
                     * int: Specific index of the analysis results.
                     * slice: A list slice of indexes.
-                    * str: ID of the analysis result.
+                    * str: ID or name of the analysis result.
             refresh: Retrieve the latest analysis results from the server, if
                 an experiment service is available.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This updates `ExperimentData.analysis_results` so that if the arg is a str it will check for matching result IDs or result names.
- If multiple names match it will return a list of matching results
- if only 1 matches it will return the single result
- if None match it will raise an exception.

### Details and comments

example usage:

```python
data = T2Ramsey(**kwargs).run(backend).block_for_results()
result = data.analysis_results("T2")
```

