### PR TITLE
[WIP] add parent_id support

### DIFF
--- a/qiskit_experiments/database_service/database_service.py
+++ b/qiskit_experiments/database_service/database_service.py
@@ -54,6 +54,7 @@ class DatabaseServiceV1(DatabaseService, ABC):
         backend_name: str,
         metadata: Optional[Dict] = None,
         experiment_id: Optional[str] = None,
+        parent_id: Optional[str] = None,
         job_ids: Optional[List[str]] = None,
         tags: Optional[List[str]] = None,
         notes: Optional[str] = None,
@@ -68,6 +69,9 @@ class DatabaseServiceV1(DatabaseService, ABC):
             metadata: Experiment metadata.
             experiment_id: Experiment ID. It must be in the ``uuid4`` format.
                 One will be generated if not supplied.
+            parent_id: The experiment ID of the parent experiment.
+                The parent experiment must exist, must be on the same backend as the child,
+                and an experiment cannot be its own parent.
             job_ids: IDs of experiment jobs.
             tags: Tags to be associated with the experiment.
             notes: Freeform notes about the experiment.
@@ -134,6 +138,7 @@ class DatabaseServiceV1(DatabaseService, ABC):
         experiment_type: Optional[str] = None,
         backend_name: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        parent_id: Optional[str] = None,
         tags_operator: Optional[str] = "OR",
         **filters: Any,
     ) -> List[Dict]:
@@ -148,6 +153,7 @@ class DatabaseServiceV1(DatabaseService, ABC):
             backend_name: Backend name used for filtering.
             tags: Filter by tags assigned to experiments. This can be used
                 with `tags_operator` for granular filtering.
+            parent_id: Filter by parent experiment ID.
             tags_operator: Logical operator to use when filtering by tags. Valid
                 values are "AND" and "OR":
 

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -99,6 +99,7 @@ class DbExperimentDataV1(DbExperimentData):
         experiment_type: Optional[str] = "Unknown",
         backend: Optional[Union[Backend, BaseBackend]] = None,
         experiment_id: Optional[str] = None,
+        parent_id: Optional[str] = None,
         tags: Optional[List[str]] = None,
         job_ids: Optional[List[str]] = None,
         share_level: Optional[str] = None,
@@ -113,6 +114,7 @@ class DbExperimentDataV1(DbExperimentData):
             experiment_type: Experiment type.
             backend: Backend the experiment runs on.
             experiment_id: Experiment ID. One will be generated if not supplied.
+            parent_id: The experiment ID of the parent experiment.
             tags: Tags to be associated with the experiment.
             job_ids: IDs of jobs submitted for the experiment.
             share_level: Whether this experiment can be shared with others. This
@@ -140,6 +142,7 @@ class DbExperimentDataV1(DbExperimentData):
         self._set_service_from_backend(backend)
 
         self._id = experiment_id or str(uuid.uuid4())
+        self._parent_id = parent_id
         self._type = experiment_type
         self._tags = tags or []
         self._share_level = share_level
@@ -792,6 +795,7 @@ class DbExperimentDataV1(DbExperimentData):
             experiment_type=service_data.pop("experiment_type"),
             backend=service_data.pop("backend"),
             experiment_id=service_data.pop("experiment_id"),
+            parent_id=service_data.pop("parent_id"),
             tags=service_data.pop("tags"),
             job_ids=service_data.pop("job_ids"),
             share_level=service_data.pop("share_level"),
@@ -1141,6 +1145,8 @@ class DbExperimentDataV1(DbExperimentData):
     def __repr__(self):
         out = f"{type(self).__name__}({self.experiment_type}"
         out += f", {self.experiment_id}"
+        if self._parent_id:
+            out += f", parent_id={self._parent_id}"
         if self._tags:
             out += f", tags={self._tags}"
         if self.job_ids:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

[Issue](https://github.ibm.com/IBM-Q-Software/provider-planning/issues/17)
Parent ID support was recently added [here](https://github.com/Qiskit-Partners/qiskit-ibm/pull/105) to support parent-child relationships. 

`qiskit-experiments` should be able to use this new feature inside `database_service` and `db_experiment_data`

### Details and comments


