### PR TITLE
Adjust tomography doc strings to automatic template

### DIFF
--- a/qiskit_experiments/library/tomography/__init__.py
+++ b/qiskit_experiments/library/tomography/__init__.py
@@ -22,6 +22,7 @@ Experiments
 ===========
 .. autosummary::
     :toctree: ../stubs/
+    :template: autosummary/experiment.rst
 
     StateTomography
     ProcessTomography
@@ -32,6 +33,7 @@ Analysis
 
 .. autosummary::
     :toctree: ../stubs/
+    :template: autosummary/analysis.rst
 
     StateTomographyAnalysis
     ProcessTomographyAnalysis

--- a/qiskit_experiments/library/tomography/qpt_analysis.py
+++ b/qiskit_experiments/library/tomography/qpt_analysis.py
@@ -20,41 +20,7 @@ from .tomography_analysis import TomographyAnalysis
 class ProcessTomographyAnalysis(TomographyAnalysis):
     """Quantum state and process tomography experiment analysis.
 
-    Analysis Options
-        - **measurement_basis**
-          (:class:`~qiskit_experiments.library.tomography.basis.BaseFitterMeasurementBasis`):
-          The measurement
-          :class:`~qiskit_experiments.library.tomography.basis.BaseFitterMeasurementBasis`
-          to use for tomographic reconstruction when running a
-          :class:`~qiskit_experiments.library.tomography.StateTomography` or
-          :class:`~qiskit_experiments.library.tomography.ProcessTomography`.
-        - **preparation_basis**
-          (:class:`~qiskit_experiments.library.tomography.basis.BaseFitterPreparationBasis`):
-          The preparation
-          :class:`~qiskit_experiments.library.tomography.basis.BaseFitterPreparationBasis`
-          to use for tomographic reconstruction for
-          :class:`~qiskit_experiments.library.tomography.ProcessTomography`.
-        - **fitter** (``str`` or ``Callable``): The fitter function to use for reconstruction.
-          This can  be a string to select one of the built-in fitters, or a callable to
-          supply a custom fitter function. See the `Fitter Functions` section
-          for additional information.
-        - **rescale_positive** (``bool``): If True rescale the state returned by the fitter
-          to be positive-semidefinite. See the `PSD Rescaling` section for
-          additional information (Default: True).
-        - **rescale_trace** (``bool``): If True rescale the state returned by the fitter
-          have either trace 1 for :class:`~qiskit.quantum_info.DensityMatrix`,
-          or trace dim for :class:`~qiskit.quantum_info.Choi`.
-          matrices (Default: True).
-        - **target** (``QuantumChannel`` or ``Operator``) Set a custom target quantum
-          channel for computing the :func:~qiskit.quantum_info.process_fidelity` of the
-          fitted process against. If ``"default"`` the ideal process corresponding for
-          the input circuit will be used. If ``None`` no fidelity will be computed
-          (Default: "default").
-        - **kwargs**: will be supplied to the fitter function,
-          for documentation of available args refer to the fitter function
-          documentation.
-
-    Fitter Functions
+    # section: Fitter Functions
         Built-in fitter functions may be selected using the following string
         labels, refer to the corresponding functions documentation for additional
         details on the fitters.
@@ -79,7 +45,7 @@ class ProcessTomographyAnalysis(TomographyAnalysis):
             The API for tomography fitters is still under development so may change
             in future releases.
 
-    PSD Rescaling
+    # section: PSD Rescaling
         For fitters that do not constrain the reconstructed state to be
         `positive-semidefinite` (PSD) we construct the maximum-likelihood
         nearest PSD state under the assumption of Gaussian measurement noise
@@ -87,13 +53,41 @@ class ProcessTomographyAnalysis(TomographyAnalysis):
         support PSD constraints this option can be disabled by setting
         ``rescale_positive=False``.
 
-    References
-        1. J Smolin, JM Gambetta, G Smith, Phys. Rev. Lett. 108, 070502 (2012).
-           Open access: https://arxiv.org/abs/arXiv:1106.5458
+    # section: reference
+        .. ref_arxiv:: 1 1106.5458
     """
 
     @classmethod
     def _default_options(cls) -> Options:
