### PR TITLE
[WIP] Removed bounds everywhere!

### DIFF
--- a/docs/_ext/custom_styles/example/example_experiment.py
+++ b/docs/_ext/custom_styles/example/example_experiment.py
@@ -62,15 +62,11 @@ class DocumentedCurveAnalysis(CurveAnalysis):
             desc: Description of parameter :math:`a`.
             init_guess: Here you can describe how this analysis estimate initial guess of
                 parameter :math:`a`.
-            bounds: Here you can describe how this analysis bounds parameter :math:`a` value
-                during the fit.
 
         defpar b:
             desc: Description of parameter :math:`b`.
             init_guess: Here you can describe how this analysis estimate initial guess of
                 parameter :math:`b`.
-            bounds: Here you can describe how this analysis bounds parameter :math:`b` value
-                during the fit.
 
         Note that you cannot write text block (i.e. bullet lines, math mode, parsed literal, ...)
         in the ``defpar`` syntax items. These are a single line description of parameters.

--- a/docs/_ext/custom_styles/section_parsers.py
+++ b/docs/_ext/custom_styles/section_parsers.py
@@ -33,7 +33,6 @@ def load_fit_parameters(docstring_lines: List[str]) -> List[str]:
     description_kind = {
         "desc": re.compile(r"desc: (?P<s>.+)"),
         "init_guess": re.compile(r"init_guess: (?P<s>.+)"),
-        "bounds": re.compile(r"bounds: (?P<s>.+)"),
     }
 
     # parse lines
@@ -52,7 +51,6 @@ def load_fit_parameters(docstring_lines: List[str]) -> List[str]:
             parameter_desc[current_param] = {
                 "desc": "",
                 "init_guess": "",
-                "bounds": "",
             }
             continue
 
@@ -85,6 +83,5 @@ def load_fit_parameters(docstring_lines: List[str]) -> List[str]:
 
     write_description("Descriptions", "desc")
     write_description("Initial Guess", "init_guess")
-    write_description("Boundaries", "bounds")
 
     return _trim_empty_lines(section_lines)

--- a/qiskit_experiments/curve_analysis/curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis.py
@@ -310,8 +310,6 @@ class CurveAnalysis(BaseAnalysis, ABC):
             normalization (bool) : Set ``True`` to normalize y values within range [-1, 1].
             p0 (Dict[str, float]): Array-like or dictionary
                 of initial parameters.
-            bounds (Dict[str, Tuple[float, float]]): Array-like or dictionary
-                of (min, max) tuple of fit parameter boundaries.
             x_key (str): Circuit metadata key representing a scanned value.
             plot (bool): Set ``True`` to create figure for fit result.
             axis (AxesSubplot): Optional. A matplotlib axis object to draw.
@@ -332,7 +330,6 @@ class CurveAnalysis(BaseAnalysis, ABC):
             data_processor=None,
             normalization=False,
             p0=None,
-            bounds=None,
             x_key="xval",
             plot=True,
             axis=None,
@@ -473,12 +470,10 @@ class CurveAnalysis(BaseAnalysis, ABC):
 
             if self._get_option("my_option1") == "abc":
                 p0 = my_guess_function(curve_data.x, curve_data.y, ...)
-                bounds = ...
             else:
                 p0 = ...
-                bounds = ...
 
-            return {"p0": p0, "bounds": bounds}
+            return {"p0": p0}
 
         Note that this subroutine can generate multiple fit options.
         If multiple options are provided, fitter runs multiple times for each fit option,
@@ -486,8 +481,8 @@ class CurveAnalysis(BaseAnalysis, ABC):
 
         .. code-block::
 
-            fit_1 = {"p0": p0_1, "bounds": bounds, "extra_fit_parameter": "option1"}
-            fit_2 = {"p0": p0_2, "bounds": bounds, "extra_fit_parameter": "option2"}
+            fit_1 = {"p0": p0_1, "extra_fit_parameter": "option1"}
+            fit_2 = {"p0": p0_2, "extra_fit_parameter": "option2"}
 
             return [fit_1, fit_2]
 
