### PR TITLE
[WIP] PR for saving and loading composite experiments

### DIFF
--- a/qiskit_experiments/framework/composite/composite_experiment_data.py
+++ b/qiskit_experiments/framework/composite/composite_experiment_data.py
@@ -50,6 +50,8 @@ class CompositeExperimentData(ExperimentData):
         self._components = [
             expr.__experiment_data__(expr, backend, job_ids) for expr in experiment._experiments
         ]
+        for comp in self._components:
+            comp.tags.extend(self.tags)
 
     def __str__(self):
         line = 51 * "-"

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -47,6 +47,7 @@ class ExperimentData(DbExperimentDataV1):
             job_ids=job_ids,
             metadata=experiment._metadata() if experiment else {},
         )
+        self.tags = [self.experiment_id]
 
     @property
     def experiment(self):


### PR DESCRIPTION
### Summary

Closes #318.

Steps:
- [x] Use tagging to signal relations.
- [ ] Write overridden `CompositeExperimentData` methods `save` and `load`.
- [ ] Tests.

### Details and comments

#318 says:
> When saving, the parent experiment and sub-experiments should all be tagged with the experiment ID of the parent.

I did it a little differently:
- The tags are updated during the construction of the composite experiment data object, and not when saving. I prefer this way because the tags are properties of the experiment data, independent of whether we've saved it or not.
- It's probable that the UI solution will want to know not only the direct parent, but the entire line of ancestors up to the root. This information is therefore contained in the tags.
- For consistency, non-composite experiments are also tagged with their ids.