### PR TITLE
[WIP] Rework experiment data callbacks for running analysis

### DIFF
--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -64,9 +64,9 @@ class CompositeExperiment(BaseExperiment):
         """Return the component experiment Analysis object"""
         return self.component_experiment(index).analysis()
 
-    def _add_job_metadata(self, experiment_data, job, **run_options):
+    def _add_job_metadata(self, experiment_data, jobs, **run_options):
         # Add composite metadata
-        super()._add_job_metadata(experiment_data, job, **run_options)
+        super()._add_job_metadata(experiment_data, jobs, **run_options)
 
         # Add sub-experiment options
         for i in range(self.num_experiments):
@@ -83,7 +83,7 @@ class CompositeExperiment(BaseExperiment):
                     " are overridden by composite experiment options."
                 )
             sub_data = experiment_data.component_experiment_data(i)
-            sub_exp._add_job_metadata(sub_data, job, **run_options)
+            sub_exp._add_job_metadata(sub_data, jobs, **run_options)
 
     def _postprocess_transpiled_circuits(self, circuits, backend, **run_options):
         for expr in self._experiments:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR attempts to rework the ExperimentData class so that data processing callbacks can be added to the job future objects using a separate method `add_processing_callback` that uses the `add_done_callback` method of the Python Future API. 

It also combines multiple jobs added together in a single `add_data` call into a single future object, this is necessary to support job splitting for backends that have a maximum number of circuits per job that is less than the number of circuits generated by experiments.

Splitting an experiment with large numbers of circuits into multiple jobs is also implemented in this PR.

### Details and comments

The `run_analysis` method for BaseExperiment uses this new callback function. The goal of this is that calling `run_analysis` will not require blocking on results to work correctly so that the follwoing should be equivalent:
```python
expdata = exp.run(backend)
```

```python
expdata = exp.run(backend, analysis=False)
exp.run_analysis(exp_data)
```

These changes seem to work correctly for most experiments except the recently added CR Hamiltonian tomography one (which im not sure why only it seems to fail), and the result DB tests which explicitly use the old callback API which are all failling (and im not exactly sure how they should be updated at the moment).

I would like to get feedback on this approach before going any further with trying to fix the tests.