@@ -502,7 +497,7 @@ class CurveAnalysis(BaseAnalysis, ABC):
         Returns:
             List of FitOptions that are passed to fitter function.
         """
-        fit_options = {"p0": self._get_option("p0"), "bounds": self._get_option("bounds")}
+        fit_options = {"p0": self._get_option("p0")}
         fit_options.update(options)
 
         return fit_options
@@ -708,15 +703,6 @@ class CurveAnalysis(BaseAnalysis, ABC):
         else:
             # p0 should be defined
             raise AnalysisError("Initial guess p0 is not provided to the fitting options.")
-
-        if fitter_options.get("bounds", None):
-            if isinstance(fitter_options["bounds"], dict):
-                _check_keys("bounds")
-            else:
-                fitter_options["bounds"] = _dictionarize("bounds")
-        else:
-            # bounds are optional
-            fitter_options["bounds"] = {par: (-np.inf, np.inf) for par in self.__fit_params}
 
         return fitter_options
 
@@ -1023,8 +1009,8 @@ class CurveAnalysis(BaseAnalysis, ABC):
                     fit_results.append(fit_result)
                 if len(fit_results) == 0:
                     raise AnalysisError(
-                        "All initial guesses and parameter boundaries failed to fit the data. "
-                        "Please provide better initial guesses or fit parameter boundaries."
+                        "All initial guesses failed to fit the data. "
+                        "Please provide better initial guesses."
                     )
                 # Sort by chi squared value
                 fit_result = sorted(fit_results, key=lambda r: r.reduced_chisq)[0]

--- a/qiskit_experiments/library/calibration/analysis/drag_analysis.py
+++ b/qiskit_experiments/library/calibration/analysis/drag_analysis.py
@@ -37,22 +37,18 @@ class DragCalAnalysis(curve.CurveAnalysis):
         defpar \rm amp:
             desc: Amplitude of all series.
             init_guess: The maximum y value less the minimum y value. 0.5 is also tried.
-            bounds: [-2, 2] scaled to the maximum signal value.
 
         defpar \rm base:
             desc: Base line of all series.
             init_guess: The average of the data. 0.5 is also tried.
-            bounds: [-1, 1] scaled to the maximum signal value.
 
         defpar {\rm freq}_i:
             desc: Frequency of the :math:`i` th oscillation.
             init_guess: The frequency with the highest power spectral density.
-            bounds: [0, inf].
 
         defpar \beta:
             desc: Common beta offset. This is the parameter of interest.
             init_guess: Linearly spaced between the maximum and minimum scanned beta.
-            bounds: [-min scan range, max scan range].
     """
 
     __series__ = [
@@ -101,14 +97,6 @@ class DragCalAnalysis(curve.CurveAnalysis):
             "beta": None,
             "base": None,
         }
-        default_options.bounds = {
-            "amp": None,
-            "freq0": None,
-            "freq1": None,
-            "freq2": None,
-            "beta": None,
-            "base": None,
-        }
         default_options.result_parameters = ["beta"]
         default_options.xlabel = "Beta"
         default_options.ylabel = "Signal (arb. units)"
@@ -118,7 +106,6 @@ class DragCalAnalysis(curve.CurveAnalysis):
     def _setup_fitting(self, **options) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """Compute the initial guesses."""
         user_p0 = self._get_option("p0")
-        user_bounds = self._get_option("bounds")
 
         # Use a fast Fourier transform to guess the frequency.
         x_data = self._data("series-0").x
@@ -165,14 +152,6 @@ class DragCalAnalysis(curve.CurveAnalysis):
                         "freq2": user_p0.get("freq2", None) or freq_guess[2],
                         "beta": p_guess,
                         "base": b_guess,
-                    },
-                    "bounds": {
-                        "amp": user_bounds.get("amp", None) or (-2 * max_abs_y, 2 * max_abs_y),
-                        "freq0": user_bounds.get("freq0", None) or (0, np.inf),
-                        "freq1": user_bounds.get("freq1", None) or (0, np.inf),
-                        "freq2": user_bounds.get("freq2", None) or (0, np.inf),
-                        "beta": user_bounds.get("beta", None) or (-freq_bound, freq_bound),
-                        "base": user_bounds.get("base", None) or (-1 * max_abs_y, 1 * max_abs_y),
                     },
                 }
 