+        """Default analysis options
+
+        Analysis Options:
+            measurement_basis (:class:`~qiskit_experiments.library.tomography.basis.BaseFitterMeasurementBasis`):
+                The measurement :class:`~qiskit_experiments.library.tomography.basis.BaseFitterMeasurementBasis`
+                to use for tomographic reconstruction when running a
+                :class:`~qiskit_experiments.library.tomography.StateTomography` or
+                :class:`~qiskit_experiments.library.tomography.ProcessTomography`.
+            preparation_basis (:class:`~qiskit_experiments.library.tomography.basis.BaseFitterPreparationBasis`):
+                The preparation :class:`~qiskit_experiments.library.tomography.basis.BaseFitterPreparationBasis`
+                to use for tomographic reconstruction for
+                :class:`~qiskit_experiments.library.tomography.ProcessTomography`.
+            fitter (str or Callable): The fitter function to use for reconstruction.
+                This can  be a string to select one of the built-in fitters, or a callable to
+                supply a custom fitter function. See the `Fitter Functions` section for additional information.
+            rescale_positive (bool): If True rescale the state returned by the fitter
+                to be positive-semidefinite. See the `PSD Rescaling` section for additional information
+                (Default: True).
+            rescale_trace (bool): If True rescale the state returned by the fitter have either trace 1
+                for :class:`~qiskit.quantum_info.DensityMatrix`, or trace dim for :class:`~qiskit.quantum_info.Choi`
+                matrices (Default: True).
+            target (str or :class:`~qiskit.quantum_info..operators.channel.quantum_channel`
+                or :class:`~qiskit.quantum_info.Operator`): Set a custom target quantum
+                channel for computing the :func:~qiskit.quantum_info.process_fidelity` of the
+                fitted process against. If ``"default"`` the ideal process corresponding for
+                the input circuit will be used. If ``None`` no fidelity will be computed (Default: "default").
+            kwargs: will be supplied to the fitter function, for documentation of available args refer to
+                the fitter function documentation.
+        """
         options = super()._default_options()
 
         options.measurement_basis = PauliMeasurementBasis()

--- a/qiskit_experiments/library/tomography/qpt_experiment.py
+++ b/qiskit_experiments/library/tomography/qpt_experiment.py
@@ -25,7 +25,7 @@ from . import basis
 class ProcessTomography(TomographyExperiment):
     """Quantum process tomography experiment.
 
-    Overview
+    # section: overview
         Quantum process tomography (QPT) is a method for experimentally
         reconstructing the quantum channel from measurement data.
 
@@ -41,44 +41,45 @@ class ProcessTomography(TomographyExperiment):
             Performing full process tomography on an `N`-qubit circuit requires
             running :math:`4^N 3^N` measurement circuits when using the default
             preparation and measurement bases.
-
-    Analysis Class
-        :class:`~qiskit_experiments.library.tomography.TomographyAnalysis`.
-
-    Experiment Options
-        - **measurement_basis** (:class:`~basis.BaseTomographyMeasurementBasis`)
-          The Tomography measurement basis to use for the experiment.
-          The default basis is the :class:`~basis.PauliMeasurementBasis` which
-          performs measurements in the Pauli Z, X, Y bases for each qubit
-          measurement.
-        - **preparation_basis** (:class:`~basis.BaseTomographyPreparationBasis`)
-          The Tomography measurement basis to use for the experiment.
-          The default basis is the :class:`~basis.PauliPreparationBasis` which
-          prepares the :math:`|0\\rangle, |1\\rangle, |+\\rangle |+i\\rangle`
-          states on each prepared qubit.
-
-    Analysis Options:
-        - **measurement_basis**
-          (:class:`~basis.BaseFitterMeasurementBasis`):
-          A custom measurement basis for analysis. By default the
-          :meth:`experiment_options` measurement basis will be used.
-        - **preparation_basis**
-          (:class:`~basis.BaseFitterPreparationBasis`):
-          A custom preparation basis for analysis. By default the
-          :meth:`experiment_options` preparation basis will be used.
-        - **fitter** (``str`` or ``Callable``): The fitter function to use for
-          reconstruction.
-        - **rescale_psd** (``bool``): If True rescale the fitted state to be
-          positive-semidefinite (Default: True).
-        - **rescale_trace** (``bool``): If True rescale the state returned by the fitter
-          have either trace 1 (Default: True).
-        - **kwargs**: Additional kwargs will be supplied to the fitter function.
     """
 
     __analysis_class__ = ProcessTomographyAnalysis
 
     @classmethod
+    def _default_experiment_options(cls) -> Options:
+        """Default experiment options.
+
+        Experiment Options:
+            measurement_basis (:class:`~basis.BaseTomographyMeasurementBasis`): The
+                Tomography measurement basis to use for the experiment.
+                The default basis is the :class:`~basis.PauliMeasurementBasis` which
+                performs measurements in the Pauli Z, X, Y bases for each qubit
+                measurement.
+            preparation_basis (:class:`~basis.BaseTomographyPreparationBasis`):
+                The Tomography measurement basis to use for the experiment.
+                The default basis is the :class:`~basis.PauliPreparationBasis` which
+                prepares the :math:`|0\\rangle, |1\\rangle, |+\\rangle |+i\\rangle`
+                states on each prepared qubit.
+        """
+        options = super()._default_experiment_options()
+
+        return options
+
+    @classmethod
     def _default_analysis_options(cls) -> Options:
