### PR TITLE
[WIP] Update how CompositeAnalysis runs analysis

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -23,7 +23,7 @@ from qiskit_experiments.database_service import DbExperimentDataV1 as DbExperime
 from qiskit_experiments.database_service.database_service import (
     DatabaseServiceV1 as DatabaseService,
 )
-from qiskit_experiments.database_service.utils import ThreadSafeOrderedDict, combined_timeout
+from qiskit_experiments.database_service.utils import ThreadSafeOrderedDict
 
 LOG = logging.getLogger(__name__)
 
@@ -209,20 +209,6 @@ class ExperimentData(DbExperimentData):
             data.auto_save = original_auto_save
         if self.auto_save:
             self.save_metadata()
-
-    def block_for_results(self, timeout: Optional[float] = None) -> ExperimentData:
-        """Block until all pending jobs and analysis callbacks finish.
-
-        Args:
-            timeout: Timeout waiting for results.
-
-        Returns:
-            The experiment data with finished jobs and post-processing.
-        """
-        _, timeout = combined_timeout(super().block_for_results, timeout)
-        for subdata in self._child_data.values():
-            _, timeout = combined_timeout(subdata.block_for_results, timeout)
-        return self
 
     def __repr__(self):
         out = (


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This updates CompositeAnalysis to add each component analysis function as an analysis callback to the parent experiment data. These callbacks finish when the component analysis finishes, so that blocking on the parent will also block on all component analysis finishing. Furthermore any additional callbacks added after running composite analysis will wait for all component analysis to finish before running.

### Details and comments

TODO:
- [ ] Tests
