### PR TITLE
[WIP} enable resonator as target device component

### DIFF
--- a/qiskit_experiments/framework/base_analysis.py
+++ b/qiskit_experiments/framework/base_analysis.py
@@ -18,7 +18,7 @@ from typing import List, Tuple
 
 from qiskit.exceptions import QiskitError
 
-from qiskit_experiments.database_service.device_component import Qubit
+from qiskit_experiments.database_service.device_component import Qubit, Resonator
 from qiskit_experiments.framework import Options
 from qiskit_experiments.framework.experiment_data import ExperimentData
 from qiskit_experiments.framework.analysis_result_data import AnalysisResultData
@@ -73,12 +73,16 @@ class BaseAnalysis(ABC):
             )
 
         # Get experiment device components
+        experiment_components = []
         if "physical_qubits" in experiment_data.metadata:
             experiment_components = [
                 Qubit(qubit) for qubit in experiment_data.metadata["physical_qubits"]
-            ]
-        else:
-            experiment_components = []
+                ]
+        if "resonators" in experiment_data.metadata:
+            experiment_components.extend([
+                Resonator(resonator) for resonator in experiment_data.metadata["resonators"]
+            ])
+
 
         # Get analysis options
         analysis_options = self._default_options()

--- a/test/fake_resonator_experiment.py
+++ b/test/fake_resonator_experiment.py
@@ -1,0 +1,56 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Fake experiment using resonator instead of qubits for testing."""
+
+from typing import Iterable, Optional, Tuple, List, Dict
+from qiskit_experiments.framework import BaseExperiment, Options, BaseAnalysis, AnalysisResultData
+
+from qiskit.providers import Backend
+from qiskit.circuit import QuantumCircuit
+
+class FakeResonatorAnalysis(BaseAnalysis):
+    # pylint: disable=arguments-differ
+    def _run_analysis(
+            self,
+            experiment_data,
+    ) -> Tuple[List[AnalysisResultData], List["matplotlib.figure.Figure"]]:
+        return [], None
+
+
+class FakeResonatorExperiment(BaseExperiment):
+    """
+    An experiment to show how to use resonators instead of qubits
+    """
+
+    @classmethod
+    def _default_experiment_options(cls) -> Options:
+        """
+        Add resonators to the experiment options
+        """
+        options = super()._default_experiment_options()
+        options.resonators = []
+        return options
+
+    def __init__(
+            self,
+            resonators: Iterable[int]):
+        super().__init__([])
+
+        # Set experiment options
+        self.set_experiment_options(resonators=resonators)
+
+    def circuits(self, backend: Optional[Backend] = None):
+        circ = QuantumCircuit(1, 1)
+        circ.measure(0, 0)
+
+        return [circ]


### PR DESCRIPTION
### Summary
fixing bug in #171 :
fixing the option to create an experiment with resonator as target device along with qubits (or instead of qubits).

### Details and comments
the experiment should include "resonators" in the experiment options to specify the relevant resonators. if there are no qubits as target components, the qubits filed which every experiment has should contain 0 (as int and not as list [0] ).

testing is not complete yet.

