### PR TITLE
Update ``ExperimentData.analysis_results`` to be blocking by default

### DIFF
--- a/qiskit_experiments/calibration_management/update_library.py
+++ b/qiskit_experiments/calibration_management/update_library.py
@@ -129,7 +129,7 @@ class BaseUpdater(ABC):
     @staticmethod
     def get_value(exp_data: ExperimentData, param_name: str, index: Optional[int] = -1) -> float:
         """A helper method to extract values from experiment data instances."""
-        candidates = exp_data.analysis_results(param_name)
+        candidates = exp_data.analysis_results(param_name, block=False)
         if isinstance(candidates, list):
             return candidates[index].value.value
         else:

--- a/qiskit_experiments/calibration_management/update_library.py
+++ b/qiskit_experiments/calibration_management/update_library.py
@@ -129,6 +129,8 @@ class BaseUpdater(ABC):
     @staticmethod
     def get_value(exp_data: ExperimentData, param_name: str, index: Optional[int] = -1) -> float:
         """A helper method to extract values from experiment data instances."""
+        # Because this is called within analysis callbacks the block=False kwarg
+        # must be passed to analysis results so we don't block indefinitely
         candidates = exp_data.analysis_results(param_name, block=False)
         if isinstance(candidates, list):
             return candidates[index].value.value

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -699,7 +699,7 @@ class DbExperimentDataV1(DbExperimentData):
             refresh: Retrieve the latest analysis results from the server, if
                 an experiment service is available.
             block: If True block for any analysis callbacks to finish running.
-            timeout: max time to wait for analysis callbacks to finish running.
+            timeout: max time in seconds to wait for analysis callbacks to finish running.
 
         Returns:
             Analysis results for this experiment.

--- a/qiskit_experiments/framework/composite/composite_analysis.py
+++ b/qiskit_experiments/framework/composite/composite_analysis.py
@@ -112,6 +112,14 @@ class CompositeAnalysis(BaseAnalysis):
             )
             analysis_results.append(result)
 
+        # Add callback to wait for all component analysis to finish before returning
+        # the parent experiment analysis results
+        def _wait_for_components(experiment_data, component_ids):
+            for comp_id in component_ids:
+                experiment_data.child_data(comp_id).block_for_results()
+
+        experiment_data.add_analysis_callback(_wait_for_components, component_ids=component_ids)
+
         return analysis_results, []
 
     def _initialize_components(self, experiment, experiment_data):

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -23,7 +23,7 @@ from qiskit_experiments.database_service import DbExperimentDataV1 as DbExperime
 from qiskit_experiments.database_service.database_service import (
     DatabaseServiceV1 as DatabaseService,
 )
-from qiskit_experiments.database_service.utils import ThreadSafeOrderedDict, combined_timeout
+from qiskit_experiments.database_service.utils import ThreadSafeOrderedDict
 
 LOG = logging.getLogger(__name__)
 
@@ -214,20 +214,6 @@ class ExperimentData(DbExperimentData):
             data.auto_save = original_auto_save
         if self.auto_save:
             self.save_metadata()
