### PR TITLE
More flexible execution

### DIFF
--- a/qiskit_experiments/framework/events/__init__.py
+++ b/qiskit_experiments/framework/events/__init__.py
@@ -1,0 +1,17 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Event hooks to run experiment.
+"""
+
+from .runner import ExperimentRunner

--- a/qiskit_experiments/framework/events/events_execute.py
+++ b/qiskit_experiments/framework/events/events_execute.py
@@ -1,0 +1,29 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Execute events.
+"""
+
+from qiskit import assemble
+from qiskit.providers.basebackend import BaseBackend as LegacyBackend
+
+
+def backend_run(experiment, backend, circuits, run_options, **kwargs):
+
+    if isinstance(backend, LegacyBackend):
+        qobj = assemble(circuits, backend=backend, **run_options)
+        job = backend.run(qobj)
+    else:
+        job = backend.run(circuits, **run_options)
+
+    return {"job": job}

--- a/qiskit_experiments/framework/events/events_postprocess.py
+++ b/qiskit_experiments/framework/events/events_postprocess.py
@@ -1,0 +1,47 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Post processing events.
+"""
+
+import copy
+
+
+def set_analysis(experiment, analysis, job, experiment_data, **kwargs):
+
+    if analysis and experiment.__analysis_class__ is not None:
+        run_analysis_callback = experiment.run_analysis
+    else:
+        run_analysis_callback = None
+
+    experiment_data.add_data(job, post_processing_callback=run_analysis_callback)
+
+
+def add_job_metadata(experiment, experiment_data, job, run_options, **kwargs):
+    """Add runtime job metadata to ExperimentData.
+
+    Args:
+        experiment: Experiment object.
+        experiment_data: The experiment data container.
+        job: The job object.
+        run_options: Backend run options for the job.
+    """
+    metadata = {
+        "job_id": job.job_id(),
+        "experiment_options": copy.copy(experiment.experiment_options.__dict__),
+        "transpile_options": copy.copy(experiment.transpile_options.__dict__),
+        "analysis_options": copy.copy(experiment.analysis_options.__dict__),
+        "run_options": copy.copy(run_options)
+    }
+
+    experiment_data._metadata["job_metadata"].append(metadata)

--- a/qiskit_experiments/framework/events/events_preprocessing.py
+++ b/qiskit_experiments/framework/events/events_preprocessing.py
@@ -1,0 +1,44 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Pre processing events.
+"""
+import copy
+
+from qiskit_experiments.framework import ExperimentData
+from qiskit.exceptions import QiskitError
+
+
+def initialize_experiment_data(experiment, backend, expeirment_data, **kwargs):
+    if expeirment_data is not None:
+        init_data = experiment.__experiment_data__(experiment=experiment, backend=backend)
+    else:
+        # Validate experiment is compatible with existing data
+        if not isinstance(expeirment_data, ExperimentData):
+            raise QiskitError("Input `experiment_data` is not a valid ExperimentData.")
+        if expeirment_data.experiment_type != experiment.experiment_type:
+            raise QiskitError("Existing ExperimentData contains data from a different experiment.")
+        if expeirment_data.metadata.get("physical_qubits") != list(experiment.physical_qubits):
+            raise QiskitError(
+                "Existing ExperimentData contains data for a different set of physical qubits."
+            )
+        init_data = expeirment_data._copy_metadata()
+
+    return {"expeirment_data": init_data}
+
+
+def update_run_options(experiment, run_options, **kwargs):
+    options = copy.copy(experiment.run_options).__dict__
+    options.update(**run_options)
+
+    return {"run_options": options}

