### PR TITLE
RamseyXY experiment

### DIFF
--- a/qiskit_experiments/curve_analysis/fit_function.py
+++ b/qiskit_experiments/curve_analysis/fit_function.py
@@ -87,4 +87,4 @@ def cos_decay(
     .. math::
         y = {\rm amp} e^{-x/\tau} \cos\left(2 \pi {\rm freq} x + {\rm phase}\right) + {\rm baseline}
     """
-    return exponential_decay(x, lamb=1/tau) * cos(x, amp=amp, freq=freq, phase=phase) + baseline
+    return exponential_decay(x, lamb=1 / tau) * cos(x, amp=amp, freq=freq, phase=phase) + baseline

--- a/qiskit_experiments/curve_analysis/fit_function.py
+++ b/qiskit_experiments/curve_analysis/fit_function.py
@@ -73,3 +73,18 @@ def gaussian(
         y = {\rm amp} \exp \left( - (x - x0)^2 / 2 \sigma^2 \right) + {\rm baseline}
     """
     return amp * np.exp(-((x - x0) ** 2) / (2 * sigma ** 2)) + baseline
+
+
+def cos_decay(
+    x: np.ndarray,
+    amp: float = 1.0,
+    tau: float = 1.0,
+    freq: float = 1 / (2 * np.pi),
+    phase: float = 0.0,
+    baseline: float = 0.0,
+) -> np.ndarray:
+    r"""Cosine function with exponential decay.
+    .. math::
+        y = {\rm amp} e^{-x/\tau} \cos\left(2 \pi {\rm freq} x + {\rm phase}\right) + {\rm baseline}
+    """
+    return exponential_decay(x, lamb=1/tau) * cos(x, amp=amp, freq=freq, phase=phase) + baseline

--- a/qiskit_experiments/curve_analysis/fit_function.py
+++ b/qiskit_experiments/curve_analysis/fit_function.py
@@ -88,3 +88,18 @@ def cos_decay(
         y = {\rm amp} e^{-x/\tau} \cos\left(2 \pi {\rm freq} x + {\rm phase}\right) + {\rm baseline}
     """
     return exponential_decay(x, lamb=1 / tau) * cos(x, amp=amp, freq=freq, phase=phase) + baseline
+
+
+def sin_decay(
+    x: np.ndarray,
+    amp: float = 1.0,
+    tau: float = 1.0,
+    freq: float = 1 / (2 * np.pi),
+    phase: float = 0.0,
+    baseline: float = 0.0,
+) -> np.ndarray:
+    r"""Sine function with exponential decay.
+    .. math::
+        y = {\rm amp} e^{-x/\tau} \sin\left(2 \pi {\rm freq} x + {\rm phase}\right) + {\rm baseline}
+    """
+    return exponential_decay(x, lamb=1 / tau) * sin(x, amp=amp, freq=freq, phase=phase) + baseline

--- a/qiskit_experiments/library/__init__.py
+++ b/qiskit_experiments/library/__init__.py
@@ -82,9 +82,18 @@ See :doc:`/tutorials/calibrating_armonk` for example.
     ~calibration.FineAmplitude
     ~calibration.FineXAmplitude
     ~calibration.FineSXAmplitude
+    ~calibration.RamseyXY
 
 """
-from .calibration import DragCal, Rabi, EFRabi, FineAmplitude, FineXAmplitude, FineSXAmplitude
+from .calibration import (
+    DragCal,
+    Rabi,
+    EFRabi,
+    FineAmplitude,
+    FineXAmplitude,
+    FineSXAmplitude,
+    RamseyXY,
+)
 from .characterization import T1, T2Ramsey, QubitSpectroscopy, EFSpectroscopy
 from .randomized_benchmarking import StandardRB, InterleavedRB
 from .tomography import StateTomography, ProcessTomography

--- a/qiskit_experiments/library/calibration/__init__.py
+++ b/qiskit_experiments/library/calibration/__init__.py
@@ -65,7 +65,7 @@ See :mod:`qiskit_experiments.calibration_management`.
 from .drag import DragCal
 from .rabi import Rabi, EFRabi
 from .fine_amplitude import FineAmplitude, FineXAmplitude, FineSXAmplitude
-from .remsey_xy import RamseyXY
+from .ramsey_xy import RamseyXY
 
 from .analysis.oscillation_analysis import OscillationAnalysis
 from .analysis.drag_analysis import DragCalAnalysis

--- a/qiskit_experiments/library/calibration/__init__.py
+++ b/qiskit_experiments/library/calibration/__init__.py
@@ -44,6 +44,7 @@ module.
     FineAmplitude
     FineXAmplitude
     FineSXAmplitude
+    RamseyXY
 
 Calibration analysis
 ====================
@@ -64,7 +65,9 @@ See :mod:`qiskit_experiments.calibration_management`.
 from .drag import DragCal
 from .rabi import Rabi, EFRabi
 from .fine_amplitude import FineAmplitude, FineXAmplitude, FineSXAmplitude
+from .remsey_xy import RamseyXY
 
 from .analysis.oscillation_analysis import OscillationAnalysis
 from .analysis.drag_analysis import DragCalAnalysis
 from .analysis.fine_amplitude_analysis import FineAmplitudeAnalysis
+from .analysis.remsey_xy_analysis import RamseyXYAnalysis

--- a/qiskit_experiments/library/calibration/analysis/remsey_xy_analysis.py
+++ b/qiskit_experiments/library/calibration/analysis/remsey_xy_analysis.py
@@ -95,7 +95,8 @@ class RamseyXYAnalysis(curve.CurveAnalysis):
         """
         default_options = super()._default_options()
         default_options.result_parameters = ["freq"]
-        default_options.xlabel = "Delay (s)"
+        default_options.xlabel = "Delay"
+        default_options.xval_unit = "s"
         default_options.ylabel = "Signal (arb. units)"
 
         return default_options

--- a/qiskit_experiments/library/calibration/analysis/remsey_xy_analysis.py
+++ b/qiskit_experiments/library/calibration/analysis/remsey_xy_analysis.py
@@ -1,0 +1,157 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""The analysis class for the Ramsey XY experiment."""
+
+from typing import Any, Dict, List, Union
+import numpy as np
+
+import qiskit_experiments.curve_analysis as curve
+from qiskit_experiments.curve_analysis.fit_function import cos_decay
+
+
+class RamseyXYAnalysis(curve.CurveAnalysis):
+    r"""The Ramsey XY analysis is based on a fit to a cosine function and a sine function.
+
+    # section: fit_model
+
+        Analyse a Ramsey XY experiment by fitting the X and Y series to a cosine and sine
+        function, respectively. The two functions share the frequency and amplitude parameters
+        (i.e. beta).
+
+        .. math::
+
+            y_X = {\rm amp}e^{x/\tau}\cos\left(2\pi\cdot{\rm freq}_i\cdot x-\pi/2\right)+{\rm base}
+            y_Y = {\rm amp}e^{x/\tau}\cos\left(2\pi\cdot{\rm freq}_i\cdot x) + {\rm base}
+
+    # section: fit_parameters
+        defpar \rm amp:
+            desc: Amplitude of both series.
+            init_guess: The maximum y value less the minimum y value. 0.5 is also tried.
+            bounds: [-2, 2] scaled to the maximum signal value.
+
+        defpar \tau:
+            desc: The exponential decay of the curve.
+            init_guess: The initial guess is obtained by fitting an exponential to the
+                square root of (X data)**2 + (Y data)**2.
+            bounds: [0, inf].
+
+        defpar \rm base:
+            desc: Base line of both series.
+            init_guess: The average of the data. 0.5 is also tried.
+            bounds: [-1, 1] scaled to the maximum signal value.
+
+        defpar \rm freq:
+            desc: Frequency of both series. This is the parameter of interest.
+            init_guess: The frequency with the highest power spectral density.
+            bounds: [0, inf].
+
+        defpar \rm phase:
+            desc: Common phase offset.
+            init_guess: Linearly spaced between the maximum and minimum scanned beta.
+            bounds: [-min scan range, max scan range].
+    """
+
+    __series__ = [
+        curve.SeriesDef(
+            fit_func=lambda x, amp, tau, freq, base, phase: cos_decay(
+                x, amp=amp, tau=tau, freq=freq, phase=phase, baseline=base
+            ),
+            plot_color="blue",
+            name="X",
+            filter_kwargs={"series": "X"},
+            plot_symbol="o",
+            model_description=r"{\rm amp} e^{-x/\tau} \cos\left(2 \pi\cdot {\rm freq}\cdot x "
+            r"+ {\rm phase}) + {\rm base}",
+        ),
+        curve.SeriesDef(
+            fit_func=lambda x, amp, tau, freq, base, phase: cos_decay(
+                x, amp=amp, tau=tau, freq=freq, phase=phase-np.pi/2, baseline=base
+            ),
+            plot_color="green",
+            name="Y",
+            filter_kwargs={"series": "Y"},
+            plot_symbol="^",
+            model_description=r"{\rm amp} e^{-x/\tau} \cos\left(2 \pi\cdot {\rm freq}\cdot x "
+            r"+{\rm phase} - \pi/2\right) + {\rm base}",
+        ),
+    ]
+
+    @classmethod
+    def _default_options(cls):
+        """Return the default analysis options.
+
+        See :meth:`~qiskit_experiment.curve_analysis.CurveAnalysis._default_options` for
+        descriptions of analysis options.
+        """
+        default_options = super()._default_options()
+        default_options.result_parameters = ["freq"]
+        default_options.xlabel = "Delay (s)"
+        default_options.ylabel = "Signal (arb. units)"
+
+        return default_options
+
+    def _setup_fitting(self, **extra_options) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        """Compute the initial guesses."""
+        user_p0 = self._get_option("p0")
+        user_bounds = self._get_option("bounds")
+
+        # Default guess values
+        freq_guesses, amp_guesses, offset_guesses = [], [], []
+
+        for series in ["X", "Y"]:
+            data = self._data(series)
+            freq_guesses.append(curve.guess.frequency(data.x, data.y))
+            offset_guesses.append(curve.guess.constant_sinusoidal_offset(data.y))
+
+        # Guess the exponential decay by combining both curves
+        data_x = self._data("X")
+        data_y = self._data("Y")
+        decay_data = (data_x.y - offset_guesses[0]) ** 2 + (data_y.y - offset_guesses[1]) ** 2
+        guess_decay = -curve.guess.exp_decay(data_x.x, decay_data)
+
+        freq_guess = user_p0.get("freq", None) or np.average(freq_guesses)
+        fit_options = []
+
+        for freq in [-freq_guess, freq_guess]:
+            fit_options.append(
+            {
+                "p0": {
+                    "amp": user_p0.get("amp", None) or 0.5,
+                    "tau": guess_decay,
+                    "freq": freq,
+                    "base": user_p0.get("base", None) or np.average(offset_guesses),
+                    "phase": user_p0.get("phase", None) or 0.0,
+                },
+            })
+
+        return fit_options
+
+    def _evaluate_quality(self, fit_data: curve.FitData) -> Union[str, None]:
+        """Algorithmic criteria for whether the fit is good or bad.
+
+        A good fit has:
+            - a reduced chi-squared lower than three,
+            - an error on the frequency smaller than the frequency.
+        """
+        fit_freq = fit_data.fitval("freq").value
+        fit_freq_err = fit_data.fitval("freq").stderr
+
+        criteria = [
+            fit_data.reduced_chisq < 3,
+            fit_freq_err < abs(fit_freq),
+        ]
+
+        if all(criteria):
+            return "good"
+
+        return "bad"

--- a/qiskit_experiments/library/calibration/analysis/remsey_xy_analysis.py
+++ b/qiskit_experiments/library/calibration/analysis/remsey_xy_analysis.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Union
 import numpy as np
 
 import qiskit_experiments.curve_analysis as curve
-from qiskit_experiments.curve_analysis.fit_function import cos_decay
+from qiskit_experiments.curve_analysis import fit_function
 
 
 class RamseyXYAnalysis(curve.CurveAnalysis):
@@ -63,7 +63,7 @@ class RamseyXYAnalysis(curve.CurveAnalysis):
 
     __series__ = [
         curve.SeriesDef(
-            fit_func=lambda x, amp, tau, freq, base, phase: cos_decay(
+            fit_func=lambda x, amp, tau, freq, base, phase: fit_function.cos_decay(
                 x, amp=amp, tau=tau, freq=freq, phase=phase, baseline=base
             ),
             plot_color="blue",
@@ -74,7 +74,7 @@ class RamseyXYAnalysis(curve.CurveAnalysis):
             r"+ {\rm phase}) + {\rm base}",
         ),
         curve.SeriesDef(
-            fit_func=lambda x, amp, tau, freq, base, phase: cos_decay(
+            fit_func=lambda x, amp, tau, freq, base, phase: fit_function.cos_decay(
                 x, amp=amp, tau=tau, freq=freq, phase=phase - np.pi / 2, baseline=base
             ),
             plot_color="green",

--- a/qiskit_experiments/library/calibration/analysis/remsey_xy_analysis.py
+++ b/qiskit_experiments/library/calibration/analysis/remsey_xy_analysis.py
@@ -75,7 +75,7 @@ class RamseyXYAnalysis(curve.CurveAnalysis):
         ),
         curve.SeriesDef(
             fit_func=lambda x, amp, tau, freq, base, phase: cos_decay(
-                x, amp=amp, tau=tau, freq=freq, phase=phase-np.pi/2, baseline=base
+                x, amp=amp, tau=tau, freq=freq, phase=phase - np.pi / 2, baseline=base
             ),
             plot_color="green",
             name="Y",
@@ -103,10 +103,9 @@ class RamseyXYAnalysis(curve.CurveAnalysis):
     def _setup_fitting(self, **extra_options) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """Compute the initial guesses."""
         user_p0 = self._get_option("p0")
-        user_bounds = self._get_option("bounds")
 
         # Default guess values
-        freq_guesses, amp_guesses, offset_guesses = [], [], []
+        freq_guesses, offset_guesses = [], []
 
         for series in ["X", "Y"]:
             data = self._data(series)
@@ -124,15 +123,16 @@ class RamseyXYAnalysis(curve.CurveAnalysis):
 
         for freq in [-freq_guess, freq_guess]:
             fit_options.append(
-            {
-                "p0": {
-                    "amp": user_p0.get("amp", None) or 0.5,
-                    "tau": guess_decay,
-                    "freq": freq,
-                    "base": user_p0.get("base", None) or np.average(offset_guesses),
-                    "phase": user_p0.get("phase", None) or 0.0,
-                },
-            })
+                {
+                    "p0": {
+                        "amp": user_p0.get("amp", None) or 0.5,
+                        "tau": guess_decay,
+                        "freq": freq,
+                        "base": user_p0.get("base", None) or np.average(offset_guesses),
+                        "phase": user_p0.get("phase", None) or 0.0,
+                    },
+                }
+            )
 
         return fit_options
 

--- a/qiskit_experiments/library/calibration/ramsey_xy.py
+++ b/qiskit_experiments/library/calibration/ramsey_xy.py
@@ -164,12 +164,20 @@ class RamseyXY(BaseExperiment):
         rotation_angle = 2 * np.pi * self.experiment_options.osc_freq * conversion_factor * p_delay
 
         # Create the X and Y circuits.
+        metadata = {
+            "experiment_type": self._type,
+            "qubits": self.physical_qubits,
+            "osc_freq": self.experiment_options.osc_freq,
+            "unit": "s",
+        }
+
         ram_x = self._pre_circuit()
         ram_x.sx(0)
         ram_x.delay(p_delay, 0, self.experiment_options.unit)
         ram_x.rz(rotation_angle, 0)
         ram_x.sx(0)
         ram_x.measure_active()
+        ram_x.metadata = metadata.copy()
 
         ram_y = self._pre_circuit()
         ram_y.sx(0)
@@ -177,6 +185,7 @@ class RamseyXY(BaseExperiment):
         ram_y.rz(rotation_angle - np.pi / 2, 0)
         ram_y.sx(0)
         ram_y.measure_active()
+        ram_y.metadata = metadata.copy()
 
         # Add the schedule if any.
         schedule = self.experiment_options.schedule
@@ -187,23 +196,15 @@ class RamseyXY(BaseExperiment):
         circs = []
         for delay in self.experiment_options.delays:
 
-            metadata = {
-                "experiment_type": self._type,
-                "qubits": self.physical_qubits,
-                "osc_freq": self.experiment_options.osc_freq,
-                "unit": "s",
-                "xval": delay * conversion_factor,
-            }
-
             # create ramsey x
             assigned_x = ram_x.assign_parameters({p_delay: delay}, inplace=False)
-            assigned_x.metadata = metadata.copy()
             assigned_x.metadata["series"] = "X"
+            assigned_x.metadata["xval"] = delay * conversion_factor
 
             # create ramsey y
             assigned_y = ram_y.assign_parameters({p_delay: delay}, inplace=False)
-            assigned_y.metadata = metadata.copy()
             assigned_y.metadata["series"] = "Y"
+            assigned_y.metadata["xval"] = delay * conversion_factor
 
             circs.extend([assigned_x, assigned_y])
 

--- a/qiskit_experiments/library/calibration/remsey_xy.py
+++ b/qiskit_experiments/library/calibration/remsey_xy.py
@@ -22,6 +22,7 @@ from qiskit.utils import apply_prefix
 import qiskit.pulse as pulse
 
 from qiskit_experiments.framework import BaseExperiment
+from qiskit_experiments.exceptions import CalibrationError
 from qiskit_experiments.library.calibration.analysis.remsey_xy_analysis import RamseyXYAnalysis
 
 
@@ -169,6 +170,10 @@ class RamseyXY(BaseExperiment):
 
         # Get the schedule and add a potential frequency shift.
         schedule = self.experiment_options.schedule
+
+        if schedule is None:
+            raise CalibrationError(f"The schedule was not specified for self.__class__.__name__.")
+
         d_freq = self.experiment_options.frequency_offset
 
         with pulse.build(backend=backend, name="RamseyXY_x") as sched_x:

--- a/qiskit_experiments/library/calibration/remsey_xy.py
+++ b/qiskit_experiments/library/calibration/remsey_xy.py
@@ -111,7 +111,7 @@ class RamseyXY(BaseExperiment):
         osc_freq: float = 2e6,
     ):
         """Create new experiment.
-        
+
         Args:
             qubit: The qubit on which to run the Ramsey XY experiment.
             delays: The delays to scan.
@@ -159,10 +159,8 @@ class RamseyXY(BaseExperiment):
 
         # Compute the rz rotation angle to add a modulation.
         p_delay = Parameter("delay")
-        
-        rotation_angle = (
-            2 * np.pi * self.experiment_options.osc_freq * conversion_factor * p_delay
-        )
+
+        rotation_angle = 2 * np.pi * self.experiment_options.osc_freq * conversion_factor * p_delay
 
         # Create the X and Y circuits.
         ram_x = self._pre_circuit()

--- a/qiskit_experiments/library/calibration/remsey_xy.py
+++ b/qiskit_experiments/library/calibration/remsey_xy.py
@@ -80,7 +80,8 @@ class RamseyXY(BaseExperiment):
         Note: The experiment allows users to add a small frequency offset to better resolve
         any oscillations. This is implemented by embedding the circuits shown above in a
         single gate (:code:`RamseyX` or :code:`RamseyY`) since :code:`pulse.set_frequency`
-        on IBM backends has unexpected behaviour. The circuits that are run are thus
+        cannot be encapsulated in pulse gates on IBM backends yet. The circuits that are run
+        are thus
 
         .. parsed-literal::
 

--- a/qiskit_experiments/library/calibration/remsey_xy.py
+++ b/qiskit_experiments/library/calibration/remsey_xy.py
@@ -146,6 +146,7 @@ class RamseyXY(BaseExperiment):
                 from the backend's configuration.
         """
 
+        conversion_factor = 1
         if self.experiment_options.unit == "dt":
             try:
                 conversion_factor = getattr(backend.configuration(), "dt")

--- a/qiskit_experiments/library/calibration/remsey_xy.py
+++ b/qiskit_experiments/library/calibration/remsey_xy.py
@@ -1,0 +1,234 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Ramsey XY frequency calibration experiment."""
+
+from typing import List, Optional
+import numpy as np
+
+from qiskit import QuantumCircuit
+from qiskit.circuit import Parameter, Gate
+from qiskit.providers import Backend
+from qiskit.utils import apply_prefix
+import qiskit.pulse as pulse
+
+from qiskit_experiments.framework import BaseExperiment
+from qiskit_experiments.library.calibration.analysis.remsey_xy_analysis import RamseyXYAnalysis
+
+
+class RamseyXY(BaseExperiment):
+    """Ramsey XY experiment to measure the frequency of a qubit.
+
+    This experiment differs from the :class:`~qiskit_experiments.characterization.\
+    t2ramsey.T2Ramsey` since it is sensitive to the sign of frequency offset from the main transition.
+    This experiment consists of following two circuits:
+
+    .. parsed-literal::
+
+        (Ramsey X) The second pulse rotates by pi-half around the X axis
+
+                   ┌────┐┌─────────────┐┌────┐ ░ ┌─┐
+              q_0: ┤ √X ├┤ Delay(τ[s]) ├┤ √X ├─░─┤M├
+                   └────┘└─────────────┘└────┘ ░ └╥┘
+        measure: 1/═══════════════════════════════╩═
+                                                  0
+
+        (Ramsey Y) The second pulse rotates by pi-half around the Y axis
+
+                   ┌────┐┌─────────────┐┌──────────┐┌────┐ ░ ┌─┐
+              q_0: ┤ √X ├┤ Delay(τ[s]) ├┤ Rz(-π/2) ├┤ √X ├─░─┤M├
+                   └────┘└─────────────┘└──────────┘└────┘ ░ └╥┘
+        measure: 1/═══════════════════════════════════════════╩═
+                                                              0
+
+    The first and second circuits measure the expectation value along the X and Y axis,
+    respectively. This experiment therefore draws the dynamics of the Bloch vector as a
+    Lissajous figure. Since the control electronics tracks the frame of qubit at the
+    reference frequency, which differs from the true qubit frequency by :math:`\Delta\omega`,
+    we can describe the dynamics of two circuits as follows. The Hamiltonian during the
+    ``Delay`` instruction is :math:`H^R = - \frac{1}{2} \Delta\omega` in the rotating frame,
+    and the propagator will be :math:`U(\tau) = \exp(-iH^R\tau)` where :math:`\tau` is the
+    duration of the delay. By scanning this duration, we can get
+
+    .. math::
+
+        {\cal E}_x(\tau)
+            = {\rm Re} {\rm Tr}\left( Y U \rho U^\dagger \right)
+            &= - \cos(\Delta\omega\tau) = \sin(\Delta\omega\tau - \frac{\pi}{2}), \\
+        {\cal E}_y(\tau)
+            = {\rm Re} {\rm Tr}\left( X U \rho U^\dagger \right)
+            &= \sin(\Delta\omega\tau),
+
+    where :math:`\rho` is prepared by the first :math:`\sqrt{\rm X}` gate. Note that phase
+    difference of these two outcomes :math:`{\cal E}_x, {\cal E}_y` depends on the sign and
+    the magnitude of the frequency offset :math:`\Delta\omega`. By contrast, the measured
+    data in the standard Ramsey experiment does not depend on the sign of :math:`\Delta\omega`,
+    i.e. :math:`\cos(-\Delta\omega\tau) = \cos(\Delta\omega\tau)`.
+
+    Note: The experiment allows users to add a small frequency offset to better resolve
+    any oscillations. This is implemented by embedding the circuits shown above in a
+    single gate (:code:`RamseyX` or :code:`RamseyY`) since :code:`pulse.set_frequency`
+    on IBM backends has unexpected behaviour. The circuits that are run are thus
+
+    .. parsed-literal::
+
+                   ┌───────────────┐ ░ ┌─┐
+              q_0: ┤ RamseyX(τ[s]) ├─░─┤M├
+                   └───────────────┘ ░ └╥┘
+        measure: 1/═════════════════════╩═
+                                        0
+
+                   ┌───────────────┐ ░ ┌─┐
+              q_0: ┤ RamseyY(τ[s]) ├─░─┤M├
+                   └───────────────┘ ░ └╥┘
+        measure: 1/═════════════════════╩═
+                                        0
+
+    """
+
+    __analysis_class__ = RamseyXYAnalysis
+
+    @classmethod
+    def _default_experiment_options(cls):
+        """Default values for the Ramsey XY experiment.
+
+        Experiment Options:
+            schedule (ScheduleBlock): The schedule for the sx gate.
+            delays (list): The list of delays that will be scanned in the experiment.
+            unit (str): The unit of the delays. Accepted values are dt, i.e. the
+                duration of a single sample on the backend, seconds, and sub-units,
+                e.g. ms, us, ns.
+            frequency_offset (float): A frequency shift in Hz that will be applied to the
+                schedule to increase the frequency of the measured oscillation.
+        """
+        options = super()._default_experiment_options()
+        options.schedule = None
+        options.delays = np.linspace(0, 1.0e-6, 51)
+        options.unit = "s"
+        options.frequency_offset = 2e6
+        options.sample_multiple = 16
+
+        return options
+
+    def __init__(
+        self,
+        qubit: int,
+        delays: Optional[List] = None,
+        unit: Optional[str] = None,
+        freq_offset: Optional[float] = None,
+    ):
+        """
+        Args:
+            qubit: The qubit on which to run the Ramsey XY experiment.
+            delays: The delays to scan.
+            unit: The unit of the delays.
+            freq_offset: A frequency offset from the qubit's frequency.
+        """
+        super().__init__([qubit])
+
+        if delays is not None:
+            self.experiment_options.delays = delays
+
+        if unit is not None:
+            self.experiment_options.unit = unit
+
+        if freq_offset is not None:
+            self.experiment_options.frequency_offset = freq_offset
+
+    def _pre_circuit(self) -> QuantumCircuit:
+        """Return a preparation circuit.
+
+        This method can be overridden by subclasses e.g. to calibrate schedules on
+        transitions other than the 0 <-> 1 transition.
+        """
+        return QuantumCircuit(1)
+
+    def circuits(self, backend: Optional[Backend] = None) -> List[QuantumCircuit]:
+        """Create the circuits for the Ramsey XY calibration experiment.
+
+        Args:
+            backend: A backend object.
+
+        Returns:
+            A list of circuits with a variable delay.
+        """
+        p_delay = Parameter("delay")
+        unit = self._experiment_options.unit
+
+        # Get the schedule and add a potential frequency shift.
+        schedule = self.experiment_options.schedule
+        d_freq = self.experiment_options.frequency_offset
+
+        with pulse.build(backend=backend, name="RamseyXY_x") as sched_x:
+            with pulse.frequency_offset(d_freq, pulse.drive_channel(self.physical_qubits[0])):
+                pulse.call(schedule)
+                pulse.delay(p_delay, pulse.drive_channel(self.physical_qubits[0]))
+                pulse.call(schedule)
+
+        with pulse.build(backend=backend, name="RamseyXY_y") as sched_y:
+            with pulse.frequency_offset(d_freq, pulse.DriveChannel(self.physical_qubits[0])):
+                pulse.call(schedule)
+                pulse.delay(p_delay, pulse.drive_channel(self.physical_qubits[0]))
+                pulse.shift_phase(-np.pi/2, pulse.drive_channel(self.physical_qubits[0]))
+                pulse.call(schedule)
+
+        # Create the X and Y circuits.
+        ram_x = self._pre_circuit()
+        ram_x.append(Gate("RamseyX", num_qubits=1, params=[p_delay]), (0,))
+        ram_x.measure_active()
+        ram_x.add_calibration("RamseyX", self.physical_qubits, sched_x, params=[p_delay])
+
+        ram_y = self._pre_circuit()
+        ram_y.append(Gate("RamseyY", num_qubits=1, params=[p_delay]), (0,))
+        ram_y.measure_active()
+        ram_y.add_calibration("RamseyY", self.physical_qubits, sched_y, params=[p_delay])
+
+        circs = []
+        for delay in self.experiment_options.delays:
+
+            # format delay to SI unit for analysis
+            if unit == "dt":
+                xval = delay * backend.configuration().dt
+                samples = delay
+            else:
+                if unit == "s":
+                    xval = delay
+                else:
+                    xval = apply_prefix(delay, unit)
+
+                samples = int(xval / backend.configuration().dt)
+
+            if self.experiment_options.sample_multiple:
+                mult = self.experiment_options.sample_multiple
+                samples = int(samples / mult) * mult
+
+            metadata = {
+                "experiment_type": self._type,
+                "qubits": (self.physical_qubits[0], ),
+                "delay": delay,
+                "unit": unit,
+                "xval": xval,
+            }
+
+            # create ramsey x
+            assigned_x = ram_x.assign_parameters({p_delay: samples}, inplace=False)
+            assigned_x.metadata = metadata.copy()
+            assigned_x.metadata["series"] = "X"
+
+            # create ramsey y
+            assigned_y = ram_y.assign_parameters({p_delay: samples}, inplace=False)
+            assigned_y.metadata = metadata.copy()
+            assigned_y.metadata["series"] = "Y"
+
+            circs.extend([assigned_x, assigned_y])
+
+        return circs

--- a/qiskit_experiments/library/calibration/remsey_xy.py
+++ b/qiskit_experiments/library/calibration/remsey_xy.py
@@ -28,70 +28,72 @@ from qiskit_experiments.library.calibration.analysis.remsey_xy_analysis import R
 class RamseyXY(BaseExperiment):
     r"""Ramsey XY experiment to measure the frequency of a qubit.
 
-    This experiment differs from the :class:`~qiskit_experiments.characterization.\
-    t2ramsey.T2Ramsey` since it is sensitive to the sign of frequency offset from the main transition.
-    This experiment consists of following two circuits:
+    # section: overview
 
-    .. parsed-literal::
+        This experiment differs from the :class:`~qiskit_experiments.characterization.\
+        t2ramsey.T2Ramsey` since it is sensitive to the sign of frequency offset from the main
+        transition. This experiment consists of following two circuits:
 
-        (Ramsey X) The second pulse rotates by pi-half around the X axis
+        .. parsed-literal::
 
-                   ┌────┐┌─────────────┐┌────┐ ░ ┌─┐
-              q_0: ┤ √X ├┤ Delay(τ[s]) ├┤ √X ├─░─┤M├
-                   └────┘└─────────────┘└────┘ ░ └╥┘
-        measure: 1/═══════════════════════════════╩═
-                                                  0
+            (Ramsey X) The second pulse rotates by pi-half around the X axis
 
-        (Ramsey Y) The second pulse rotates by pi-half around the Y axis
+                       ┌────┐┌─────────────┐┌────┐ ░ ┌─┐
+                  q_0: ┤ √X ├┤ Delay(τ[s]) ├┤ √X ├─░─┤M├
+                       └────┘└─────────────┘└────┘ ░ └╥┘
+            measure: 1/═══════════════════════════════╩═
+                                                      0
 
-                   ┌────┐┌─────────────┐┌──────────┐┌────┐ ░ ┌─┐
-              q_0: ┤ √X ├┤ Delay(τ[s]) ├┤ Rz(-π/2) ├┤ √X ├─░─┤M├
-                   └────┘└─────────────┘└──────────┘└────┘ ░ └╥┘
-        measure: 1/═══════════════════════════════════════════╩═
-                                                              0
+            (Ramsey Y) The second pulse rotates by pi-half around the Y axis
 
-    The first and second circuits measure the expectation value along the X and Y axis,
-    respectively. This experiment therefore draws the dynamics of the Bloch vector as a
-    Lissajous figure. Since the control electronics tracks the frame of qubit at the
-    reference frequency, which differs from the true qubit frequency by :math:`\Delta\omega`,
-    we can describe the dynamics of two circuits as follows. The Hamiltonian during the
-    ``Delay`` instruction is :math:`H^R = - \frac{1}{2} \Delta\omega` in the rotating frame,
-    and the propagator will be :math:`U(\tau) = \exp(-iH^R\tau)` where :math:`\tau` is the
-    duration of the delay. By scanning this duration, we can get
+                       ┌────┐┌─────────────┐┌──────────┐┌────┐ ░ ┌─┐
+                  q_0: ┤ √X ├┤ Delay(τ[s]) ├┤ Rz(-π/2) ├┤ √X ├─░─┤M├
+                       └────┘└─────────────┘└──────────┘└────┘ ░ └╥┘
+            measure: 1/═══════════════════════════════════════════╩═
+                                                                  0
 
-    .. math::
+        The first and second circuits measure the expectation value along the X and Y axis,
+        respectively. This experiment therefore draws the dynamics of the Bloch vector as a
+        Lissajous figure. Since the control electronics tracks the frame of qubit at the
+        reference frequency, which differs from the true qubit frequency by :math:`\Delta\omega`,
+        we can describe the dynamics of two circuits as follows. The Hamiltonian during the
+        ``Delay`` instruction is :math:`H^R = - \frac{1}{2} \Delta\omega` in the rotating frame,
+        and the propagator will be :math:`U(\tau) = \exp(-iH^R\tau)` where :math:`\tau` is the
+        duration of the delay. By scanning this duration, we can get
 
-        {\cal E}_x(\tau)
-            = {\rm Re} {\rm Tr}\left( Y U \rho U^\dagger \right)
-            &= - \cos(\Delta\omega\tau) = \sin(\Delta\omega\tau - \frac{\pi}{2}), \\
-        {\cal E}_y(\tau)
-            = {\rm Re} {\rm Tr}\left( X U \rho U^\dagger \right)
-            &= \sin(\Delta\omega\tau),
+        .. math::
 
-    where :math:`\rho` is prepared by the first :math:`\sqrt{\rm X}` gate. Note that phase
-    difference of these two outcomes :math:`{\cal E}_x, {\cal E}_y` depends on the sign and
-    the magnitude of the frequency offset :math:`\Delta\omega`. By contrast, the measured
-    data in the standard Ramsey experiment does not depend on the sign of :math:`\Delta\omega`,
-    i.e. :math:`\cos(-\Delta\omega\tau) = \cos(\Delta\omega\tau)`.
+            {\cal E}_x(\tau)
+                = {\rm Re} {\rm Tr}\left( Y U \rho U^\dagger \right)
+                &= - \cos(\Delta\omega\tau) = \sin(\Delta\omega\tau - \frac{\pi}{2}), \\
+            {\cal E}_y(\tau)
+                = {\rm Re} {\rm Tr}\left( X U \rho U^\dagger \right)
+                &= \sin(\Delta\omega\tau),
 
-    Note: The experiment allows users to add a small frequency offset to better resolve
-    any oscillations. This is implemented by embedding the circuits shown above in a
-    single gate (:code:`RamseyX` or :code:`RamseyY`) since :code:`pulse.set_frequency`
-    on IBM backends has unexpected behaviour. The circuits that are run are thus
+        where :math:`\rho` is prepared by the first :math:`\sqrt{\rm X}` gate. Note that phase
+        difference of these two outcomes :math:`{\cal E}_x, {\cal E}_y` depends on the sign and
+        the magnitude of the frequency offset :math:`\Delta\omega`. By contrast, the measured
+        data in the standard Ramsey experiment does not depend on the sign of :math:`\Delta\omega`,
+        i.e. :math:`\cos(-\Delta\omega\tau) = \cos(\Delta\omega\tau)`.
 
-    .. parsed-literal::
+        Note: The experiment allows users to add a small frequency offset to better resolve
+        any oscillations. This is implemented by embedding the circuits shown above in a
+        single gate (:code:`RamseyX` or :code:`RamseyY`) since :code:`pulse.set_frequency`
+        on IBM backends has unexpected behaviour. The circuits that are run are thus
 
-                   ┌───────────────┐ ░ ┌─┐
-              q_0: ┤ RamseyX(τ[s]) ├─░─┤M├
-                   └───────────────┘ ░ └╥┘
-        measure: 1/═════════════════════╩═
-                                        0
+        .. parsed-literal::
 
-                   ┌───────────────┐ ░ ┌─┐
-              q_0: ┤ RamseyY(τ[s]) ├─░─┤M├
-                   └───────────────┘ ░ └╥┘
-        measure: 1/═════════════════════╩═
-                                        0
+                       ┌───────────────┐ ░ ┌─┐
+                  q_0: ┤ RamseyX(τ[s]) ├─░─┤M├
+                       └───────────────┘ ░ └╥┘
+            measure: 1/═════════════════════╩═
+                                            0
+
+                       ┌───────────────┐ ░ ┌─┐
+                  q_0: ┤ RamseyY(τ[s]) ├─░─┤M├
+                       └───────────────┘ ░ └╥┘
+            measure: 1/═════════════════════╩═
+                                            0
 
     """
 

--- a/qiskit_experiments/library/calibration/remsey_xy.py
+++ b/qiskit_experiments/library/calibration/remsey_xy.py
@@ -154,7 +154,7 @@ class RamseyXY(BaseExperiment):
                     "Dt parameter is missing from the backend's configuration."
                 ) from no_dt
 
-        else:
+        elif self.experiment_options.unit != "s":
             conversion_factor = apply_prefix(1, self.experiment_options.unit)
 
         # Compute the rz rotation angle to add a modulation.

--- a/qiskit_experiments/library/calibration/remsey_xy.py
+++ b/qiskit_experiments/library/calibration/remsey_xy.py
@@ -26,7 +26,7 @@ from qiskit_experiments.library.calibration.analysis.remsey_xy_analysis import R
 
 
 class RamseyXY(BaseExperiment):
-    """Ramsey XY experiment to measure the frequency of a qubit.
+    r"""Ramsey XY experiment to measure the frequency of a qubit.
 
     This experiment differs from the :class:`~qiskit_experiments.characterization.\
     t2ramsey.T2Ramsey` since it is sensitive to the sign of frequency offset from the main transition.
@@ -178,7 +178,7 @@ class RamseyXY(BaseExperiment):
             with pulse.frequency_offset(d_freq, pulse.DriveChannel(self.physical_qubits[0])):
                 pulse.call(schedule)
                 pulse.delay(p_delay, pulse.drive_channel(self.physical_qubits[0]))
-                pulse.shift_phase(-np.pi/2, pulse.drive_channel(self.physical_qubits[0]))
+                pulse.shift_phase(-np.pi / 2, pulse.drive_channel(self.physical_qubits[0]))
                 pulse.call(schedule)
 
         # Create the X and Y circuits.
@@ -213,7 +213,7 @@ class RamseyXY(BaseExperiment):
 
             metadata = {
                 "experiment_type": self._type,
-                "qubits": (self.physical_qubits[0], ),
+                "qubits": (self.physical_qubits[0],),
                 "delay": delay,
                 "unit": unit,
                 "xval": xval,

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -92,7 +92,6 @@ class T2Ramsey(BaseExperiment):
                 used for both T2Ramsey and for the frequency.
             osc_freq: the oscillation frequency induced by the user. \
             The frequency is given in Hz.
-            experiment_type: String indicating the experiment type.
 
         """
 
@@ -114,15 +113,14 @@ class T2Ramsey(BaseExperiment):
         Raises:
             AttributeError: if unit is 'dt', but 'dt' parameter is missing in the backend configuration.
         """
-        conversion_factor = 1
         if self.experiment_options.unit == "dt":
             try:
                 dt_factor = getattr(backend._configuration, "dt")
                 conversion_factor = dt_factor
             except AttributeError as no_dt:
                 raise AttributeError("Dt parameter is missing in backend configuration") from no_dt
-        elif self.experiment_options.unit != "s":
-            apply_prefix(1, self.experiment_options.unit)
+        else:
+            conversion_factor = apply_prefix(1, self.experiment_options.unit)
 
         circuits = []
         for delay in self.experiment_options.delays:

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -113,6 +113,7 @@ class T2Ramsey(BaseExperiment):
         Raises:
             AttributeError: if unit is 'dt', but 'dt' parameter is missing in the backend configuration.
         """
+        conversion_factor = 1
         if self.experiment_options.unit == "dt":
             try:
                 dt_factor = getattr(backend._configuration, "dt")

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -119,7 +119,7 @@ class T2Ramsey(BaseExperiment):
                 conversion_factor = dt_factor
             except AttributeError as no_dt:
                 raise AttributeError("Dt parameter is missing in backend configuration") from no_dt
-        else:
+        elif self.experiment_options.unit != "s":
             conversion_factor = apply_prefix(1, self.experiment_options.unit)
 
         circuits = []

--- a/qiskit_experiments/test/mock_iq_backend.py
+++ b/qiskit_experiments/test/mock_iq_backend.py
@@ -201,4 +201,4 @@ class MockRamseyXY(MockIQBackend):
         else:
             phase_offset = np.pi / 2
 
-        return 0.5*np.cos(2*np.pi*delay*self.freq_shift - phase_offset) + 0.5
+        return 0.5 * np.cos(2 * np.pi * delay * self.freq_shift - phase_offset) + 0.5

--- a/qiskit_experiments/test/mock_iq_backend.py
+++ b/qiskit_experiments/test/mock_iq_backend.py
@@ -181,3 +181,24 @@ class MockFineAmp(MockIQBackend):
         angle += np.pi * n_x_ops
 
         return np.sin(angle / 2) ** 2
+
+
+class MockRamseyXY(MockIQBackend):
+    """A mock backend for the RamseyXY experiment."""
+
+    def __init__(self, freq_shift: float):
+        super().__init__()
+        self.freq_shift = freq_shift
+
+    def _compute_probability(self, circuit: QuantumCircuit) -> float:
+        """Return the probability of the circuit."""
+
+        series = circuit.metadata["series"]
+        delay = circuit.metadata["xval"]
+
+        if series == "X":
+            phase_offset = 0.0
+        else:
+            phase_offset = np.pi / 2
+
+        return 0.5*np.cos(2*np.pi*delay*self.freq_shift - phase_offset) + 0.5

--- a/test/calibration/experiments/test_ramsey_xy.py
+++ b/test/calibration/experiments/test_ramsey_xy.py
@@ -1,0 +1,39 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test Ramsey XY calibration experiment."""
+
+from qiskit.test import QiskitTestCase
+import qiskit.pulse as pulse
+
+from qiskit_experiments.library import RamseyXY
+from qiskit_experiments.test.mock_iq_backend import MockRamseyXY
+
+
+class TestRamseyXY(QiskitTestCase):
+    """Tests for the Ramsey XY experiment."""
+
+    def test_end_to_end(self):
+        """Test that we can run on a mock backend and perform a fit.
+
+        This test also checks that we can pickup frequency shifts with different signs.
+        """
+
+        test_tol = 0.01
+
+        ramsey = RamseyXY(0)
+        ramsey.set_experiment_options(schedule=pulse.ScheduleBlock())
+
+        for freq_shift in [2e6, -3e6]:
+            test_data = ramsey.run(MockRamseyXY(freq_shift=freq_shift)).block_for_results()
+            meas_shift = test_data.analysis_results(1).value.value
+            self.assertTrue((meas_shift - freq_shift) < abs(test_tol * freq_shift))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR implements a Ramsey XY calibration experiment to measure the qubit frequency.
This PR replaces #165

### Details and comments

Note that to better resolve the oscillations when close to resonance the user can add a frequency offset. For this reason the gates are embedded in a single schedule since `pulse.set_frequency` has unexpected behavior. The experiment can be run by doing
```
qubit = 1
sx = backend.defaults().instruction_schedule_map.get("sx", qubit)

ramsey = RamseyXY(qubit)
ramsey.set_experiment_options(schedule=sx)

exp_data = ramsey.run(backend).block_for_results()
```