-
-    def block_for_results(self, timeout: Optional[float] = None) -> ExperimentData:
-        """Block until all pending jobs and analysis callbacks finish.
-
-        Args:
-            timeout: Timeout waiting for results.
-
-        Returns:
-            The experiment data with finished jobs and post-processing.
-        """
-        _, timeout = combined_timeout(super().block_for_results, timeout)
-        for subdata in self._child_data.values():
-            _, timeout = combined_timeout(subdata.block_for_results, timeout)
-        return self
 
     def add_tags_recursive(self, tags2add: List[str]) -> None:
         """Add tags to this experiment itself and its descendants

--- a/releasenotes/notes/block-result-bc065ba7ffb883bc.yaml
+++ b/releasenotes/notes/block-result-bc065ba7ffb883bc.yaml
@@ -9,6 +9,14 @@ features:
     returning results. This prevents issues where trying to retrieve analysis
     results before analysis was finished would raise an error that the result
     could not be found.
+
+    Note that in the case of
+    :class:`~qiskit-experiments.framework.ParallelExperiment` and
+    :class:`~qiskit-experiments.framework.BatchExperiment` blocking or
+    calling ``analysis_results`` on the parent experiment should be performed
+    before attempting to access results in the component experiment data
+    containers to ensure the component analysis callbacks
+    have been initialized.
 upgrade:
   - |
     The :meth:`qiskit_experiments.framework.ExperimentData.analysis_results`

--- a/releasenotes/notes/block-result-bc065ba7ffb883bc.yaml
+++ b/releasenotes/notes/block-result-bc065ba7ffb883bc.yaml
@@ -1,0 +1,24 @@
+---
+features:
+  - |
+    Added a ``block`` kwarg with default value ``block=True`` to the
+    :meth:`qiskit_experiments.framework.ExperimentData.analysis_results`
+    method. If this is True then calling
+    :meth:`~qiskit_experiments.framework.ExperimentData.analysis_results`
+    will block to wait for all running analysis callbacks to finish before
+    returning results. This prevents issues where trying to retrieve analysis
+    results before analysis was finished would raise an error that the result
+    could not be found.
+upgrade:
+  - |
+    The :meth:`qiskit_experiments.framework.ExperimentData.analysis_results`
+    method has been changed to block on analysis callbacks finishing by
+    default, this means it is no longer necessary to call the
+    :meth:`~qiskit_experiments.framework.ExperimentData.block_for_results`
+    method first before accessing analysis results.
+    
+    To disable blocking this can be set to run with ``block=False``.
+    This should be used
+    :meth:`~qiskit_experiments.framework.ExperimentData.analysis_results`
+    needs to be called during another analysis callback to prevent that
+    callback from blocking.

--- a/test/calibration/experiments/test_drag.py
+++ b/test/calibration/experiments/test_drag.py
@@ -60,7 +60,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
 
         drag = RoughDrag(1, self.x_plus)
 
-        expdata = drag.run(backend).block_for_results()
+        expdata = drag.run(backend)
         result = expdata.analysis_results(1)
 
         self.assertTrue(abs(result.value.value - backend.ideal_beta) < self.test_tol)
@@ -72,7 +72,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
 
         drag = RoughDrag(0, self.x_plus)
         drag.set_analysis_options(p0={"beta": 1.2})
-        exp_data = drag.run(backend).block_for_results()
+        exp_data = drag.run(backend)
         result = exp_data.analysis_results(1)
 
         self.assertTrue(abs(result.value.value - backend.ideal_beta) < self.test_tol)
@@ -84,7 +84,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
         drag = RoughDrag(1, self.x_plus, betas=np.linspace(-4, 4, 31))
         drag.set_run_options(shots=200)
         drag.set_analysis_options(p0={"beta": 1.8, "freq0": 0.08, "freq1": 0.16, "freq2": 0.32})
-        exp_data = drag.run(backend).block_for_results()
+        exp_data = drag.run(backend)
         result = exp_data.analysis_results(1)
 
         meas_level = exp_data.metadata["job_metadata"][-1]["run_options"]["meas_level"]

--- a/test/calibration/experiments/test_fine_amplitude.py
+++ b/test/calibration/experiments/test_fine_amplitude.py
@@ -50,7 +50,7 @@ class TestFineAmpEndToEnd(QiskitExperimentsTestCase):
         error = -np.pi * pi_ratio
         backend = MockFineAmp(error, np.pi, "xp")
 
-        expdata = amp_exp.run(backend).block_for_results()
+        expdata = amp_exp.run(backend)
         result = expdata.analysis_results(1)
         d_theta = result.value.value
 
@@ -71,7 +71,7 @@ class TestFineAmpEndToEnd(QiskitExperimentsTestCase):
         error = np.pi * pi_ratio
         backend = MockFineAmp(error, np.pi, "xp")
 
-        expdata = amp_exp.run(backend).block_for_results()
+        expdata = amp_exp.run(backend)
         result = expdata.analysis_results(1)
         d_theta = result.value.value
 
@@ -214,7 +214,7 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         self.assertEqual(circs[5].calibrations["sx"][((0,), ())], expected_sx)
 
         # run the calibration experiment. This should update the amp parameter of x which we test.
-        exp_data = amp_cal.run(self.backend).block_for_results()
+        exp_data = amp_cal.run(self.backend)
         d_theta = exp_data.analysis_results(1).value.value
         new_amp = init_amp * np.pi / (np.pi + d_theta)
 
@@ -252,7 +252,7 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         self.assertEqual(circs[5].calibrations["sx"][((0,), ())], expected_sx)
 
         # run the calibration experiment. This should update the amp parameter of x which we test.
-        exp_data = amp_cal.run(MockFineAmp(-np.pi * 0.07, np.pi / 2, "sx")).block_for_results()
+        exp_data = amp_cal.run(MockFineAmp(-np.pi * 0.07, np.pi / 2, "sx"))
         d_theta = exp_data.analysis_results(1).value.value
         new_amp = init_amp * (np.pi / 2) / (np.pi / 2 + d_theta)
 

--- a/test/calibration/experiments/test_fine_drag.py
+++ b/test/calibration/experiments/test_fine_drag.py
@@ -126,7 +126,7 @@ class TestFineDragCal(QiskitExperimentsTestCase):
         self.assertEqual(circs[5].calibrations["sx"][((0,), ())], expected_sx)
 
         # run the calibration experiment. This should update the beta parameter of x which we test.
-        exp_data = drag_cal.run(self.backend).block_for_results()
+        exp_data = drag_cal.run(self.backend)
         d_theta = exp_data.analysis_results(1).value.value
         sigma = 40
         target_angle = np.pi

--- a/test/calibration/experiments/test_fine_drag.py
+++ b/test/calibration/experiments/test_fine_drag.py
@@ -65,14 +65,14 @@ class TestFineDrag(QiskitExperimentsTestCase):
         drag = FineDrag(0, Gate("Drag", num_qubits=1, params=[]))
         drag.set_experiment_options(schedule=self.schedule)
         drag.set_transpile_options(basis_gates=["rz", "Drag", "sx"])
-        exp_data = drag.run(FineDragTestBackend()).block_for_results()
+        exp_data = drag.run(FineDragTestBackend())
 
         self.assertEqual(exp_data.analysis_results(0).quality, "good")
 
     def test_end_to_end_no_schedule(self):
         """Test that we can run without a schedule."""
 
-        exp_data = FineXDrag(0).run(FineDragTestBackend()).block_for_results()
+        exp_data = FineXDrag(0).run(FineDragTestBackend())
 
         self.assertEqual(exp_data.analysis_results(0).quality, "good")
 

--- a/test/calibration/experiments/test_rabi.py
+++ b/test/calibration/experiments/test_rabi.py
@@ -54,7 +54,6 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
         rabi = Rabi(self.qubit, self.sched)
         rabi.set_experiment_options(amplitudes=np.linspace(-0.95, 0.95, 21))
         expdata = rabi.run(backend)
-        expdata.block_for_results()
         result = expdata.analysis_results(0)
 
         self.assertEqual(result.quality, "good")
@@ -65,7 +64,6 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
         rabi = Rabi(self.qubit, self.sched)
         rabi.set_experiment_options(amplitudes=np.linspace(-0.95, 0.95, 21))
         expdata = rabi.run(backend)
-        expdata.block_for_results()
         result = expdata.analysis_results(0)
         self.assertEqual(result.quality, "good")
         self.assertTrue(abs(result.value.value[1] - backend.rabi_rate) < test_tol)
@@ -75,7 +73,6 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
         rabi = Rabi(self.qubit, self.sched)
         rabi.set_experiment_options(amplitudes=np.linspace(-0.95, 0.95, 101))
         expdata = rabi.run(backend)
-        expdata.block_for_results()
         result = expdata.analysis_results(0)
         self.assertEqual(result.quality, "good")
         self.assertTrue(abs(result.value.value[1] - backend.rabi_rate) < test_tol)
@@ -92,7 +89,6 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
         rabi.set_analysis_options(data_processor=DataProcessor(fail_key, []))
         rabi.set_run_options(shots=2)
         data = rabi.run(backend)
-        data.block_for_results()
         result = data.analysis_results()
 
         self.assertEqual(len(result), 0)
@@ -139,7 +135,6 @@ class TestEFRabi(QiskitExperimentsTestCase):
         rabi = EFRabi(self.qubit, self.sched)
         rabi.set_experiment_options(amplitudes=np.linspace(-0.95, 0.95, 21))
         expdata = rabi.run(backend)
-        expdata.block_for_results()
         result = expdata.analysis_results(1)
 
         self.assertEqual(result.quality, "good")
@@ -274,10 +269,8 @@ class TestRabiAnalysis(QiskitExperimentsTestCase):
 
         data_processor = DataProcessor("counts", [Probability(outcome="1")])
 
-        experiment_data = (
-            OscillationAnalysis()
-            .run(experiment_data, data_processor=data_processor, plot=False)
-            .block_for_results()
+        experiment_data = OscillationAnalysis().run(
+            experiment_data, data_processor=data_processor, plot=False
         )
         experiment_data.block_for_results()
         result = experiment_data.analysis_results()
@@ -295,10 +288,8 @@ class TestRabiAnalysis(QiskitExperimentsTestCase):
 
         data_processor = DataProcessor("counts", [Probability(outcome="1")])
 
-        experiment_data = (
-            OscillationAnalysis()
-            .run(experiment_data, data_processor=data_processor, plot=False)
-            .block_for_results()
+        experiment_data = OscillationAnalysis().run(
+            experiment_data, data_processor=data_processor, plot=False
         )
         experiment_data.block_for_results()
         result = experiment_data.analysis_results()

--- a/test/calibration/experiments/test_rabi.py
+++ b/test/calibration/experiments/test_rabi.py
@@ -272,7 +272,6 @@ class TestRabiAnalysis(QiskitExperimentsTestCase):
         experiment_data = OscillationAnalysis().run(
             experiment_data, data_processor=data_processor, plot=False
         )
-        experiment_data.block_for_results()
         result = experiment_data.analysis_results()
         self.assertEqual(result[0].quality, "good")
         self.assertTrue(abs(result[0].value.value[1] - expected_rate) < test_tol)
@@ -291,7 +290,6 @@ class TestRabiAnalysis(QiskitExperimentsTestCase):
         experiment_data = OscillationAnalysis().run(
             experiment_data, data_processor=data_processor, plot=False
         )
-        experiment_data.block_for_results()
         result = experiment_data.analysis_results()
 
         self.assertEqual(result[0].quality, "bad")

--- a/test/calibration/experiments/test_ramsey_xy.py
+++ b/test/calibration/experiments/test_ramsey_xy.py
@@ -43,7 +43,7 @@ class TestRamseyXY(QiskitExperimentsTestCase):
         ramsey = RamseyXY(0)
 
         for freq_shift in [2e6, -3e6]:
-            test_data = ramsey.run(MockRamseyXY(freq_shift=freq_shift)).block_for_results()
+            test_data = ramsey.run(MockRamseyXY(freq_shift=freq_shift))
             meas_shift = test_data.analysis_results(1).value.value
             self.assertTrue((meas_shift - freq_shift) < abs(test_tol * freq_shift))
 

--- a/test/calibration/test_update_library.py
+++ b/test/calibration/test_update_library.py
@@ -67,7 +67,6 @@ class TestFrequencyUpdate(QiskitExperimentsTestCase):
         spec = QubitSpectroscopy(qubit, frequencies, unit="MHz")
         spec.set_run_options(meas_level=MeasLevel.CLASSIFIED)
         exp_data = spec.run(backend)
-        exp_data.block_for_results()
         result = exp_data.analysis_results(1)
         value = result.value.value
 

--- a/test/quantum_volume/test_qv.py
+++ b/test/quantum_volume/test_qv.py
@@ -105,11 +105,10 @@ class TestQuantumVolume(QiskitExperimentsTestCase):
         # set number of trials to a low number to make the test faster
         qv_exp.set_experiment_options(trials=2)
         expdata1 = qv_exp.run(backend)
-        expdata1.block_for_results()
         result_data1 = expdata1.analysis_results(0)
-        expdata2 = qv_exp.run(backend, analysis=False).block_for_results()
+        expdata2 = qv_exp.run(backend, analysis=False)
         expdata2.add_data(expdata1.data())
-        qv_exp.run_analysis(expdata2).block_for_results()
+        qv_exp.run_analysis(expdata2)
         result_data2 = expdata2.analysis_results(0)
 
         self.assertTrue(result_data1.extra["trials"] == 2, "number of trials is incorrect")
@@ -139,7 +138,7 @@ class TestQuantumVolume(QiskitExperimentsTestCase):
         exp_data = ExperimentData(experiment=qv_exp, backend=backend)
         exp_data.add_data(insufficient_trials_data)
 
-        qv_exp.run_analysis(exp_data).block_for_results()
+        qv_exp.run_analysis(exp_data)
         qv_result = exp_data.analysis_results(1)
         self.assertTrue(
             qv_result.extra["success"] is False and qv_result.value == 1,
@@ -163,7 +162,7 @@ class TestQuantumVolume(QiskitExperimentsTestCase):
         exp_data = ExperimentData(experiment=qv_exp, backend=backend)
         exp_data.add_data(insufficient_hop_data)
 
-        qv_exp.run_analysis(exp_data).block_for_results()
+        qv_exp.run_analysis(exp_data)
         qv_result = exp_data.analysis_results(1)
         self.assertTrue(
             qv_result.extra["success"] is False and qv_result.value == 1,
@@ -188,7 +187,7 @@ class TestQuantumVolume(QiskitExperimentsTestCase):
         exp_data = ExperimentData(experiment=qv_exp, backend=backend)
         exp_data.add_data(insufficient_confidence_data)
 
-        qv_exp.run_analysis(exp_data).block_for_results()
+        qv_exp.run_analysis(exp_data)
         qv_result = exp_data.analysis_results(1)
         self.assertTrue(
             qv_result.extra["success"] is False and qv_result.value == 1,
@@ -212,7 +211,7 @@ class TestQuantumVolume(QiskitExperimentsTestCase):
         exp_data = ExperimentData(experiment=qv_exp, backend=backend)
         exp_data.add_data(successful_data)
 
-        qv_exp.run_analysis(exp_data).block_for_results()
+        qv_exp.run_analysis(exp_data)
         results_json_file = "qv_result_moderate_noise_300_trials.json"
         with open(os.path.join(dir_name, results_json_file), "r") as json_file:
             successful_results = json.load(json_file, cls=ExperimentDecoder)

--- a/test/randomized_benchmarking/rb_generate_data.py
+++ b/test/randomized_benchmarking/rb_generate_data.py
@@ -104,11 +104,9 @@ def _generate_rb_fitter_data(dir_name: str, rb_exp_name: str, exp_attributes: di
     )
     rb_exp.set_analysis_options(gate_error_ratio=gate_error_ratio)
     print("Running experiment")
-    experiment_obj = rb_exp.run(
-        backend, noise_model=noise_model, basis_gates=transpiled_base_gate
-    ).block_for_results()
-    print("Done running experiment")
+    experiment_obj = rb_exp.run(backend, noise_model=noise_model, basis_gates=transpiled_base_gate)
     experiment_obj.block_for_results()
+    print("Done running experiment")
     exp_results = experiment_obj.data()
     with open(results_file_path, "w") as json_file:
         joined_list_data = [exp_attributes, exp_results]
@@ -203,8 +201,8 @@ def _generate_int_rb_fitter_data(dir_name: str, rb_exp_name: str, exp_attributes
     rb_exp.set_analysis_options(gate_error_ratio=gate_error_ratio)
     print("Running experiment")
     experiment_obj = rb_exp.run(backend, noise_model=noise_model, basis_gates=transpiled_base_gate)
-    print("Done running experiment")
     experiment_obj.block_for_results()
+    print("Done running experiment")
     exp_results = experiment_obj.data()
     with open(results_file_path, "w") as json_file:
         joined_list_data = [exp_attributes, exp_results]

--- a/test/test_cross_resonance_hamiltonian.py
+++ b/test/test_cross_resonance_hamiltonian.py
@@ -318,7 +318,6 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
             qubits=(0, 1), flat_top_widths=durations, sigma=sigma, risefall=2
         )
         exp_data = expr.run(backend, shots=2000)
-        exp_data.block_for_results()
 
         self.assertEqual(exp_data.analysis_results(0).quality, "good")
         self.assertAlmostEqual(exp_data.analysis_results("omega_ix").value.value, ix, delta=2e4)

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -57,9 +57,11 @@ class TestFramework(QiskitExperimentsTestCase):
     def test_analysis_replace_results_true(self):
         """Test running analysis with replace_results=True"""
         analysis = FakeAnalysis()
-        expdata1 = analysis.run(ExperimentData(), seed=54321).block_for_results()
+        expdata1 = analysis.run(ExperimentData(), seed=54321)
+        expdata1.block_for_results()
         result_ids = [res.result_id for res in expdata1.analysis_results()]
-        expdata2 = analysis.run(expdata1, replace_results=True, seed=12345).block_for_results()
+        expdata2 = analysis.run(expdata1, replace_results=True, seed=12345)
+        expdata2.block_for_results()
 
         self.assertEqual(expdata1, expdata2)
         self.assertEqual(expdata1.analysis_results(), expdata2.analysis_results())
@@ -68,8 +70,10 @@ class TestFramework(QiskitExperimentsTestCase):
     def test_analysis_replace_results_false(self):
         """Test running analysis with replace_results=False"""
         analysis = FakeAnalysis()
-        expdata1 = analysis.run(ExperimentData(), seed=54321).block_for_results()
-        expdata2 = analysis.run(expdata1, replace_results=False, seed=12345).block_for_results()
+        expdata1 = analysis.run(ExperimentData(), seed=54321)
+        expdata1.block_for_results()
+        expdata2 = analysis.run(expdata1, replace_results=False, seed=12345)
+        expdata2.block_for_results()
 
         self.assertNotEqual(expdata1, expdata2)
         self.assertNotEqual(expdata1.experiment_id, expdata2.experiment_id)

--- a/test/test_half_angle.py
+++ b/test/test_half_angle.py
@@ -50,7 +50,7 @@ class TestHalfAngle(QiskitExperimentsTestCase):
         tol = 0.005
         for error in [-0.05, -0.02, 0.02, 0.05]:
             hac = HalfAngle(0)
-            exp_data = hac.run(HalfAngleTestBackend(error)).block_for_results()
+            exp_data = hac.run(HalfAngleTestBackend(error))
             d_theta = exp_data.analysis_results(1).value.value
 
             self.assertTrue(abs(d_theta - error) < tol)

--- a/test/test_qubit_spectroscopy.py
+++ b/test/test_qubit_spectroscopy.py
@@ -64,7 +64,6 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         spec = QubitSpectroscopy(qubit, frequencies, unit="Hz")
         spec.set_run_options(meas_level=MeasLevel.CLASSIFIED)
         expdata = spec.run(backend)
-        expdata.block_for_results()
         result = expdata.analysis_results(1)
         value = result.value.value
 
@@ -77,7 +76,6 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         spec = QubitSpectroscopy(qubit, frequencies, unit="Hz")
         spec.set_run_options(meas_level=MeasLevel.CLASSIFIED)
         expdata = spec.run(backend)
-        expdata.block_for_results()
         result = expdata.analysis_results(1)
         value = result.value.value
 
@@ -94,7 +92,6 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
 
         spec = QubitSpectroscopy(qubit, frequencies, unit="MHz")
         expdata = spec.run(backend)
-        expdata.block_for_results()
         result = expdata.analysis_results(1)
         value = result.value.value
 
@@ -106,7 +103,6 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
 
         spec = QubitSpectroscopy(qubit, frequencies, unit="MHz")
         expdata = spec.run(backend)
-        expdata.block_for_results()
         result = expdata.analysis_results(1)
         value = result.value.value
 
@@ -115,7 +111,6 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
 
         spec.set_run_options(meas_return="avg")
         expdata = spec.run(backend)
-        expdata.block_for_results()
         result = expdata.analysis_results(1)
         value = result.value.value
 
@@ -136,7 +131,6 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         spec.backend = backend
         spec.set_run_options(meas_level=MeasLevel.CLASSIFIED)
         expdata = spec.run(backend)
-        expdata.block_for_results()
         result = expdata.analysis_results(1)
         value = result.value.value
 

--- a/test/test_t1.py
+++ b/test/test_t1.py
@@ -53,7 +53,6 @@ class TestT1(QiskitExperimentsTestCase):
         exp = T1(0, delays, unit="dt")
         exp.set_analysis_options(p0={"amp": 1, "tau": t1 / dt_factor, "base": 0})
         exp_data = exp.run(backend, shots=10000)
-        exp_data.block_for_results()  # Wait for analysis to finish.
         res = exp_data.analysis_results("T1")
         fitval = res.value
         self.assertEqual(res.quality, "good")
@@ -78,8 +77,7 @@ class TestT1(QiskitExperimentsTestCase):
         exp0 = T1(0, delays)
         exp2 = T1(2, delays)
         par_exp = ParallelExperiment([exp0, exp2])
-        res = par_exp.run(T1Backend([t1[0], None, t1[1]]))
-        res.block_for_results()
+        res = par_exp.run(T1Backend([t1[0], None, t1[1]])).block_for_results()
 
         for i in range(2):
             sub_res = res.child_data(i).analysis_results("T1")
@@ -110,8 +108,7 @@ class TestT1(QiskitExperimentsTestCase):
         exp1.set_analysis_options(p0={"tau": 1000000})
 
         par_exp = ParallelExperiment([exp0, exp1])
-        res = par_exp.run(T1Backend([t1, t1]))
-        res.block_for_results()
+        res = par_exp.run(T1Backend([t1, t1])).block_for_results()
 
         sub_res = []
         for i in range(2):
@@ -152,9 +149,10 @@ class TestT1(QiskitExperimentsTestCase):
                 }
             )
 
-        res = T1Analysis()._run_analysis(data)[0][1]
-        self.assertEqual(res.quality, "good")
-        self.assertAlmostEqual(res.value.value, 25e-9, delta=3)
+        res, _ = T1Analysis()._run_analysis(data)
+        result = res[1]
+        self.assertEqual(result.quality, "good")
+        self.assertAlmostEqual(result.value.value, 25e-9, delta=3)
 
     def test_t1_metadata(self):
         """