--- a/qiskit_experiments/framework/events/events_transpiler.py
+++ b/qiskit_experiments/framework/events/events_transpiler.py
@@ -1,0 +1,82 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Transpile events.
+"""
+
+import copy
+
+from qiskit import transpile
+from qiskit.test.mock import FakeBackend
+
+from qiskit_experiments.framework import ParallelExperiment
+
+
+def count_transpiled_ops(experiment, circuits, **kwargs):
+
+    def get_metadata(circuit):
+        if circuit.metadata["experiment_type"] == experiment.experiment_type:
+            return circuit.metadata
+        if circuit.metadata["experiment_type"] == ParallelExperiment.__name__:
+            for meta in circuit.metadata["composite_metadata"]:
+                if meta["physical_qubits"] == experiment.physical_qubits:
+                    return meta
+        return dict()
+
+    for circ in circuits:
+        meta = get_metadata(circ)
+        if meta:
+            qubits = range(len(circ.qubits))
+            c_count_ops = {}
+            for instr, qargs, _ in circ:
+                instr_qubits = []
+                skip_instr = False
+                for qubit in qargs:
+                    qubit_index = circ.qubits.index(qubit)
+                    if qubit_index not in qubits:
+                        skip_instr = True
+                    instr_qubits.append(qubit_index)
+                if not skip_instr:
+                    instr_qubits = tuple(instr_qubits)
+                    c_count_ops[(instr_qubits, instr.name)] = (
+                            c_count_ops.get((instr_qubits, instr.name), 0) + 1
+                    )
+            circuit_length = meta["xval"]
+            count_ops = [(key, (value, circuit_length)) for key, value in c_count_ops.items()]
+            meta.update({"count_ops": count_ops})
+
+
+def set_scheduling_contraints(expeirment, backend, **kwargs):
+    if not backend.configuration().simulator and not isinstance(backend, FakeBackend):
+        timing_constraints = getattr(
+            expeirment.transpile_options.__dict__,
+            "timing_constraints",
+            {}
+        )
+        timing_constraints["acquire_alignment"] = getattr(
+            timing_constraints, "acquire_alignment", 16
+        )
+        scheduling_method = getattr(
+            expeirment.transpile_options.__dict__, "scheduling_method", "alap"
+        )
+        expeirment.set_transpile_options(
+            timing_constraints=timing_constraints, scheduling_method=scheduling_method
+        )
+
+
+def transpile_circuits(experiment, backend, **kwargs):
+    options = copy.copy(experiment.transpile_options.__dict__)
+    options["initial_layout"] = list(experiment.physical_qubits)
+    circuits = transpile(experiment.circuits(backend), backend, **options)
+
+    return {"circuits": circuits}

--- a/qiskit_experiments/framework/events/runner.py
+++ b/qiskit_experiments/framework/events/runner.py
@@ -1,0 +1,71 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+EventHook for experiment runner.
+"""
+
+import importlib
+
+from qiskit.exceptions import QiskitError
+from qiskit_experiments.framework.experiment_data import ExperimentData
+
+
+class ExperimentRunner:
+    """Event handler of the experiment run."""
+
+    def __init__(self, experiment: "BaseExperiment"):
+        """Create new runner.
+
+        Args:
+            experiment: Associated experiment instance.
+        """
+        self.__experiment = experiment
+
+        self.__handlers = list()
+        self.__scope_vars = dict()
+
+    def add_handler(self, handler: str, module: str):
+        """Add new event handler.
+
+        Args:
+            handler: Name of event handler.
+            module: Name of event module.
+        """
+        try:
+            callback = importlib.import_module(f"{module}.{handler}")
+            self.__handlers.append(callback)
+        except ModuleNotFoundError:
+            QiskitError(f"Event handler {module}.{handler} is not found.")
+
+    def run(self, **kwargs) -> ExperimentData:
+        """Run experiment.
+
+        Args:
+            kwargs: User provided runtime options.
+
+        Returns:
+            Experiment data.
+        """
+        self.__scope_vars.update(**kwargs)
+
+        for handler in self.__handlers:
+            scope_args = handler(self.__experiment, **self.__scope_vars)
+            if scope_args:
+                self.__scope_vars.update(scope_args)
+
+        # return experiment data
+        try:
+            return self.__scope_vars["experiment_data"]
+        except KeyError:
+            # TODO no logger
+            raise QiskitError("Experiment result data is not generated. Check log.")

--- a/qiskit_experiments/library/characterization/t1.py
+++ b/qiskit_experiments/library/characterization/t1.py
@@ -46,6 +46,9 @@ class T1(BaseExperiment):
 
     __analysis_class__ = T1Analysis
 
