### PR TITLE
Use latest reno release

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,8 +7,7 @@ qiskit-sphinx-theme>=1.6
 sphinx-autodoc-typehints
 jupyter-sphinx
 pygments>=2.4
-# TODO: Remove after reno 3.3.0 is released
-reno @ git+https://opendev.org/openstack/reno.git
+reno>=3.4.0
 sphinx-panels
 nbsphinx
 arxiv


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #294 we switched to using reno from source to workaround a bug in
reno that required a branch named master to exist for
When #294 was proposed the fix for this issue [1] was not included in
a release. But since #294 has merged a new reno release has been
published [2] and we can instead rely on that version instead of the
installing from source. This commit makes this change and switches
to using reno>=3.4.0 instead of reno from git.

### Details and comments

[1] https://opendev.org/openstack/reno/commit/ed6bbae82e01edf781534d9e9cce21e0c55a49a6
[2] https://pypi.org/project/reno/3.4.0/
