### PR TITLE
Temporarily remove Windows from GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macOS-latest"]
     steps:
       - name: Print Concurrency Group
         env:


### PR DESCRIPTION
### Summary

Recently we've been experiencing issues with Windows (#292). Until we solve them, *and only until then*, this PR removes Windows from the GitHub workflow.