--- a/qiskit_experiments/library/calibration/analysis/fine_amplitude_analysis.py
+++ b/qiskit_experiments/library/calibration/analysis/fine_amplitude_analysis.py
@@ -38,18 +38,15 @@ class FineAmplitudeAnalysis(curve.CurveAnalysis):
         defpar \rm amp:
             desc: Amplitude of the oscillation.
             init_guess: The maximum y value less the minimum y value.
-            bounds: [-2, 2] scaled to the maximum signal value.
 
         defpar \rm base:
             desc: Base line.
             init_guess: The average of the data.
-            bounds: [-1, 1] scaled to the maximum signal value.
 
         defpar d\theta:
             desc: The angle offset in the gate that we wish to measure.
             init_guess: Multiple initial guesses are tried ranging from -a to a
                 where a is given by :code:`max(abs(angle_per_gate), np.pi / 2)`.
-            bounds: [-pi, pi].
 
     # section: note
 
@@ -97,7 +94,6 @@ class FineAmplitudeAnalysis(curve.CurveAnalysis):
         """
         default_options = super()._default_options()
         default_options.p0 = {"amp": None, "d_theta": None, "phase": None, "base": None}
-        default_options.bounds = {"amp": None, "d_theta": None, "phase": None, "base": None}
         default_options.result_parameters = ["d_theta"]
         default_options.xlabel = "Number of gates (n)"
         default_options.ylabel = "Population"
@@ -111,14 +107,11 @@ class FineAmplitudeAnalysis(curve.CurveAnalysis):
     def _setup_fitting(self, **options) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """Fitter options."""
         user_p0 = self._get_option("p0")
-        user_bounds = self._get_option("bounds")
         n_guesses = self._get_option("number_guesses")
 
         max_y, min_y = np.max(self._data().y), np.min(self._data().y)
         b_guess = (max_y + min_y) / 2
         a_guess = max_y - min_y
-
-        max_abs_y = np.max(np.abs(self._data().y))
 
         # Base the initial guess on the intended angle_per_gate.
         angle_per_gate = self._get_option("angle_per_gate")
@@ -136,11 +129,6 @@ class FineAmplitudeAnalysis(curve.CurveAnalysis):
                     "amp": user_p0["amp"] or a_guess,
                     "d_theta": angle,
                     "base": b_guess,
-                },
-                "bounds": {
-                    "amp": user_bounds.get("amp", None) or (-2 * max_abs_y, 2 * max_abs_y),
-                    "d_theta": user_bounds.get("d_theta", None) or (-np.pi, np.pi),
-                    "base": user_bounds.get("d_theta", None) or (-1 * max_abs_y, 1 * max_abs_y),
                 },
             }
 

--- a/qiskit_experiments/library/calibration/analysis/oscillation_analysis.py
+++ b/qiskit_experiments/library/calibration/analysis/oscillation_analysis.py
@@ -33,24 +33,20 @@ class OscillationAnalysis(curve.CurveAnalysis):
         defpar \rm amp:
             desc: Amplitude of the oscillation.
             init_guess: Calculated by :func:`~qiskit_experiments.curve_analysis.guess.max_height`.
-            bounds: [-2, 2] scaled to the maximum signal value.
 
         defpar \rm base:
             desc: Base line.
             init_guess: Calculated by :func:`~qiskit_experiments.curve_analysis.\
             guess.constant_sinusoidal_offset`.
-            bounds: [-1, 1] scaled to the maximum signal value.
 
         defpar \rm freq:
             desc: Frequency of the oscillation. This is the fit parameter of interest.
             init_guess: Calculated by :func:`~qiskit_experiments.curve_analysis.\
             guess.frequency`.
-            bounds: [0, inf].
 
         defpar \rm phase:
             desc: Phase of the oscillation.
             init_guess: Zero.
-            bounds: [-pi, pi].
     """
 
     __series__ = [
@@ -71,7 +67,6 @@ class OscillationAnalysis(curve.CurveAnalysis):
         """
         default_options = super()._default_options()
         default_options.p0 = {"amp": None, "freq": None, "phase": None, "base": None}
-        default_options.bounds = {"amp": None, "freq": None, "phase": None, "base": None}
         default_options.result_parameters = ["freq"]
         default_options.xlabel = "Amplitude"
         default_options.ylabel = "Signal (arb. units)"
@@ -81,11 +76,8 @@ class OscillationAnalysis(curve.CurveAnalysis):
     def _setup_fitting(self, **options) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """Fitter options."""
         user_p0 = self._get_option("p0")
-        user_bounds = self._get_option("bounds")
 
         curve_data = self._data()
-
-        max_abs_y = np.max(np.abs(curve_data.y))
 
         f_guess = curve.guess.frequency(curve_data.x, curve_data.y)
         b_guess = curve.guess.constant_sinusoidal_offset(curve_data.y)
@@ -104,12 +96,6 @@ class OscillationAnalysis(curve.CurveAnalysis):
                     "freq": user_p0["freq"] or f_guess,
                     "phase": p_guess,
                     "base": user_p0["base"] or b_guess,
-                },
-                "bounds": {
-                    "amp": user_bounds["amp"] or (-2 * max_abs_y, 2 * max_abs_y),
-                    "freq": user_bounds["freq"] or (0, np.inf),
-                    "phase": user_bounds["phase"] or (-np.pi, np.pi),
-                    "base": user_bounds["base"] or (-1 * max_abs_y, 1 * max_abs_y),
                 },
             }
             fit_option.update(options)

--- a/qiskit_experiments/library/characterization/resonance_analysis.py
+++ b/qiskit_experiments/library/characterization/resonance_analysis.py
@@ -46,14 +46,6 @@ class ResonanceAnalysis(curve.CurveAnalysis):
         - :math:`\sigma`: Calculated from FWHM of peak :math:`w`
           such that :math:`w / \sqrt{8} \ln{2}`, where FWHM is calculated by
           :func:`~qiskit_experiments.curve_analysis.guess.full_width_half_max`.
-
-    Bounds
-        - :math:`a`: [-2, 2] scaled with maximum signal value.
-        - :math:`b`: [-1, 1] scaled with maximum signal value.
-        - :math:`f`: [min(x), max(x)] of frequency scan range.
-        - :math:`\sigma`: [0, :math:`\Delta x`] where :math:`\Delta x`
-          represents frequency scan range.
-
     """
 
     __series__ = [
@@ -74,7 +66,6 @@ class ResonanceAnalysis(curve.CurveAnalysis):
         """
         default_options = super()._default_options()
         default_options.p0 = {"a": None, "sigma": None, "freq": None, "b": None}
-        default_options.bounds = {"a": None, "sigma": None, "freq": None, "b": None}
         default_options.reporting_parameters = {"freq": ("frequency", "Hz")}
         default_options.normalization = True
 
@@ -83,7 +74,6 @@ class ResonanceAnalysis(curve.CurveAnalysis):
     def _setup_fitting(self, **options) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """Fitter options."""
         user_p0 = self._get_option("p0")
-        user_bounds = self._get_option("bounds")
 
         curve_data = self._data()
 
@@ -97,20 +87,12 @@ class ResonanceAnalysis(curve.CurveAnalysis):
             8 * np.log(2)
         )
 
-        max_abs_y = np.max(np.abs(curve_data.y))
-
         fit_option = {
             "p0": {
                 "a": user_p0["a"] or a_guess,
                 "sigma": user_p0["sigma"] or s_guess,
                 "freq": user_p0["freq"] or f_guess,
                 "b": user_p0["b"] or b_guess,
-            },
-            "bounds": {
-                "a": user_bounds["a"] or (-2 * max_abs_y, 2 * max_abs_y),
-                "sigma": user_bounds["sigma"] or (0.0, max(curve_data.x) - min(curve_data.x)),
-                "freq": user_bounds["freq"] or (min(curve_data.x), max(curve_data.x)),
-                "b": user_bounds["b"] or (-max_abs_y, max_abs_y),
             },
         }
         fit_option.update(options)

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -56,7 +56,6 @@ class T2Ramsey(BaseExperiment):
 
         - **user_p0** (``List[Float]``): user guesses for the fit parameters
           ``A``, ``B``, ``f``, ``phi``, ``T2star``.
-        - **bounds** - (Tuple[List[float], List[float]]) lower and upper bounds for the fit parameters.
         - **plot** (bool) - create a graph if and only if True.
 
     """

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
@@ -70,22 +70,18 @@ class InterleavedRBAnalysis(RBAnalysis):
         defpar a:
             desc: Height of decay curve.
             init_guess: Determined by the average :math:`a` of the standard and interleaved RB.
-            bounds: [0, 1]
         defpar b:
             desc: Base line.
             init_guess: Determined by the average :math:`b` of the standard and interleaved RB.
                 Usually equivalent to :math:`(1/2)^n` where :math:`n` is number of qubit.
-            bounds: [0, 1]
         defpar \alpha:
             desc: Depolarizing parameter.
             init_guess: Determined by the slope of :math:`(y - b)^{-x}` of the first and the
                 second data point of the standard RB.
-            bounds: [0, 1]
         defpar \alpha_c:
             desc: Ratio of the depolarizing parameter of interleaved RB to standard RB curve.
             init_guess: Estimate :math:`\alpha' = \alpha_c \alpha` from the
                 interleaved RB curve, then divide this by the initial guess of :math:`\alpha`.
-            bounds: [0, 1]
 
     # section: reference
         .. ref_arxiv:: 1 1203.4550
@@ -120,19 +116,12 @@ class InterleavedRBAnalysis(RBAnalysis):
         """Default analysis options."""
         default_options = super()._default_options()
         default_options.p0 = {"a": None, "alpha": None, "alpha_c": None, "b": None}
-        default_options.bounds = {
-            "a": (0.0, 1.0),
-            "alpha": (0.0, 1.0),
-            "alpha_c": (0.0, 1.0),
-            "b": (0.0, 1.0),
-        }
         default_options.result_parameters = ["alpha", "alpha_c"]
         return default_options
 
     def _setup_fitting(self, **options) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """Fitter options."""
         user_p0 = self._get_option("p0")
-        user_bounds = self._get_option("bounds")
 
         # for standard RB curve
         std_curve = self._data(series_name="Standard")
@@ -148,12 +137,6 @@ class InterleavedRBAnalysis(RBAnalysis):
                 "alpha": user_p0["alpha"] or p0_std["alpha"],
                 "alpha_c": user_p0["alpha_c"] or min(p0_int["alpha"] / p0_std["alpha"], 1),
                 "b": user_p0["b"] or np.mean([p0_std["b"], p0_int["b"]]),
-            },
-            "bounds": {
-                "a": user_bounds["a"] or (0.0, 1.0),
-                "alpha": user_bounds["alpha"] or (0.0, 1.0),
-                "alpha_c": user_bounds["alpha_c"] or (0.0, 1.0),
-                "b": user_bounds["b"] or (0.0, 1.0),
             },
         }
         fit_option.update(options)

