### PR TITLE
Data processor logger

### DIFF
--- a/qiskit_experiments/data_processing/__init__.py
+++ b/qiskit_experiments/data_processing/__init__.py
@@ -27,6 +27,7 @@ Classes
     :toctree: ../stubs/
 
     DataProcessor
+    DataLogger
     DataAction
     TrainableDataAction
 
@@ -54,4 +55,4 @@ from .nodes import (
     BasisExpectationValue,
 )
 
-from .data_processor import DataProcessor
+from .data_processor import DataProcessor, DataLogger

--- a/test/data_processing/test_data_processing.py
+++ b/test/data_processing/test_data_processing.py
@@ -21,7 +21,7 @@ from qiskit.result.models import ExperimentResultData, ExperimentResult
 from qiskit.result import Result
 
 from qiskit_experiments.framework import ExperimentData
-from qiskit_experiments.data_processing.data_processor import DataProcessor
+from qiskit_experiments.data_processing.data_processor import DataProcessor, DataLogger
 from qiskit_experiments.data_processing.exceptions import DataProcessorError
 from qiskit_experiments.data_processing.nodes import (
     AverageData,
@@ -84,9 +84,13 @@ class DataProcessorTest(BaseDataProcessorTest):
         self.assertEqual(datum, [{"00": 4, "10": 6}])
         self.assertIsNone(error)
 
-        datum, error, history = data_processor.call_with_history(self.exp_data_lvl2.data(0))
+        history = DataLogger()
+        datum, error = data_processor(
+            data=self.exp_data_lvl2.data(0),
+            callback=history,
+        )
         self.assertEqual(datum, [{"00": 4, "10": 6}])
-        self.assertEqual(history, [])
+        self.assertEqual(history.data(), [])
 
     def test_to_real(self):
         """Test scaling and conversion to real part."""
@@ -117,13 +121,17 @@ class DataProcessorTest(BaseDataProcessorTest):
         self.assertIsNone(error)
 
         # Test that we can call with history.
-        new_data, error, history = processor.call_with_history(exp_data.data(0))
+        history = DataLogger()
+        new_data, error = processor(
+            data=exp_data.data(0),
+            callback=history,
+        )
 
         self.assertEqual(exp_data.data(0), expected_old)
         self.assertTrue(np.allclose(new_data, expected_new))
 
-        self.assertEqual(history[0][0], "ToReal")
-        self.assertTrue(np.allclose(history[0][1], expected_new))
+        self.assertEqual(history.data()[0][0], "ToReal")
+        self.assertTrue(np.allclose(history.data()[0][1], expected_new))
 
         # Test to real on more than one datum
         new_data, error = processor(exp_data.data())
@@ -172,12 +180,16 @@ class DataProcessorTest(BaseDataProcessorTest):
         self.assertIsNone(error)
 
         # Test that we can call with history.
-        new_data, error, history = processor.call_with_history(exp_data.data(0))
+        history = DataLogger()
+        new_data, error = processor(
+            data=exp_data.data(0),
+            callback=history,
+        )
         self.assertEqual(exp_data.data(0), expected_old)
         self.assertTrue(np.allclose(new_data, expected_new))
 
-        self.assertEqual(history[0][0], "ToImag")
-        self.assertTrue(np.allclose(history[0][1], expected_new))
+        self.assertEqual(history.data()[0][0], "ToImag")
+        self.assertTrue(np.allclose(history.data()[0][1], expected_new))
 
         # Test to imaginary on more than one datum
         new_data, error = processor(exp_data.data())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR simplifies the interface of data processor.

Currently the processor has two interface:
```python
nominals, error, history = my_processor.call_with_history(data)
nominals, error = my_processor(data)
```
to eliminate boilerplate code it internally implements `_call_internals` method, but its return type will dynamically change depending on input flag.

### Details and comments

This PR simplifies the implementation by redefining the history mode as a callback. Namely,

```python
history = DataLogger()

nominals, error = my_processor(data, history)
history.data()
```

