### PR TITLE
Fix qv plot function missing requires matplotlib

### DIFF
--- a/qiskit_experiments/library/quantum_volume/qv_analysis.py
+++ b/qiskit_experiments/library/quantum_volume/qv_analysis.py
@@ -14,12 +14,14 @@ Quantum Volume analysis class.
 """
 
 import math
+
 import warnings
 from typing import Optional
 import numpy as np
 
 from qiskit_experiments.framework import BaseAnalysis, AnalysisResultData, FitVal
 from qiskit_experiments.curve_analysis import plot_scatter, plot_errorbar
+from qiskit_experiments.matplotlib import requires_matplotlib
 
 
 class QuantumVolumeAnalysis(BaseAnalysis):
@@ -229,6 +231,7 @@ class QuantumVolumeAnalysis(BaseAnalysis):
         return hop_result, qv_result
 
     @staticmethod
+    @requires_matplotlib
     def _format_plot(
         hop_result: AnalysisResultData, ax: Optional["matplotlib.pyplot.AxesSubplot"] = None
     ):
@@ -259,6 +262,7 @@ class QuantumVolumeAnalysis(BaseAnalysis):
         )
         # Plot accumulative HOP
         ax.plot(trial_list, hop_accumulative, color="r", label="Cumulative HOP")
+
         # Plot two-sigma shaded area
         ax = plot_errorbar(
             trial_list,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

After #280 the direct call to matplotlib `plot` in the QV plot without the requires_matplotlib decorator seemed to be causing test failures from data race condition of test threads.

### Details and comments


