### PR TITLE
[WIP] Draft of looping mechanisme for cals.

### DIFF
--- a/qiskit_experiments/library/calibration/fine_amplitude.py
+++ b/qiskit_experiments/library/calibration/fine_amplitude.py
@@ -132,11 +132,12 @@ class FineAmplitudeCal(BaseCalibrationExperiment, FineAmplitude):
             prev_amp = prev_amp[0] + 1.0j * prev_amp[1]
 
         d_theta = BaseUpdater.get_value(experiment_data, "d_theta", result_index)
+        self._latest_value = prev_amp * target_angle / (target_angle + d_theta)
 
         BaseUpdater.add_parameter_value(
             self._cals,
             experiment_data,
-            prev_amp * target_angle / (target_angle + d_theta),
+            self._latest_value,
             self._param_name,
             self._sched_name,
             group,

--- a/qiskit_experiments/library/calibration/fine_drag_cal.py
+++ b/qiskit_experiments/library/calibration/fine_drag_cal.py
@@ -136,10 +136,10 @@ class FineDragCal(BaseCalibrationExperiment, FineDrag):
         # See the documentation in fine_drag.py for the derivation of this rule.
         d_beta = -np.sqrt(np.pi) * d_theta * sigmas[0] / target_angle ** 2
         old_beta = experiment_data.metadata["cal_param_value"]
-        new_beta = old_beta + d_beta
+        self._latest_value = old_beta + d_beta
 
         BaseUpdater.add_parameter_value(
-            self._cals, experiment_data, new_beta, self._param_name, schedule, group
+            self._cals, experiment_data, self._latest_value, self._param_name, schedule, group
         )
 
 

--- a/qiskit_experiments/library/calibration/frequency_cal.py
+++ b/qiskit_experiments/library/calibration/frequency_cal.py
@@ -92,12 +92,12 @@ class FrequencyCal(BaseCalibrationExperiment, RamseyXY):
         old_freq = experiment_data.metadata["cal_param_value"]
 
         fit_freq = BaseUpdater.get_value(experiment_data, "freq", result_index)
-        new_freq = old_freq + fit_freq - osc_freq
+        self._latest_value = old_freq + fit_freq - osc_freq
 
         BaseUpdater.add_parameter_value(
             self._cals,
             experiment_data,
-            new_freq,
+            self._latest_value,
             self._param_name,
             group=group,
         )

--- a/qiskit_experiments/library/calibration/half_angle_cal.py
+++ b/qiskit_experiments/library/calibration/half_angle_cal.py
@@ -110,12 +110,12 @@ class HalfAngleCal(BaseCalibrationExperiment, HalfAngle):
         prev_amp = experiment_data.metadata["cal_param_value"]
 
         d_theta = BaseUpdater.get_value(experiment_data, "d_hac", result_index)
-        new_amp = prev_amp * np.exp(-1.0j * d_theta / 2)
+        self._latest_value = prev_amp * np.exp(-1.0j * d_theta / 2)
 
         BaseUpdater.add_parameter_value(
             self._cals,
             experiment_data,
-            new_amp,
+            self._latest_value,
             self._param_name,
             self._sched_name,
             group,

--- a/qiskit_experiments/library/calibration/rough_drag_cal.py
+++ b/qiskit_experiments/library/calibration/rough_drag_cal.py
@@ -99,14 +99,14 @@ class RoughDragCal(BaseCalibrationExperiment, RoughDrag):
         See :class:`DragCalAnalysis` for details on the fit.
         """
 
-        new_beta = BaseUpdater.get_value(
+        self._latest_value = BaseUpdater.get_value(
             experiment_data, "beta", self.experiment_options.result_index
         )
 
         BaseUpdater.add_parameter_value(
             self._cals,
             experiment_data,
-            new_beta,
+            self._latest_value,
             self._param_name,
             self._sched_name,
             self.experiment_options.group,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Many calibration experiments need to be iterated. This is typical for `fine` calibration experiments. This PR explores how to best implement this behavior. 

### Details and comments

Fine calibration experiments need to be iterated. Here, there is no optimizer. The experiment is simply ran several times until the error parameter we are trying to suppress (e.g. an angle deviation) is reduced to below a given tolerance. This PR implements a mechanism to do this iteration by extending the `BaseCalibrationExperiment` class.

