### PR TITLE
Disable intersphinx for scipy

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,5 +182,7 @@ html_theme_options = {
 }
 
 autoclass_content = 'both'
-intersphinx_mapping = {'matplotlib': ('https://matplotlib.org/stable/', None),
-                       'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None)}
+intersphinx_mapping = {'matplotlib': ('https://matplotlib.org/stable/', None)}
+# Current scipy hosted docs are missing the object.inv file so leaving this
+# commented out until the missing file is added back.
+#                       'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None)}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The recent scipy 1.7.1 release is missing the necessary object index
file for intersphinx to work correctly. To avoid doc build failures
while that's fixed this commit just comments out the scipy intersphinx
configuration. We can add it back when the hosted scipy docs have the
necessary sphinx index file.

### Details and comments


