### PR TITLE
Readd `osc_freq` metadata to T2Ramsey

### DIFF
--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -143,6 +143,8 @@ class T2Ramsey(BaseExperiment):
         Raises:
             ValueError: When conversion factor is not set.
         """
+        self.set_analysis_options(extra={"osc_freq": self.experiment_options.osc_freq})
+
         prefactor = self.experiment_options.conversion_factor
 
         if prefactor is None:
@@ -172,5 +174,4 @@ class T2Ramsey(BaseExperiment):
             }
 
             circuits.append(circ)
-
         return circuits

--- a/test/test_t2ramsey.py
+++ b/test/test_t2ramsey.py
@@ -91,6 +91,7 @@ class TestT2Ramsey(QiskitTestCase):
                     estimated_freq,
                     delta=TestT2Ramsey.__tolerance__ * result.value.value,
                 )
+                self.assertDictEqual(result.extra, {"osc_freq": osc_freq})
                 self.assertEqual(result.quality, "good", "Result quality bad for unit " + str(unit))
 
     def test_t2ramsey_parallel(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I accidentally removed `osc_freq` metadata from `T2Ramsey` experiment with the commit https://github.com/Qiskit/qiskit-experiments/pull/427/commits/cd9b9cc57e9d4335aa3dedc6eb0bf1d3f4a27124.

This PR readds `osc_freq` to result data metadata. This parameter is important because fit frequency value is always offset by this amount.

### Details and comments

Seems like this PR fails with some weird bug. `self.analysis_options` is updated only within the scope of subclass `circuits` method.