--- a/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
@@ -41,18 +41,14 @@ class RBAnalysis(curve.CurveAnalysis):
         defpar a:
             desc: Height of decay curve.
             init_guess: Determined by :math:`(y - b) / \alpha^x`.
-            bounds: [0, 1]
         defpar b:
             desc: Base line.
             init_guess: Determined by the average :math:`b` of the standard and interleaved RB.
                 Usually equivalent to :math:`(1/2)^n` where :math:`n` is number of qubit.
-            bounds: [0, 1]
         defpar \alpha:
             desc: Depolarizing parameter.
             init_guess: Determined by the slope of :math:`(y - b)^{-x}` of the first and the
                 second data point.
-            bounds: [0, 1]
-
     """
 
     __series__ = [
@@ -82,7 +78,6 @@ class RBAnalysis(curve.CurveAnalysis):
         """
         default_options = super()._default_options()
         default_options.p0 = {"a": None, "alpha": None, "b": None}
-        default_options.bounds = {"a": (0.0, 1.0), "alpha": (0.0, 1.0), "b": (0.0, 1.0)}
         default_options.xlabel = "Clifford Length"
         default_options.ylabel = "P(0)"
         default_options.result_parameters = ["alpha"]
@@ -95,7 +90,6 @@ class RBAnalysis(curve.CurveAnalysis):
     def _setup_fitting(self, **options) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """Fitter options."""
         user_p0 = self._get_option("p0")
