### PR TITLE
Serialize the basis gate library

### DIFF
--- a/qiskit_experiments/calibration_management/basis_gate_library.py
+++ b/qiskit_experiments/calibration_management/basis_gate_library.py
@@ -158,8 +158,9 @@ class BasisGateLibrary(ABC, Mapping):
 
         if hash(library) != config["hash"]:
             warn(
-                "Deserialized basis gate library's hash does not "
-                "match the hash of the serialized library."
+                "Deserialized basis gate library's hash does not match the hash of the serialized "
+                "library. Typically, the hash changes when the internal structure of the template "
+                "schedules has been changed."
             )
 
         return library

--- a/qiskit_experiments/calibration_management/basis_gate_library.py
+++ b/qiskit_experiments/calibration_management/basis_gate_library.py
@@ -54,7 +54,7 @@ class BasisGateLibrary(ABC, Mapping):
         """
         # Update the default values.
         self._extra_kwargs = extra_kwargs
-        self._default_values = dict(self.__default_values__)
+        self._default_values = self.__default_values__.copy()
         if default_values is not None:
             self._default_values.update(default_values)
 

--- a/qiskit_experiments/calibration_management/basis_gate_library.py
+++ b/qiskit_experiments/calibration_management/basis_gate_library.py
@@ -66,7 +66,7 @@ class BasisGateLibrary(ABC, Mapping):
             self._default_values.update(default_values)
 
         if basis_gates is None:
-            basis_gates = list(gate for gate in self.__supported_gates__)
+            basis_gates = list(self.__supported_gates__)
 
         self._schedules = dict()
         for gate in basis_gates:

--- a/qiskit_experiments/calibration_management/basis_gate_library.py
+++ b/qiskit_experiments/calibration_management/basis_gate_library.py
@@ -95,8 +95,8 @@ class BasisGateLibrary(ABC, Mapping):
     def __hash__(self) -> int:
         """Return the hash of the library by computing the hash of the schedule strings."""
         data_to_hash = []
-        for gate, gate_def in sorted(self._schedules.items()):
-            data_to_hash.append((gate, str(gate_def.schedule)))
+        for name, schedule in sorted(self._schedules.items()):
+            data_to_hash.append((name, str(schedule), self.__supported_gates__[name]))
 
         return hash(tuple(data_to_hash))
 

--- a/test/calibration/test_setup_library.py
+++ b/test/calibration/test_setup_library.py
@@ -22,6 +22,14 @@ from qiskit_experiments.exceptions import CalibrationError
 from qiskit_experiments.framework.json import ExperimentEncoder, ExperimentDecoder
 
 
+class FixedFrequencyTransmonTmp(FixedFrequencyTransmon):
+    """A subclass designed for test_hash_warn.
+
+    This class ensures that FixedFrequencyTransmon is preserved if anything goes wrong
+    with the serialization :meth:`in test_hash_warn`.
+    """
+
+
 class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
     """Test the various setup methods."""
 
@@ -181,21 +189,21 @@ class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
         4. A warning is raised since the class definition has changed.
         """
 
-        lib1 = FixedFrequencyTransmon()
+        lib1 = FixedFrequencyTransmonTmp()
         lib_data = json.dumps(lib1, cls=ExperimentEncoder)
         lib2 = json.loads(lib_data, cls=ExperimentDecoder)
 
         self.assertTrue(self._test_library_equivalence(lib1, lib2))
 
         # stash method build schedules to avoid other tests from failing
-        build_schedules = FixedFrequencyTransmon._build_schedules
+        build_schedules = FixedFrequencyTransmonTmp._build_schedules
 
         def _my_build_schedules():
             """A dummy function to change the class behaviour."""
             pass
 
         # Change the schedule behaviour
-        FixedFrequencyTransmon._build_schedules = _my_build_schedules
+        FixedFrequencyTransmonTmp._build_schedules = _my_build_schedules
 
         with self.assertWarns(UserWarning):
             json.loads(lib_data, cls=ExperimentDecoder)

