### PR TITLE
FineAmp without schedules

### DIFF
--- a/qiskit_experiments/test/mock_iq_backend.py
+++ b/qiskit_experiments/test/mock_iq_backend.py
@@ -176,13 +176,13 @@ class MockFineAmp(MockIQBackend):
         """Return the probability of being in the excited state."""
 
         n_ops = circuit.count_ops().get(self._gate_name, 0)
-        n_sx_ops = circuit.count_ops().get("sx", 0)
-        n_x_ops = circuit.count_ops().get("x", 0)
-
         angle = n_ops * (self._angle_per_gate + self.angle_error)
 
-        angle += np.pi / 2 * n_sx_ops
-        angle += np.pi * n_x_ops
+        if self._gate_name != "sx":
+            angle += np.pi / 2 * circuit.count_ops().get("sx", 0)
+
+        if self._gate_name != "x":
+            angle += np.pi * circuit.count_ops().get("x", 0)
 
         return np.sin(angle / 2) ** 2
 

--- a/test/calibration/experiments/test_fine_amplitude.py
+++ b/test/calibration/experiments/test_fine_amplitude.py
@@ -153,3 +153,21 @@ class TestSpecializations(QiskitTestCase):
         self.assertEqual(exp.experiment_options.repetitions, expected)
         self.assertEqual(exp.analysis_options.angle_per_gate, np.pi / 2)
         self.assertEqual(exp.analysis_options.phase_offset, 0)
+
+    def test_end_to_end_no_schedule(self):
+        """Test the experiment end to end."""
+
+        amp_cal = FineXAmplitude(0)
+        amp_cal.set_analysis_options(number_guesses=11)
+
+        backend = MockFineAmp(-np.pi * 0.07, np.pi, "x")
+
+        expdata = amp_cal.run(backend).block_for_results()
+        result = expdata.analysis_results(1)
+        d_theta = result.value.value
+
+        tol = 0.04
+
+        self.assertTrue(abs(d_theta - backend.angle_error) < tol)
+        self.assertEqual(result.quality, "good")
+        self.assertIsNone(amp_cal.experiment_options.schedule)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR enables the fine amplitude experiments to run without a schedule.

### Details and comments

This is achieved by adding a `gate_type` option in the experiment. The `FineXAmplitude` and `FineSXAmplitude` specializations use the `XGate` and the `SXGate` respectively.
