### PR TITLE
Catching the "Adding job from different backend" warning

### DIFF
--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -554,7 +554,9 @@ class TestDbExperimentData(QiskitTestCase):
         job2.status.return_value = JobStatus.ERROR
 
         exp_data = DbExperimentData(experiment_type="qiskit_test")
-        exp_data.add_data([job1, job2])
+        with self.assertLogs(logger="qiskit_experiments.database_service", level="WARN") as cm:
+            exp_data.add_data([job1, job2])
+        self.assertIn("Adding a job from a backend", ",".join(cm.output))
         self.assertEqual("ERROR", exp_data.status())
 
     def test_status_post_processing(self):


### PR DESCRIPTION
…ant test

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR addresses issue #76 


### Details and comments
The "Adding a job from a backend that is different than the current backend" warning is omitted in exactly one test, which adds data from two different mock backends in order to test catching the error return status in the second.

Rather than disable the log or letting it record a warning as a standard part of the test run, we add another test to verify this warning is logged, without logging it in practice.

