### PR TITLE
Add missing __init__.py to make qiskit_experiments.test importable

### DIFF
--- a/docs/apidocs/index.rst
+++ b/docs/apidocs/index.rst
@@ -17,6 +17,7 @@ Package Modules
     curve_analysis
     calibration_management
     database_service
+    test
 
 Experiment Modules
 ==================

--- a/docs/apidocs/test.rst
+++ b/docs/apidocs/test.rst
@@ -1,0 +1,6 @@
+.. _qiskit-experiments-test:
+
+.. automodule:: qiskit_experiments.test
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/qiskit_experiments/test/__init__.py
+++ b/qiskit_experiments/test/__init__.py
@@ -1,0 +1,41 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+=================================================================
+Qiskit Experiments Test Utilties (:mod:`qiskit_experiments.test`)
+=================================================================
+
+.. currentmodule:: qiskit_experiments.test
+
+This module contains classes and functions that are used to enable testing
+of Qiskit Experiments. It's primarily composed of fake and mock backends that
+act like a normal :class:`~qiskit.providers.BackendV1` for a real device but
+instead call a simulator internally.
+
+.. autosummary::
+    :toctree: ../stubs/
+
+    MockIQBackend
+    MockRamseyXY
+    MockFineAmp
+    DragBackend
+    T1Backend
+    T2RamseyBackend
+    FakeJob
+
+"""
+
+from .utils import FakeJob
+from .mock_iq_backend import MockIQBackend, MockRamseyXY, MockFineAmp, DragBackend
+from .t1_backend import T1Backend
+from .t2ramsey_backend import T2RamseyBackend

--- a/qiskit_experiments/test/mock_iq_backend.py
+++ b/qiskit_experiments/test/mock_iq_backend.py
@@ -153,6 +153,8 @@ class DragBackend(MockIQBackend):
 
 
 class MockFineAmp(MockIQBackend):
+    """A mock backend for fine amplitude calibration."""
+
     def __init__(self, angle_error: float, angle_per_gate: float, gate_name: str):
         """Setup a mock backend to test the fine amplitude calibration.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a packaging issue with the qiskit_experiments.test
package. It was missing it's __init__.py file meaning it wasn't a valid
python package and couldn't be imported when install from a a package.
This wasn't caught in CI because we have it locally and the path is
found in the git tree. This commit adds the missing file to fix this
and adds it to the documentation so there are docs available for the
packaged test module.

### Details and comments

Fixes #393