-        user_bounds = self._get_option("bounds")
 
         curve_data = self._data()
         initial_guess = self._initial_guess(curve_data.x, curve_data.y, self._num_qubits)
@@ -104,11 +98,6 @@ class RBAnalysis(curve.CurveAnalysis):
                 "a": user_p0["a"] or initial_guess["a"],
                 "alpha": user_p0["alpha"] or initial_guess["alpha"],
                 "b": user_p0["b"] or initial_guess["b"],
-            },
-            "bounds": {
-                "a": user_bounds["a"] or (0.0, 1.0),
-                "alpha": user_bounds["alpha"] or (0.0, 1.0),
-                "b": user_bounds["b"] or (0.0, 1.0),
             },
         }
         fit_option.update(options)

--- a/test/curve_analysis/test_curve_fit.py
+++ b/test/curve_analysis/test_curve_fit.py
@@ -246,14 +246,12 @@ class TestCurveAnalysisUnit(QiskitTestCase):
         """Test option formatter."""
         test_options = {
             "p0": [0, 1, 2, 3, 4],
-            "bounds": [(-1, 1), (-2, 2), (-3, 3), (-4, 4), (-5, 5)],
             "other_value": "test",
         }
         formatted_options = self.analysis._format_fit_options(**test_options)
 
         ref_options = {
             "p0": {"p0": 0, "p1": 1, "p2": 2, "p3": 3, "p4": 4},
-            "bounds": {"p0": (-1, 1), "p1": (-2, 2), "p2": (-3, 3), "p3": (-4, 4), "p4": (-5, 5)},
             "other_value": "test",
         }
         self.assertDictEqual(formatted_options, ref_options)