@@ -211,8 +209,9 @@ class TestT1(QiskitExperimentsTestCase):
                 }
             )
 
-        res = T1Analysis()._run_analysis(data)[0][1]
-        self.assertEqual(res.quality, "bad")
+        res, _ = T1Analysis()._run_analysis(data)
+        result = res[1]
+        self.assertEqual(result.quality, "bad")
 
     def test_experiment_config(self):
         """Test converting to and from config works"""

--- a/test/test_t2ramsey.py
+++ b/test/test_t2ramsey.py
@@ -115,8 +115,7 @@ class TestT2Ramsey(QiskitExperimentsTestCase):
         }
 
         backend = T2RamseyBackend(p0)
-        expdata = par_exp.run(backend=backend, shots=1000)
-        expdata.block_for_results()
+        expdata = par_exp.run(backend=backend, shots=1000).block_for_results()
 
         for i in range(2):
             res_t2star = expdata.child_data(i).analysis_results("T2star")
@@ -174,17 +173,15 @@ class TestT2Ramsey(QiskitExperimentsTestCase):
 
         # run circuits
         expdata0 = exp0.run(backend=backend, shots=1000)
-        expdata0.block_for_results()
-
         res_t2star_0 = expdata0.analysis_results("T2star")
 
         # second experiment
         delays1 = list(range(2, 65, 2))
         exp1 = T2Ramsey(qubit, delays1, unit=unit)
         exp1.set_analysis_options(p0=default_p0)