+        """Default analysis options.
+
+        Analysis Options:
+            measurement_basis (:class:`~basis.BaseFitterMeasurementBasis`): A custom measurement
+                basis for analysis. By default the :meth:`experiment_options` measurement basis will be used.
+            preparation_basis (:class:`~basis.BaseFitterPreparationBasis`): A custom preparation
+                basis for analysis. By default the :meth:`experiment_options` preparation basis will be used.
+            fitter (str or Callable): The fitter function to use for reconstruction.
+            rescale_psd (bool): If True rescale the fitted state to be positive-semidefinite (Default: True).
+            rescale_trace (bool): If True rescale the state returned by the fitter have either trace 1
+                (Default: True).
+            kwargs: Additional kwargs will be supplied to the fitter function.
+        """
         options = super()._default_analysis_options()
 
         options.measurement_basis = basis.PauliMeasurementBasis()

--- a/qiskit_experiments/library/tomography/qst_analysis.py
+++ b/qiskit_experiments/library/tomography/qst_analysis.py
@@ -20,34 +20,7 @@ from .tomography_analysis import TomographyAnalysis
 class StateTomographyAnalysis(TomographyAnalysis):
     """State tomography experiment analysis.
 
-    Analysis Options
-        - **measurement_basis**
-          (:class:`~qiskit_experiments.library.tomography.basis.BaseFitterMeasurementBasis`):
-          The measurement
-          :class:`~qiskit_experiments.library.tomography.basis.BaseFitterMeasurementBasis`
-          to use for tomographic reconstruction when running a
-          :class:`~qiskit_experiments.library.tomography.StateTomography` or
-          :class:`~qiskit_experiments.library.tomography.ProcessTomography`.
-        - **fitter** (``str`` or ``Callable``): The fitter function to use for reconstruction.
-          This can  be a string to select one of the built-in fitters, or a callable to
-          supply a custom fitter function. See the `Fitter Functions` section
-          for additional information.
-        - **rescale_positive** (``bool``): If True rescale the state returned by the fitter
-          to be positive-semidefinite. See the `PSD Rescaling` section for
-          additional information (Default: True).
-        - **rescale_trace** (``bool``): If True rescale the state returned by the fitter
-          have either trace 1 for :class:`~qiskit.quantum_info.DensityMatrix`,
-          or trace dim for :class:`~qiskit.quantum_info.Choi`.
-          matrices (Default: True).
-        - **target** (``Statevector`` or ``DensityMatrix``) Set a custom target state
-          for computing the :func:`~qiskit.quantum_info.state_fidelity` of the fitted
-          state against. If ``"default"``  the ideal state prepared by the input circuit
-          will be used. If ``None`` no fidelity will be computed (Default: "default").
-        - **kwargs**: will be supplied to the fitter function,
-          for documentation of available args refer to the fitter function
-          documentation.
-
-    Fitter Functions
+    # section: Fitter Functions
         Built-in fitter functions may be selected using the following string
         labels, refer to the corresponding functions documentation for additional
         details on the fitters.
@@ -72,7 +45,7 @@ class StateTomographyAnalysis(TomographyAnalysis):
             The API for tomography fitters is still under development so may change
             in future releases.
 
-    PSD Rescaling
+    # section: PSD Rescaling
         For fitters that do not constrain the reconstructed state to be
         `positive-semidefinite` (PSD) we construct the maximum-likelihood
         nearest PSD state under the assumption of Gaussian measurement noise
@@ -80,13 +53,38 @@ class StateTomographyAnalysis(TomographyAnalysis):
         support PSD constraints this option can be disabled by setting
         ``rescale_positive=False``.
 
-    References
-        1. J Smolin, JM Gambetta, G Smith, Phys. Rev. Lett. 108, 070502 (2012).
-           Open access: https://arxiv.org/abs/arXiv:1106.5458
+    # section: reference
+        .. ref_arxiv:: 1 1106.5458
     """
 
     @classmethod
     def _default_options(cls) -> Options:
