### PR TITLE
Revert "Replace `str(uuid4())` with `uuid4().hex` (#492)"

### DIFF
--- a/qiskit_experiments/database_service/db_analysis_result.py
+++ b/qiskit_experiments/database_service/db_analysis_result.py
@@ -90,7 +90,7 @@ class DbAnalysisResultV1(DbAnalysisResult):
         """
         # Data to be stored in DB.
         self._experiment_id = experiment_id
-        self._id = result_id or uuid.uuid4().hex
+        self._id = result_id or str(uuid.uuid4())
         self._name = name
         self._value = copy.deepcopy(value)
         self._extra = copy.deepcopy(extra or {})

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -156,7 +156,7 @@ class DbExperimentDataV1(DbExperimentData):
         self._auto_save = False
         self._set_service_from_backend(backend)
 
-        self._id = experiment_id or uuid.uuid4().hex
+        self._id = experiment_id or str(uuid.uuid4())
         self._parent_id = parent_id
         self._type = experiment_type
         self._tags = tags or []
@@ -287,7 +287,7 @@ class DbExperimentDataV1(DbExperimentData):
                       keywork arguments passed to this method.
             **kwargs: Keyword arguments to be passed to the callback function.
         """
-        callback_id = uuid.uuid4().hex
+        callback_id = uuid.uuid4()
         self._callback_statuses[callback_id] = CallbackStatus(callback, kwargs=kwargs)
 
         # Wrap callback function to handle reporting status and catching

--- a/test/calibration/test_calibrations.py
+++ b/test/calibration/test_calibrations.py
@@ -1302,7 +1302,7 @@ class TestSavingAndLoading(CrossResonanceTest):
 
     def setUp(self):
         """Setup the test."""
-        self._prefix = uuid.uuid4().hex
+        self._prefix = str(uuid.uuid4())
         super().setUp()
 
     def tearDown(self):


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This reverts commit f5da13c236dc2204a5ab8990bee9f5d0ca5979f5.

There is validation in the IBMQ service that fails for the hex formated uuid string that would need to be fixed before making this change.

### Details and comments
