### PR TITLE
Fixes T2* figure upload to resultsdb

### DIFF
--- a/qiskit_experiments/library/characterization/t2ramsey_analysis.py
+++ b/qiskit_experiments/library/characterization/t2ramsey_analysis.py
@@ -95,7 +95,7 @@ class T2RamseyAnalysis(BaseAnalysis):
             ax.tick_params(labelsize=14)
             ax.set_xlabel("Delay (s)", fontsize=12)
             ax.ticklabel_format(axis="x", style="sci", scilimits=(0, 0))
-            ax.set_ylabel("Probability of 0 state", fontsize=12)
+            ax.set_ylabel("Probability of measuring 0", fontsize=12)
             t2ramsey = fit_result["popt"][1] / conversion_factor
             t2_err = fit_result["popt_err"][1] / conversion_factor
             box_text = "$T_2Ramsey$ = {:.2f} \u00B1 {:.2f} {}".format(t2ramsey, t2_err, unit)


### PR DESCRIPTION
Closes #216. For whatever reason, the API doesn't allow `Probability to measure |0>` in the SVG. This is the fix until that problem is resolved.