+        """Default analysis options
+        Analysis Options:
+            measurement_basis (:class:`~qiskit_experiments.library.tomography.basis.BaseFitterMeasurementBasis`):
+                The measurement :class:`~qiskit_experiments.library.tomography.basis.BaseFitterMeasurementBasis`
+                to use for tomographic reconstruction when running a
+                :class:`~qiskit_experiments.library.tomography.StateTomography` or
+                :class:`~qiskit_experiments.library.tomography.ProcessTomography`.
+            fitter (str or Callable): The fitter function to use for reconstruction.
+                This can  be a string to select one of the built-in fitters, or a callable to
+                supply a custom fitter function. See the `Fitter Functions` section
+                for additional information.
+            rescale_positive (bool): If True rescale the state returned by the fitter
+                to be positive-semidefinite. See the `PSD Rescaling` section for
+                additional information (Default: True).
+            rescale_trace (bool): If True rescale the state returned by the fitter
+                have either trace 1 for :class:`~qiskit.quantum_info.DensityMatrix`,
+                or trace dim for :class:`~qiskit.quantum_info.Choi`.
+                matrices (Default: True).
+            target (str or :class:`~qiskit.quantum_info.DensityMatrix` or :class:`~qiskit.quantum_info.StateVector`):
+                Set a custom target state for computing the
+                :func:`~qiskit.quantum_info.state_fidelity` of the fitted
+                state against. If ``"default"``  the ideal state prepared by the input circuit
+                will be used. If ``None`` no fidelity will be computed (Default: "default").
+            kwargs: will be supplied to the fitter function, for documentation of available
+                args refer to the fitter function documentation.
+        """
         options = super()._default_options()
 
         options.measurement_basis = PauliMeasurementBasis()

--- a/qiskit_experiments/library/tomography/qst_experiment.py
+++ b/qiskit_experiments/library/tomography/qst_experiment.py
@@ -26,7 +26,7 @@ from . import basis
 class StateTomography(TomographyExperiment):
     """Quantum state tomography experiment.
 
-    Overview
+    # section: overview
         Quantum state tomography (QST) is a method for experimentally
         reconstructing the quantum state from measurement data.
 
@@ -41,35 +41,25 @@ class StateTomography(TomographyExperiment):
             Performing full state tomography on an `N`-qubit state requires
             running :math:`3^N` measurement circuits when using the default
             measurement basis.
-
-    Analysis Class
-        :class:`~qiskit.experiments.tomography.TomographyAnalysis`
-
-    Experiment Options
-        - **measurement_basis** (:class:`~basis.BaseTomographyMeasurementBasis`):
-          The Tomography measurement basis to use for the experiment.
-          The default basis is the :class:`~basis.PauliMeasurementBasis` which
-          performs measurements in the Pauli Z, X, Y bases for each qubit
-          measurement.
-
-    Analysis Options
-        - **measurement_basis**
-          (:class`~basis.BaseFitterMeasurementBasis`):
-          A custom measurement basis for analysis. By default the
-          :meth:`experiment_options` measurement basis will be used.
-        - **fitter** (``str`` or ``Callable``): The fitter function to use for
-          reconstruction.
-        - **rescale_psd** (``bool``): If True rescale the fitted state to be
-          positive-semidefinite (Default: True).
-        - **rescale_trace** (``bool``): If True rescale the state returned by the fitter
-          have either trace 1 (Default: True).
-        - **kwargs**: Additional kwargs will be supplied to the fitter function.
     """
 
     __analysis_class__ = StateTomographyAnalysis
 
     @classmethod
     def _default_analysis_options(cls) -> Options:
+        """Default analysis options.
+
+        Analysis Options:
+            measurement_basis (:class`~basis.BaseFitterMeasurementBasis`): A custom
+                measurement basis for analysis. By default the :meth:`experiment_options`
+                measurement basis will be used.
+            fitter (``str`` or ``Callable``): The fitter function to use for reconstruction.
+            rescale_psd (``bool``): If True rescale the fitted state to be
+                positive-semidefinite (Default: True).
+            rescale_trace (``bool``): If True rescale the state returned by the fitter
+                have either trace 1 (Default: True).
+            kwargs: Additional kwargs will be supplied to the fitter function.
+        """
         options = super()._default_analysis_options()
 
         options.measurement_basis = basis.PauliMeasurementBasis().matrix

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -34,6 +34,15 @@ class TomographyExperiment(BaseExperiment):
 
     @classmethod
     def _default_experiment_options(cls) -> Options:
+        """Default experiment options.
+
+        Experiment Options:
+            measurement_basis (:class:`~basis.BaseTomographyMeasurementBasis`): The
+                Tomography measurement basis to use for the experiment.
+                The default basis is the :class:`~basis.PauliMeasurementBasis` which
+                performs measurements in the Pauli Z, X, Y bases for each qubit
+                measurement.
+        """
         options = super()._default_experiment_options()
 
         options.basis_indices = None


### PR DESCRIPTION
### Summary
Addressing #254 and adjusting tomography to the automatic docstring template


### Details and comments
I am not sure about the fitter options sections. the auto template assumes that the fitting is with curve fitting and therefore has fitting parameters, but here there are different fitting methods in the tomography. 
@nkanazawa1989 - can you see if this is the way you intended the docs to be in such a case?