### PR TITLE
set scheduling parameters in the base class

### DIFF
--- a/qiskit_experiments/library/characterization/t1.py
+++ b/qiskit_experiments/library/characterization/t1.py
@@ -19,7 +19,6 @@ import numpy as np
 from qiskit.utils import apply_prefix
 from qiskit.circuit import QuantumCircuit
 from qiskit.providers.backend import Backend
-from qiskit.test.mock import FakeBackend
 
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.library.characterization.analysis.t1_analysis import T1Analysis
@@ -93,16 +92,6 @@ class T1(BaseExperiment):
 
     def _set_backend(self, backend: Backend):
         super()._set_backend(backend)
-
-        # Scheduling parameters
-        if not self._backend.configuration().simulator and not isinstance(backend, FakeBackend):
-            timing_constraints = getattr(self.transpile_options, "timing_constraints", {})
-            if "acquire_alignment" not in timing_constraints:
-                timing_constraints["acquire_alignment"] = 16
-            scheduling_method = getattr(self.transpile_options, "scheduling_method", "alap")
-            self.set_transpile_options(
-                timing_constraints=timing_constraints, scheduling_method=scheduling_method
-            )
 
         # Set conversion factor
         if self.experiment_options.unit == "dt":

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -21,7 +21,6 @@ import qiskit
 from qiskit.utils import apply_prefix
 from qiskit.circuit import QuantumCircuit
 from qiskit.providers.backend import Backend
-from qiskit.test.mock import FakeBackend
 
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.library.characterization.analysis.t2ramsey_analysis import T2RamseyAnalysis
@@ -106,16 +105,6 @@ class T2Ramsey(BaseExperiment):
 
     def _set_backend(self, backend: Backend):
         super()._set_backend(backend)
-
-        # Scheduling parameters
-        if not self._backend.configuration().simulator and not isinstance(backend, FakeBackend):
-            timing_constraints = getattr(self.transpile_options, "timing_constraints", {})
-            if "acquire_alignment" not in timing_constraints:
-                timing_constraints["acquire_alignment"] = 16
-            scheduling_method = getattr(self.transpile_options, "scheduling_method", "alap")
-            self.set_transpile_options(
-                timing_constraints=timing_constraints, scheduling_method=scheduling_method
-            )
 
         # Set conversion factor
         if self.experiment_options.unit == "dt":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #535.
Implements one of the solutions that are suggested in #535. Transpiler options that involve scheduling will be set in the base class, if one of the circuits contains a delay gate.

### Details and comments


