### PR TITLE
Remove analysis run options

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -179,10 +179,13 @@ class BaseExperiment(ABC):
         Raises:
             QiskitError: if experiment_data container is not valid for analysis.
         """
+        # Get analysis options
+        analysis_options = copy.copy(self.analysis_options)
+        analysis_options = analysis_options.__dict__
 
         # Run analysis
         analysis = self.analysis()
-        analysis.run(experiment_data, **self.analysis_options)
+        analysis.run(experiment_data, **analysis_options)
         return experiment_data
 
     @property

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -167,14 +167,11 @@ class BaseExperiment(ABC):
 
         return experiment_data._copy_metadata()
 
-    def run_analysis(self, experiment_data, **options) -> ExperimentData:
+    def run_analysis(self, experiment_data) -> ExperimentData:
         """Run analysis and update ExperimentData with analysis result.
 
         Args:
             experiment_data (ExperimentData): the experiment data to analyze.
-            options: additional analysis options. Any values set here will
-                     override the value from :meth:`analysis_options`
-                     for the current run.
 
         Returns:
             An experiment data object containing the analysis results and figures.
@@ -182,14 +179,10 @@ class BaseExperiment(ABC):
         Raises:
             QiskitError: if experiment_data container is not valid for analysis.
         """
-        # Get analysis options
-        analysis_options = copy.copy(self.analysis_options)
-        analysis_options.update_options(**options)
-        analysis_options = analysis_options.__dict__
 
         # Run analysis
         analysis = self.analysis()
-        analysis.run(experiment_data, **analysis_options)
+        analysis.run(experiment_data, **self.analysis_options)
         return experiment_data
 
     @property


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR addresses #120 .

Since analysis options are set in the experiment metadata, running `run_analyis` with new analysis options will result in those new options conflicting with the existing ones. To avoid this, adding options via the `run_analysis` method is disabled; `run_analysis` will use the options given when creating the experiment.


### Details and comments


