### PR TITLE
Fix storing of component metadata in composite experiment

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -304,7 +304,7 @@ class BaseExperiment(ABC):
         # Run jobs
         jobs = experiment._run_jobs(circuits, **run_opts)
         experiment_data.add_data(jobs)
-        experiment._add_job_metadata(experiment_data, jobs, **run_opts)
+        experiment._add_job_metadata(experiment_data.metadata, jobs, **run_opts)
 
         # Optionally run analysis
         if analysis and self.__analysis_class__ is not None:
@@ -515,7 +515,6 @@ class BaseExperiment(ABC):
             "experiment_type": self._type,
             "num_qubits": self.num_qubits,
             "physical_qubits": list(self.physical_qubits),
-            "job_metadata": [],
         }
         # Add additional metadata if subclasses specify it
         for key, val in self._additional_metadata().items():
@@ -530,7 +529,7 @@ class BaseExperiment(ABC):
         """
         return {}
 
-    def _add_job_metadata(self, experiment_data: ExperimentData, jobs: BaseJob, **run_options):
+    def _add_job_metadata(self, metadata: Dict[str, Any], jobs: BaseJob, **run_options):
         """Add runtime job metadata to ExperimentData.
 
         Args:
@@ -538,14 +537,15 @@ class BaseExperiment(ABC):
             jobs: the job objects.
             run_options: backend run options for the job.
         """
-        metadata = {
-            "job_ids": [job.job_id() for job in jobs],
-            "experiment_options": copy.copy(self.experiment_options.__dict__),
-            "transpile_options": copy.copy(self.transpile_options.__dict__),
-            "analysis_options": copy.copy(self.analysis_options.__dict__),
-            "run_options": copy.copy(run_options),
-        }
-        experiment_data._metadata["job_metadata"].append(metadata)
+        metadata["job_metadata"] = [
+            {
+                "job_ids": [job.job_id() for job in jobs],
+                "experiment_options": copy.copy(self.experiment_options.__dict__),
+                "transpile_options": copy.copy(self.transpile_options.__dict__),
+                "analysis_options": copy.copy(self.analysis_options.__dict__),
+                "run_options": copy.copy(run_options),
+            }
+        ]
 
 
 def fix_class_docs(wrapped_cls):

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -533,7 +533,7 @@ class BaseExperiment(ABC):
         """Add runtime job metadata to ExperimentData.
 
         Args:
-            experiment_data: the experiment data container.
+            metadata: the metadata dict to update with job data.
             jobs: the job objects.
             run_options: backend run options for the job.
         """

--- a/qiskit_experiments/framework/composite/composite_analysis.py
+++ b/qiskit_experiments/framework/composite/composite_analysis.py
@@ -66,10 +66,9 @@ class CompositeAnalysis(BaseAnalysis):
         # analysis classes
         composite_exp = experiment_data.experiment
         component_exps = composite_exp.component_experiment()
-        if "component_job_metadata" in experiment_data.metadata:
-            component_metadata = experiment_data.metadata["component_job_metadata"][-1]
-        else:
-            component_metadata = [{}] * composite_exp.num_experiments
+        component_metadata = experiment_data.metadata.get(
+            "component_metadata", [{}] * composite_exp.num_experiments
+        )
 
         # Initialize component data for updating and get the experiment IDs for
         # the component child experiments in case there are other child experiments
@@ -94,7 +93,8 @@ class CompositeAnalysis(BaseAnalysis):
             sub_exp_data.add_data(sub_data)
 
             # Add component job metadata
-            sub_exp_data.metadata["job_metadata"] = [component_metadata[i]]
+            for key, val in component_metadata[i].items():
+                sub_exp_data.metadata[key] = val
 
             # Run analysis
             # Since copy for replace result is handled at the parent level

--- a/qiskit_experiments/framework/composite/composite_analysis.py
+++ b/qiskit_experiments/framework/composite/composite_analysis.py
@@ -93,8 +93,7 @@ class CompositeAnalysis(BaseAnalysis):
             sub_exp_data.add_data(sub_data)
 
             # Add component job metadata
-            for key, val in component_metadata[i].items():
-                sub_exp_data.metadata[key] = val
+            sub_exp_data.metadata.update(component_metadata[i])
 
             # Run analysis
             # Since copy for replace result is handled at the parent level

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -13,7 +13,6 @@
 Composite Experiment abstract base class.
 """
 
-import copy
 from typing import List, Sequence, Optional
 from abc import abstractmethod
 import warnings
@@ -93,13 +92,20 @@ class CompositeExperiment(BaseExperiment):
         return experiment_data
 
     def _additional_metadata(self):
-        return {"component_job_metadata": []}
+        """Add component experiment metadata"""
+        return {
+            "component_metadata": [sub_exp._metadata() for sub_exp in self.component_experiment()]
+        }
 
-    def _add_job_metadata(self, experiment_data, jobs, **run_options):
-        # Extract component metadata
-        component_metadata = []
+    def _add_job_metadata(self, metadata, jobs, **run_options):
+        super()._add_job_metadata(metadata, jobs, **run_options)
+
+        # Add component job metadata
+        if "component_metadata" not in metadata:
+            metadata["component_metadata"] = [{}] * self.num_experiments
+        component_metadata = metadata["component_metadata"]
         # Add sub-experiment options
-        for sub_exp in self.component_experiment():
+        for sub_metadata, sub_exp in zip(component_metadata, self.component_experiment()):
             # Run and transpile options are always overridden
             if (
                 sub_exp.run_options != sub_exp._default_run_options()
@@ -109,17 +115,7 @@ class CompositeExperiment(BaseExperiment):
                     "Sub-experiment run and transpile options"
                     " are overridden by composite experiment options."
                 )
-            component_metadata.append(
-                {
-                    "job_ids": [job.job_id() for job in jobs],
-                    "experiment_options": copy.copy(sub_exp.experiment_options.__dict__),
-                    "transpile_options": copy.copy(sub_exp.transpile_options.__dict__),
-                    "analysis_options": copy.copy(sub_exp.analysis_options.__dict__),
-                    "run_options": copy.copy(run_options),
-                }
-            )
-        super()._add_job_metadata(experiment_data, jobs, **run_options)
-        experiment_data._metadata["component_job_metadata"].append(component_metadata)
+            sub_exp._add_job_metadata(sub_metadata, jobs, **run_options)
 
     def _postprocess_transpiled_circuits(self, circuits, **run_options):
         for expr in self._experiments:

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -99,13 +99,10 @@ class CompositeExperiment(BaseExperiment):
 
     def _add_job_metadata(self, metadata, jobs, **run_options):
         super()._add_job_metadata(metadata, jobs, **run_options)
-
-        # Add component job metadata
-        if "component_metadata" not in metadata:
-            metadata["component_metadata"] = [{}] * self.num_experiments
-        component_metadata = metadata["component_metadata"]
         # Add sub-experiment options
-        for sub_metadata, sub_exp in zip(component_metadata, self.component_experiment()):
+        for sub_metadata, sub_exp in zip(
+            metadata["component_metadata"], self.component_experiment()
+        ):
             # Run and transpile options are always overridden
             if (
                 sub_exp.run_options != sub_exp._default_run_options()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes how CompositeExperiment stores component experiment metadata in #451.

Fixes #507

### Details and comments

Now all experiment metadata is stored in the parent experiment data container, including arbitrary nesting of other composite experiments. Previously only composite job metadata was stored rather than all experiment metadata, and recursion wasn't handled correctly for nested composite experiments.

