### PR TITLE
Generalize extra_database_entry method

### DIFF
--- a/qiskit_experiments/curve_analysis/curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis.py
@@ -203,11 +203,6 @@ class CurveAnalysis(BaseAnalysis, ABC):
             By default, data is sorted by x values and the measured values at the same
             x value are averaged.
 
-        - Create extra data from fit result:
-            Override :meth:`~self._extra_database_entry`. You need to return a list of
-            :class:`~qiskit_experiments.framework.analysis_result_data.AnalysisResultData`
-            object. This returns an empty list by default.
-
         - Customize fit quality evaluation:
             Override :meth:`~self._evaluate_quality`. This value will be shown in the
             database. You can determine the quality represented by the predefined string
@@ -500,20 +495,6 @@ class CurveAnalysis(BaseAnalysis, ABC):
             shots=shots,
             data_index=series,
         )
-
-    # pylint: disable=unused-argument
-    def _extra_database_entry(self, fit_data: FitData) -> List[AnalysisResultData]:
-        """Calculate new quantity from the fit result.
-
-        Subclasses can override this method to do post analysis.
-
-        Args:
-            fit_data: Fit result.
-
-        Returns:
-            List of database entry created from the fit data.
-        """
-        return []
 
     # pylint: disable=unused-argument
     def _evaluate_quality(self, fit_data: FitData) -> Union[str, None]:
@@ -1016,9 +997,6 @@ class CurveAnalysis(BaseAnalysis, ABC):
                         extra=self._get_option("extra"),
                     )
                     analysis_results.append(result_entry)
-
-            # add extra database entries
-            analysis_results.extend(self._extra_database_entry(fit_result))
 
         if self._get_option("return_data_points"):
             # save raw data points in the data base if option is set (default to false)

--- a/qiskit_experiments/framework/base_analysis.py
+++ b/qiskit_experiments/framework/base_analysis.py
@@ -115,7 +115,23 @@ class BaseAnalysis(ABC):
             if figures:
                 expdata.add_figures(figures)
 
+        def extra_analysis(expdata):
+            # A callback to generate extra entries based on standard analysis output.
+            results = self._extra_database_entry(expdata)
+            if results:
+                analysis_results = [
+                    self._format_analysis_result(
+                        result, expdata.experiment_id, experiment_components
+                    )
+                    for result in results
+                ]
+                experiment_data.add_analysis_results(analysis_results)
+
+        # Run standard analysis
         experiment_data.add_analysis_callback(run_analysis)
+
+        # Wait for standard analysis to complete, then compute extra quantities
+        experiment_data.add_analysis_callback(extra_analysis)
 
         return experiment_data
 
@@ -136,6 +152,20 @@ class BaseAnalysis(ABC):
             quality=data.quality,
             extra=data.extra,
         )
+
+    # pylint: disable=unused-argument
+    def _extra_database_entry(self, experiment_data: ExperimentData) -> List[AnalysisResultData]:
+        """Calculate new quantity from the fit result.
+
+        Subclasses can override this method to do post analysis.
+
+        Args:
+            experiment_data: Fit result.
+
+        Returns:
+            List of database entry created from the fit data.
+        """
+        return []
 
     @abstractmethod
     def _run_analysis(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #460, parameters of interest are computed based on child experiment parameters in the batch, however, there is no approach to write this workflow except for overriding `_run_analysis`. This needs the parent analysis to block for callback of child analysis, otherwise it fails with no entry error.


### Details and comments
This PR generalize `_extra_database_entry` method that has been existing in `CurveAnalysis`. This method is designed to take analyzed dataset and compute new values to return. This part is moved to base analysis, as second callback attached to experiment data. This chained callback should be computed sequentially, thus we don't need to manage callback sync in child classes.
