### PR TITLE
Fix curve analysis error handling

### DIFF
--- a/qiskit_experiments/curve_analysis/curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis.py
@@ -915,9 +915,8 @@ class CurveAnalysis(BaseAnalysis, ABC):
                 )
                 fit_results.append(fit_result)
             except AnalysisError:
-                # some guess might be completely off from true parameters.
-                # even if some attempts fail, we just ignore that result and continue
-                # as long as we have more fit option candidates.
+                # Some guesses might be too far from the true parameters and may thus fail.
+                # We ignore initial guesses that fail and continue with the next fit candidate.
                 pass
 
         # Find best value with chi-squared value


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Curve analysis can take multiple guesses and it tries fitting for all provided guesses and find the best result based on chisq value. However, in the current implementation, all provided guesses should pass the fit otherwise the fit loop is immediately terminated. 

This PR changes error handling so that it just ignores the result with wrong parameter estimation, and continues the fit with the rest of guesses.

### Details and comments