--- a/test/calibration/test_setup_library.py
+++ b/test/calibration/test_setup_library.py
@@ -171,6 +171,29 @@ class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
 
         self.assertTrue(self._test_library_equivalence(lib1, lib2))
 
+    def test_hash_warn(self):
+        """Test that a warning is raised when the hash of the library is different."""
+
+        lib1 = FixedFrequencyTransmon()
+        lib_data = json.dumps(lib1, cls=ExperimentEncoder)
+        lib2 = json.loads(lib_data, cls=ExperimentDecoder)
+
+        self.assertTrue(self._test_library_equivalence(lib1, lib2))
+
+        # stash method build schedules to avoid other tests from failing
+        build_schedules = FixedFrequencyTransmon._build_schedules
+
+        def _my_build_schedules():
+            """A dummy function to change the class behaviour."""
+            pass
+
+        FixedFrequencyTransmon._build_schedules = _my_build_schedules
+
+        with self.assertWarns(UserWarning):
+            json.loads(lib_data, cls=ExperimentDecoder)
+
+        FixedFrequencyTransmon._build_schedules = build_schedules
+
     def _test_library_equivalence(self, lib1, lib2) -> bool:
         """Test if libraries are equivalent.
 

--- a/test/calibration/test_setup_library.py
+++ b/test/calibration/test_setup_library.py
@@ -12,10 +12,14 @@
 
 """Class to test the calibrations setup methods."""
 
+import json
+
 from test.base import QiskitExperimentsTestCase
 import qiskit.pulse as pulse
+
 from qiskit_experiments.calibration_management.basis_gate_library import FixedFrequencyTransmon
 from qiskit_experiments.exceptions import CalibrationError
+from qiskit_experiments.framework.json import ExperimentEncoder, ExperimentDecoder
 
 
 class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
@@ -119,3 +123,68 @@ class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
 
         with self.assertRaises(CalibrationError):
             FixedFrequencyTransmon(basis_gates=["x", "bswap"])
+
+    def test_serialization(self):
+        """Test the serialization of the object."""
+
+        lib1 = FixedFrequencyTransmon(
+            basis_gates=["x", "sy"],
+            default_values={"duration": 320},
+            use_drag=False,
+            link_parameters=False,
+        )
+
+        lib2 = FixedFrequencyTransmon.from_config(lib1.config)
+
+        self.assertEqual(lib2.basis_gates, lib1.basis_gates)
+
+        # Note: we convert to string since the parameters prevent a direct comparison.
+        self.assertTrue(self._test_library_equivalence(lib1, lib2))
+
+        # Test that the extra args are properly accounted for.
+        lib3 = FixedFrequencyTransmon(
+            basis_gates=["x", "sy"],
+            default_values={"duration": 320},
+            use_drag=True,
+            link_parameters=False,
+        )
+
+        self.assertFalse(self._test_library_equivalence(lib1, lib3))
+
+    def test_json_serialization(self):
+        """Test that the library can be serialized using JSon."""
+
+        lib1 = FixedFrequencyTransmon(
+            basis_gates=["x", "sy"],
+            default_values={"duration": 320},
+            use_drag=False,
+            link_parameters=False,
+        )
+
+        # Test that serialization fails without the right encoder
+        with self.assertRaises(TypeError):
+            json.dumps(lib1)
+
+        # Test that serialization works with the proper library
+        lib_data = json.dumps(lib1, cls=ExperimentEncoder)
+        lib2 = json.loads(lib_data, cls=ExperimentDecoder)
+
+        self.assertTrue(self._test_library_equivalence(lib1, lib2))
+
+    def _test_library_equivalence(self, lib1, lib2) -> bool:
+        """Test if libraries are equivalent.
+
+        Two libraries are equivalent if they have the same basis gates and
+        if the strings of the schedules are equal. We cannot directly compare
+        the schedules because the parameter objects in them will be different
+        instances.
+        """
+
+        if len(set(lib1.basis_gates)) != len(set(lib2.basis_gates)):
+            return False
+
+        for gate in lib1.basis_gates:
+            if str(lib1[gate]) != str(lib2[gate]):
+                return False
+
+        return True

--- a/test/calibration/test_setup_library.py
+++ b/test/calibration/test_setup_library.py
@@ -87,15 +87,6 @@ class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
         # Test the basis gates of the library.
         self.assertListEqual(library.basis_gates, ["x", "y", "sx", "sy"])
 
-    def test_turn_off_drag(self):
-        """Test the use_drag parameter."""
-
-        library = FixedFrequencyTransmon(use_drag=False)
-        self.assertTrue(isinstance(library["x"].blocks[0].pulse, pulse.Gaussian))
-
-        library = FixedFrequencyTransmon()
-        self.assertTrue(isinstance(library["x"].blocks[0].pulse, pulse.Drag))
-
     def test_unlinked_parameters(self):
         """Test the we get schedules with unlinked parameters."""
 
@@ -150,7 +141,6 @@ class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
         lib1 = FixedFrequencyTransmon(
             basis_gates=["x", "sy"],
             default_values={"duration": 320},
-            use_drag=False,
             link_parameters=False,
         )
 
@@ -165,7 +155,6 @@ class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
         lib3 = FixedFrequencyTransmon(
             basis_gates=["x", "sy"],
             default_values={"duration": 320},
-            use_drag=True,
             link_parameters=False,
         )
 
@@ -177,7 +166,6 @@ class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
         lib1 = FixedFrequencyTransmon(
             basis_gates=["x", "sy"],
             default_values={"duration": 320},
-            use_drag=False,
             link_parameters=False,
         )
 

--- a/test/calibration/test_setup_library.py
+++ b/test/calibration/test_setup_library.py
@@ -155,7 +155,7 @@ class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
         lib3 = FixedFrequencyTransmon(
             basis_gates=["x", "sy"],
             default_values={"duration": 320},
-            link_parameters=False,
+            link_parameters=True,
         )
 
         self.assertFalse(self._test_library_equivalence(lib1, lib3))

--- a/test/calibration/test_setup_library.py
+++ b/test/calibration/test_setup_library.py
@@ -172,7 +172,14 @@ class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
         self.assertTrue(self._test_library_equivalence(lib1, lib2))
 
     def test_hash_warn(self):
-        """Test that a warning is raised when the hash of the library is different."""
+        """Test that a warning is raised when the hash of the library is different.
+
+        This test mimics the behaviour of the following workflow:
+        1. A user serializes a library.
+        2. Changes to the class of the library are made.
+        3. The user deserializes the library with the changed class.
+        4. A warning is raised since the class definition has changed.
+        """
 
         lib1 = FixedFrequencyTransmon()
         lib_data = json.dumps(lib1, cls=ExperimentEncoder)
@@ -187,11 +194,13 @@ class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
             """A dummy function to change the class behaviour."""
             pass
 
+        # Change the schedule behaviour
         FixedFrequencyTransmon._build_schedules = _my_build_schedules
 
         with self.assertWarns(UserWarning):
             json.loads(lib_data, cls=ExperimentDecoder)
 
+        # Restore the method for future tests.
         FixedFrequencyTransmon._build_schedules = build_schedules
 
     def _test_library_equivalence(self, lib1, lib2) -> bool:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR is part of #491 and focuses only on the library.

### Details and comments

* Serialization is implemented using kwargs. The tests show that the basis gate libraries can be serialized and deserialized with the `ExperimentEncoder` and with the `ExperimentDecoder`, respectively. 
* The basis gate library is now also a subclass of `Mapping` for convenience.
* The internal workings of the `__supported_gates__` has been reworked to make the internals of the class more consistent. To do this the internal variable `self._basis_gates`.
