### PR TITLE
Change `BaseAnalysis.run` to return ExperimentData

### DIFF
--- a/qiskit_experiments/framework/base_analysis.py
+++ b/qiskit_experiments/framework/base_analysis.py
@@ -72,10 +72,6 @@ class BaseAnalysis(ABC):
                 f" but received {type(experiment_data).__name__}"
             )
 
-        # Check if data already contains analysis, if so make a copy
-        if experiment_data.analysis_results():
-            experiment_data = experiment_data._copy_metadata()
-
         # Get experiment device components
         if "physical_qubits" in experiment_data.metadata():
             experiment_components = [

--- a/qiskit_experiments/framework/base_analysis.py
+++ b/qiskit_experiments/framework/base_analysis.py
@@ -51,29 +51,17 @@ class BaseAnalysis(ABC):
     def run(
         self,
         experiment_data: ExperimentData,
-        save: bool = True,
-        return_figures: bool = False,
         **options,
-    ):
+    ) -> ExperimentData:
         """Run analysis and update ExperimentData with analysis result.
 
         Args:
             experiment_data: the experiment data to analyze.
-            save: if True save analysis results and figures to the
-                  :class:`ExperimentData`.
-            return_figures: if true return a pair of
-                            ``(analysis_results, figures)``,
-                            otherwise return only analysis_results.
             options: additional analysis options. See class documentation for
                      supported options.
 
         Returns:
-            List[DbAnalysisResultV1]: the output for analysis that produces
-                                  multiple results.
-            Tuple: If ``return_figures=True`` the output is a pair
-                   ``(analysis_results, figures)`` where  ``analysis_results``
-                   may be a single or list of :class:`DbAnalysisResultV1` objects, and
-                   ``figures`` may be None, a single figure, or a list of figures.
+            An experiment data object containing the analysis results and figures.
 
         Raises:
             QiskitError: if experiment_data container is not valid for analysis.
@@ -83,6 +71,10 @@ class BaseAnalysis(ABC):
                 f"Invalid experiment data type, expected {self.__experiment_data__.__name__}"
                 f" but received {type(experiment_data).__name__}"
             )
+
+        # Check if data already contains analysis, if so make a copy
+        if experiment_data.analysis_results():
+            experiment_data = experiment_data._copy_metadata()
 
         # Get experiment device components
         if "physical_qubits" in experiment_data.metadata():
@@ -108,16 +100,12 @@ class BaseAnalysis(ABC):
             for result in results
         ]
 
-        # Save to experiment data
-        if save:
-            experiment_data.add_analysis_results(analysis_results)
-            if figures:
-                experiment_data.add_figures(figures)
+        # Update experiment data with analysis results
+        experiment_data.add_analysis_results(analysis_results)
+        if figures:
+            experiment_data.add_figures(figures)
 
-        if return_figures:
-            return analysis_results, figures
-
-        return analysis_results
+        return experiment_data
 
     def _format_analysis_result(self, data, experiment_id, experiment_components=None):
         """Format run analysis result to DbAnalysisResult"""

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -178,7 +178,7 @@ class BaseExperiment(ABC):
                      for the current run.
 
         Returns:
-            The updated experiment data containing the analysis results and figures.
+            An experiment data object containing the analysis results and figures.
 
         Raises:
             QiskitError: if experiment_data container is not valid for analysis.
@@ -190,8 +190,7 @@ class BaseExperiment(ABC):
 
         # Run analysis
         analysis = self.analysis()
-        analysis.run(experiment_data, save=True, return_figures=False, **analysis_options)
-        return experiment_data
+        return analysis.run(experiment_data, **analysis_options)
 
     @property
     def num_qubits(self) -> int:

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -190,7 +190,8 @@ class BaseExperiment(ABC):
 
         # Run analysis
         analysis = self.analysis()
-        return analysis.run(experiment_data, **analysis_options)
+        analysis.run(experiment_data, **analysis_options)
+        return experiment_data
 
     @property
     def num_qubits(self) -> int:

--- a/test/calibration/experiments/test_rabi.py
+++ b/test/calibration/experiments/test_rabi.py
@@ -234,10 +234,10 @@ class TestRabiAnalysis(QiskitTestCase):
 
         data_processor = DataProcessor("counts", [Probability(outcome="1")])
 
-        result = OscillationAnalysis().run(
+        experiment_data = OscillationAnalysis().run(
             experiment_data, data_processor=data_processor, plot=False
         )
-
+        result = experiment_data.analysis_results()
         self.assertEqual(result[0].quality, "good")
         self.assertTrue(abs(result[0].value.value[1] - expected_rate) < test_tol)
 
@@ -252,9 +252,10 @@ class TestRabiAnalysis(QiskitTestCase):
 
         data_processor = DataProcessor("counts", [Probability(outcome="1")])
 
-        result = OscillationAnalysis().run(
+        experiment_data = OscillationAnalysis().run(
             experiment_data, data_processor=data_processor, plot=False
         )
+        result = experiment_data.analysis_results()
 
         self.assertEqual(result[0].quality, "bad")
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This simplifies the signature of the function. It is also the behavior we need if we want to be able to make a new experiment data container for re-run analysis results.

### Details and comments

Now there is also no difference in return from `experiment.run_analysis(data, **options)` and `analysis.run(data, **options)`