-        expdata1 = exp1.run(backend=backend, analysis=False, shots=1000).block_for_results()
+        expdata1 = exp1.run(backend=backend, analysis=False, shots=1000)
         expdata1.add_data(expdata0.data())
-        exp1.run_analysis(expdata1).block_for_results()
+        exp1.run_analysis(expdata1)
 
         res_t2star_1 = expdata1.analysis_results("T2star")
         res_freq_1 = expdata1.analysis_results("Frequency")

--- a/test/test_tomography.py
+++ b/test/test_tomography.py
@@ -51,7 +51,6 @@ class TestStateTomography(QiskitExperimentsTestCase):
         if fitter:
             qstexp.set_analysis_options(fitter=fitter)
         expdata = qstexp.run(backend)
-        expdata.block_for_results()
         results = expdata.analysis_results()
 
         # Check state is density matrix
@@ -77,7 +76,6 @@ class TestStateTomography(QiskitExperimentsTestCase):
         backend = AerSimulator(seed_simulator=9000)
         exp = StateTomography(teleport_circuit(), measurement_qubits=[2])
         expdata = exp.run(backend)
-        expdata.block_for_results()
         results = expdata.analysis_results()
 
         # Check result
@@ -168,7 +166,6 @@ class TestStateTomography(QiskitExperimentsTestCase):
         backend = AerSimulator(seed_simulator=9000)
         exp = StateTomography(circ, measurement_qubits=meas_qubits)
         expdata = exp.run(backend)