+    # update transpile events
+    __transpile_events__ = ["set_scheduling_contraints", "transpile_circuits"]
+
     @classmethod
     def _default_experiment_options(cls) -> Options:
         """Default experiment options.

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -63,6 +63,9 @@ class T2Ramsey(BaseExperiment):
     """
     __analysis_class__ = T2RamseyAnalysis
 
+    # update transpile events
+    __transpile_events__ = ["set_scheduling_contraints", "transpile_circuits"]
+
     @classmethod
     def _default_experiment_options(cls) -> Options:
         """Default experiment options.

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -59,6 +59,9 @@ class StandardRB(BaseExperiment):
     # Analysis class for experiment
     __analysis_class__ = RBAnalysis
 
+    # Update transpile hook
+    __transpile_events__ = ["transpile_circuits", "count_transpiled_ops"]
+
     def __init__(
         self,
         qubits: Union[int, Iterable[int]],
@@ -219,13 +222,3 @@ class StandardRB(BaseExperiment):
                 if meta["physical_qubits"] == self.physical_qubits:
                     return meta
         return None
-
-    def _postprocess_transpiled_circuits(self, circuits, backend, **run_options):
-        """Additional post-processing of transpiled circuits before running on backend"""
-        for c in circuits:
-            meta = self._get_circuit_metadata(c)
-            if meta is not None:
-                c_count_ops = RBUtils.count_ops(c, self.physical_qubits)
-                circuit_length = meta["xval"]
-                count_ops = [(key, (value, circuit_length)) for key, value in c_count_ops.items()]
-                meta.update({"count_ops": count_ops})

--- a/qiskit_experiments/library/randomized_benchmarking/rb_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_utils.py
@@ -60,38 +60,6 @@ class RBUtils:
         return error_dict
 
     @staticmethod
-    def count_ops(
-        circuit: QuantumCircuit, qubits: Optional[Iterable[int]] = None
-    ) -> Dict[Tuple[Iterable[int], str], int]:
-        """Counts occurrences of each gate in the given circuit
-
-        Args:
-            circuit: The quantum circuit whose gates are counted
-            qubits: A list of qubits to filter irrelevant gates
-
-        Returns:
-            A dictionary of the form (qubits, gate) -> value where value
-            is the number of occurrences of the gate on the given qubits
-        """
-        if qubits is None:
-            qubits = range(len(circuit.qubits))
-        count_ops_result = {}
-        for instr, qargs, _ in circuit:
-            instr_qubits = []
-            skip_instr = False
-            for qubit in qargs:
-                qubit_index = circuit.qubits.index(qubit)
-                if qubit_index not in qubits:
-                    skip_instr = True
-                instr_qubits.append(qubit_index)
-            if not skip_instr:
-                instr_qubits = tuple(instr_qubits)
-                count_ops_result[(instr_qubits, instr.name)] = (
-                    count_ops_result.get((instr_qubits, instr.name), 0) + 1
-                )
-        return count_ops_result
-
-    @staticmethod
     def gates_per_clifford(
         ops_count: List,
     ) -> Dict[Tuple[Iterable[int], str], float]:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR adds more flexible execution chain for experiment run.

close https://github.com/Qiskit/qiskit-experiments/issues/151

### Details and comments

Execution chain of experiment can slightly differ per each experiment and it seems to be difficult to implement the perfect base class logic for every experiments.

For example:

- Currently scheduling constraints (alignment) is set for all experiments. However, this is not necessary for experiments that has no intentional delay instruction. This constraint inserts extra hook to transpiler, and slightly degrade the performance. Thus only T1 and similar experiment should have this configuration.
- `_postprocess_transpiled_circuits` is only used by RB to count circuit operations and indeed this method name is too broad context. For example, if we want to implement an experiment that needs count with other feature (that is not RB subclass), we cannot reuse the counting code.
- #251 calibration experiment needs extra hook to update calibrations object.

In this PR, execution chain is divided into each single piece of processing, and developer can combine them to create a full chain. Each processing step (pre-process/transpile/execution/post-process) is stored in the class attribute as a list of function names for serialization.