### PR TITLE
Removing access to private members

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/rb_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_utils.py
@@ -76,7 +76,7 @@ class RBUtils:
         if qubits is None:
             qubits = range(len(circuit.qubits))
         count_ops_result = {}
-        for instr, qargs, _ in circuit._data:
+        for instr, qargs, _ in circuit:
             instr_qubits = []
             skip_instr = False
             for qubit in qargs:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR handles issue #36 as much as possible, since most the of access to private members in the qiskit-experiments code cannot be replaced by using existing getters/setters.


### Details and comments


