### PR TITLE
Default run options for Drag and Fine

### DIFF
--- a/qiskit_experiments/library/calibration/drag.py
+++ b/qiskit_experiments/library/calibration/drag.py
@@ -17,7 +17,6 @@ import numpy as np
 
 from qiskit import QuantumCircuit
 from qiskit.circuit import Gate, Parameter
-from qiskit.qobj.utils import MeasLevel
 from qiskit.providers import Backend
 import qiskit.pulse as pulse
 
@@ -74,16 +73,6 @@ class DragCal(BaseExperiment):
     """
 
     __analysis_class__ = DragCalAnalysis
-
-    @classmethod
-    def _default_run_options(cls) -> Options:
-        """Default option values for the experiment :meth:`run` method."""
-        options = super()._default_run_options()
-
-        options.meas_level = MeasLevel.CLASSIFIED
-        options.meas_return = "avg"
-
-        return options
 
     @classmethod
     def _default_experiment_options(cls) -> Options:

--- a/qiskit_experiments/library/calibration/fine_amplitude.py
+++ b/qiskit_experiments/library/calibration/fine_amplitude.py
@@ -17,7 +17,6 @@ import numpy as np
 
 from qiskit import QuantumCircuit
 from qiskit.circuit import Gate
-from qiskit.qobj.utils import MeasLevel
 from qiskit.providers import Backend
 from qiskit.pulse.schedule import ScheduleBlock
 
@@ -96,15 +95,6 @@ class FineAmplitude(BaseExperiment):
     """
 
     __analysis_class__ = FineAmplitudeAnalysis
-
-    @classmethod
-    def _default_run_options(cls) -> Options:
-        """Default option values for the experiment :meth:`run` method."""
-        options = super()._default_run_options()
-        options.meas_level = MeasLevel.CLASSIFIED
-        options.meas_return = "avg"
-
-        return options
 
     @classmethod
     def _default_experiment_options(cls) -> Options:

--- a/test/calibration/experiments/test_drag.py
+++ b/test/calibration/experiments/test_drag.py
@@ -66,7 +66,7 @@ class TestDragEndToEnd(QiskitTestCase):
         drag = DragCal(0)
         drag.set_analysis_options(p0={"beta": 1.2})
         drag.set_experiment_options(rp=self.x_plus, rm=self.x_minus)
-        drag.set_run_options(meas_level=MeasLevel.KERNELED)
+        drag.set_run_options(meas_level=MeasLevel.KERNELED, meas_return="avg")
         exp_data = drag.run(backend)
         exp_data.block_for_results()
         result = exp_data.analysis_results(1)


### PR DESCRIPTION


### Summary

The default options for Drag and FineAmp can be simplified.

### Details and comments

The default run options have been deleted from DragCal and FineAmplitude as the base class sets them to the needed values.