-        expdata.block_for_results()
         results = expdata.analysis_results()
 
         # Check result
@@ -210,8 +207,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
         # Run batch experiments
         backend = AerSimulator(seed_simulator=9000)
         batch_exp = BatchExperiment(exps)
-        batch_data = batch_exp.run(backend)
-        batch_data.block_for_results()
+        batch_data = batch_exp.run(backend).block_for_results()
 
         # Check target fidelity of component experiments
         f_threshold = 0.95
@@ -249,8 +245,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
         # Run batch experiments
         backend = AerSimulator(seed_simulator=9000)
         par_exp = ParallelExperiment(exps)
-        par_data = par_exp.run(backend)
-        par_data.block_for_results()
+        par_data = par_exp.run(backend).block_for_results()
 
         # Check target fidelity of component experiments
         f_threshold = 0.95
@@ -295,7 +290,6 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         if fitter:
             qstexp.set_analysis_options(fitter=fitter)
         expdata = qstexp.run(backend)
-        expdata.block_for_results()
         results = expdata.analysis_results()
 
         # Check state is density matrix
@@ -369,7 +363,6 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         backend = AerSimulator(seed_simulator=9000)
         exp = ProcessTomography(circ, measurement_qubits=qubits, preparation_qubits=qubits)
         expdata = exp.run(backend)