@@ -339,7 +337,6 @@ class TestCurveAnalysisIntegration(QiskitTestCase):
         )
         default_opts = analysis._default_options()
         default_opts.p0 = {"p0": ref_p0, "p1": ref_p1, "p2": ref_p2, "p3": ref_p3}
-        default_opts.bounds = {"p0": [-10, 0], "p1": [-10, 0], "p2": [-10, 0], "p3": [-10, 0]}
         default_opts.return_data_points = True
 
         # Try to fit with infeasible parameter boundary. This should fail.

--- a/test/curve_analysis/test_curve_fitting.py
+++ b/test/curve_analysis/test_curve_fitting.py
@@ -89,8 +89,7 @@ class TestCurveFitting(QiskitTestCase):
         data = self.simulate_experiment_data(thetas)
         xdata, ydata, sigma = process_curve_data(data, data_processor=self.data_processor_p0)
         p0 = [0.6]
-        bounds = ([0], [2])
-        sol = curve_fit(self.objective0, xdata, ydata, p0, sigma=sigma, bounds=bounds)
+        sol = curve_fit(self.objective0, xdata, ydata, p0, sigma=sigma)
         self.assertTrue(abs(sol.popt[0] - 0.5) < 0.05)
 
     def test_multi_curve_fit(self):
@@ -107,9 +106,8 @@ class TestCurveFitting(QiskitTestCase):
         sigma = np.concatenate([sigma0, sigma1])
 
         p0 = [0.6]
-        bounds = ([0], [2])
         sol = multi_curve_fit(
-            [self.objective0, self.objective1], series, xdata, ydata, p0, sigma=sigma, bounds=bounds
+            [self.objective0, self.objective1], series, xdata, ydata, p0, sigma=sigma
         )
         self.assertTrue(abs(sol.popt[0] - 0.5) < 0.05)
 


### PR DESCRIPTION
### Summary

In #190 it was suggested to remove `bounds` from all over the code. We haven't decided whether it's a good idea, and until now it's been done only for T1. I've decided to promote the topic by creating this PR, where `bounds` is aggressively removed from all the experiments, without checking the consequences.

### Details and comments

Things that remain to be done (I'll need help from experiment owners for some of them):
- [ ] Handle the 8 failing tests (details below).
- [ ] Update the tutorials: The only tutorial that's directly using the `bounds` parameter is RB. The other tutorials need to rerun as well because there can be small changes in results, but I don't expect issues.
- [ ] Run Sphinx - expected to work without issues.

More details about the failing tests:
- RB tests fail because of the caching - need to regenerate the data.
- `test_run_single_curve_fail` (in `test_curve_fit.py`) verifies correct reaction when fit fails by fitting with infeasible boundaries. Another way of failing the fit is now required.
- Some calibration tests fail, I don't know why.