### PR TITLE
Check analysis result index and include experiment data error

### DIFF
--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -633,8 +633,19 @@ class DbExperimentDataV1(DbExperimentData):
         self._retrieve_analysis_results(refresh=refresh)
         if index is None:
             return self._analysis_results.values()
-        if isinstance(index, (int, slice)):
+        if isinstance(index, int):
+            if index >= len(self._analysis_results.values()):
+                raise DbExperimentEntryNotFound(
+                    f"Analysis result {index} not found. " f"Errors: {self.errors()}"
+                )
             return self._analysis_results.values()[index]
+        if isinstance(index, slice):
+            results = self._analysis_results.values()[index]
+            if not results:
+                raise DbExperimentEntryNotFound(
+                    f"Analysis result {index} not found. " f"Errors: {self.errors()}"
+                )
+            return results
         if isinstance(index, str):
             # Check by result ID
             if index in self._analysis_results:
@@ -644,7 +655,9 @@ class DbExperimentDataV1(DbExperimentData):
                 result for result in self._analysis_results.values() if result.name == index
             ]
             if not filtered:
-                raise DbExperimentEntryNotFound(f"Analysis result {index} not found.")
+                raise DbExperimentEntryNotFound(
+                    f"Analysis result {index} not found. " f"Errors: {self.errors()}"
+                )
             if len(filtered) == 1:
                 return filtered[0]
             else:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR checks whether `index` is out of range, or if no analysis results are found when `DbExperimentDataV1.analysis_results()` is called. If so, it raises an exception and include any previously found errors in the exception message.

### Details and comments