-        expdata.block_for_results()
         results = expdata.analysis_results()
 
         # Check result
@@ -396,7 +389,6 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         backend = AerSimulator(seed_simulator=9000)
         exp = ProcessTomography(teleport_circuit(), measurement_qubits=[2], preparation_qubits=[0])
         expdata = exp.run(backend, shots=10000)
-        expdata.block_for_results()
         results = expdata.analysis_results()
 
         # Check result
@@ -431,8 +423,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         # Run batch experiments
         backend = AerSimulator(seed_simulator=9000)
         batch_exp = BatchExperiment(exps)
-        batch_data = batch_exp.run(backend)
-        batch_data.block_for_results()
+        batch_data = batch_exp.run(backend).block_for_results()
 
         # Check target fidelity of component experiments
         f_threshold = 0.95
@@ -468,8 +459,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         # Run batch experiments
         backend = AerSimulator(seed_simulator=9000)
         par_exp = ParallelExperiment(exps)
-        par_data = par_exp.run(backend)
-        par_data.block_for_results()
+        par_data = par_exp.run(backend).block_for_results()
 
         # Check target fidelity of component experiments
         f_threshold = 0.95


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

features:
  - Added a ``block`` kwarg with default value ``block=True`` to the
    :meth:`qiskit_experiments.framework.ExperimentData.analysis_results`
    method. If this is True then calling
    :meth:`~qiskit_experiments.framework.ExperimentData.analysis_results`
    will block to wait for all running analysis callbacks to finish before
    returning results. This prevents issues where trying to retrieve analysis
    results before analysis was finished would raise an error that the result
    could not be found.

upgrade:
  - The :meth:`qiskit_experiments.framework.ExperimentData.analysis_results`
    method has been changed to block on analysis callbacks finishing by
    default, this means it is no longer necessary to call the
    :meth:`~qiskit_experiments.framework.ExperimentData.block_for_results`
    method first before accessing analysis results.
    
    To disable blocking this can be set to run with ``block=False``.
    This should be used
    :meth:`~qiskit_experiments.framework.ExperimentData.analysis_results`
    needs to be called during another analysis callback to prevent that
    callback from blocking.

### Details and comments


