### PR TITLE
Loading bug fix

### DIFF
--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -1063,7 +1063,13 @@ class Calibrations:
                 param_val = ParameterValue(
                     row["value"], row["date_time"], row["valid"], row["exp_id"], row["group"]
                 )
-                key = ParameterKey(row["parameter"], self._to_tuple(row["qubits"]), row["schedule"])
+
+                if row["schedule"] == "":
+                    schedule_name = None
+                else:
+                    schedule_name = row["schedule"]
+
+                key = ParameterKey(row["parameter"], self._to_tuple(row["qubits"]), schedule_name)
                 self.add_parameter_value(param_val, *key)
 
     @classmethod


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

A previous PR introduced a bug in calibration parameter loading. A `None` schedule results in `""` in the csv files which is then interpreted as a schedule with the name `""` instead of None. 

### Details and comments

This bug fix introduces the required fix and test.

