### PR TITLE
Pass jobs to sub-experiments

### DIFF
--- a/qiskit_experiments/framework/composite/composite_experiment_data.py
+++ b/qiskit_experiments/framework/composite/composite_experiment_data.py
@@ -39,7 +39,9 @@ class CompositeExperimentData(ExperimentData):
 
         # Initialize sub experiments
         self._components = [
-            expr.__experiment_data__(expr, backend=backend, parent_id=self.experiment_id)
+            expr.__experiment_data__(
+                expr, backend=backend, parent_id=self.experiment_id, job_ids=job_ids
+            )
             for expr in experiment._experiments
         ]
 
@@ -82,7 +84,7 @@ class CompositeExperimentData(ExperimentData):
         metadata = data.get("metadata", {})
         if metadata.get("experiment_type") == self._type:
 
-            # Add parallel data
+            # Add composite data
             self._data.append(data)
 
             # Add marginalized data to sub experiments
@@ -97,6 +99,8 @@ class CompositeExperimentData(ExperimentData):
                         sub_data["counts"] = marginal_counts(data["counts"], composite_clbits[i])
                     else:
                         sub_data["counts"] = data["counts"]
+
+                self._components[index]._jobs = self._jobs
                 self._components[index]._add_single_data(sub_data)
 
     def save(self) -> None:

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -269,6 +269,7 @@ class TestCompositeExperimentData(QiskitTestCase):
 
         self.backend = FakeMelbourne()
         self.share_level = "hey"
+        self.job_ids = ["1", "2"]
 
         exp1 = FakeExperiment([0, 2])
         exp2 = FakeExperiment([1, 3])
@@ -276,7 +277,9 @@ class TestCompositeExperimentData(QiskitTestCase):
         exp3 = FakeExperiment(4)
         batch_exp = BatchExperiment([par_exp, exp3])
 
-        self.rootdata = CompositeExperimentData(batch_exp, backend=self.backend)
+        self.rootdata = CompositeExperimentData(
+            batch_exp, backend=self.backend, job_ids=self.job_ids
+        )
 
         self.rootdata.share_level = self.share_level
 
@@ -286,6 +289,7 @@ class TestCompositeExperimentData(QiskitTestCase):
         """
         self.assertEqual(expdata.backend, self.backend)
         self.assertEqual(expdata.share_level, self.share_level)
+        self.assertEqual(expdata.job_ids, self.job_ids)
 
         if isinstance(expdata, CompositeExperimentData):
             components = expdata.component_experiment_data()
@@ -305,6 +309,7 @@ class TestCompositeExperimentData(QiskitTestCase):
         self.assertEqual(expdata1.tags, expdata2.tags)
         self.assertEqual(expdata1.experiment_type, expdata2.experiment_type)
         self.assertEqual(expdata1.share_level, expdata2.share_level)
+        self.assertEqual(expdata1.job_ids, expdata2.job_ids)
 
         metadata1 = copy.copy(expdata1.metadata)
         metadata2 = copy.copy(expdata2.metadata)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Sub-experiments should have the same jobs as their parent.

### Details and comments

A few comments:
1. Frankly I don't really mind about the jobs, I only mind about the job ids, because in the results db I want the sub-experiment's "related jobs" rubric to be populated.
2. For the sake of the job ids I need to pass the jobs, but not the job futures. Is there nevertheless a reason to pass the futures as well?
3. This PR in fact consists of two different changes: a `job_ids` parameter in `CompositeExperimentData.__init__`, and updating sub-experiment jobs in `_add_single_data`. Only the change in `_add_single_data` is related to the issue with the results db. However only the change in the constructor is being tested in the test.


