### PR TITLE
Change config from property to method

### DIFF
--- a/qiskit_experiments/calibration_management/basis_gate_library.py
+++ b/qiskit_experiments/calibration_management/basis_gate_library.py
@@ -140,7 +140,6 @@ class BasisGateLibrary(ABC, Mapping):
             are the corresponding schedules.
         """
 
-    @property
     def config(self) -> Dict[str, Any]:
         """Return the settings used to initialize the library."""
 
@@ -169,7 +168,7 @@ class BasisGateLibrary(ABC, Mapping):
 
     def __json_encode__(self):
         """Convert to format that can be JSON serialized."""
-        return self.config
+        return self.config()
 
     @classmethod
     def __json_decode__(cls, value: Dict[str, Any]) -> "BasisGateLibrary":

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -52,7 +52,6 @@ class ExperimentConfig:
     run_options: Dict[str, Any] = dataclasses.field(default_factory=dict)
     version: str = __version__
 
-    @property
     def experiment(self) -> "BaseExperiment":
         """Return the experiment constructed from this config.
 
@@ -187,7 +186,6 @@ class BaseExperiment(ABC, Settings):
         ret._analysis_options = copy.copy(self._analysis_options)
         return ret
 
-    @property
     def config(self) -> ExperimentConfig:
         """Return the config dataclass for this experiment"""
         args = tuple(getattr(self, "__init_args__", OrderedDict()).values())
@@ -515,7 +513,7 @@ class BaseExperiment(ABC, Settings):
 
     def __json_encode__(self):
         """Convert to format that can be JSON serialized"""
-        return self.config
+        return self.config()
 
     @classmethod
     def __json_decode__(cls, value):

--- a/test/base.py
+++ b/test/base.py
@@ -51,8 +51,8 @@ class QiskitExperimentsTestCase(QiskitTestCase):
     def experiments_equiv(exp1, exp2) -> bool:
         """Check if two experiments are equivalent by comparing their configs"""
         # pylint: disable = too-many-boolean-expressions, too-many-return-statements
-        config1 = exp1.config
-        config2 = exp2.config
+        config1 = exp1.config()
+        config2 = exp2.config()
         try:
             if config1 == config2:
                 return True

--- a/test/calibration/experiments/test_drag.py
+++ b/test/calibration/experiments/test_drag.py
@@ -164,7 +164,7 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
     def test_dragcal_experiment_config(self):
         """Test RoughDragCal config can round trip"""
         exp = RoughDragCal(0, self.cals, backend=self.backend)
-        loaded_exp = RoughDragCal.from_config(exp.config)
+        loaded_exp = RoughDragCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 
@@ -179,7 +179,7 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
         with pulse.build(name="xp") as sched:
             pulse.play(pulse.Drag(160, 0.5, 40, Parameter("β")), pulse.DriveChannel(0))
         exp = RoughDrag(0, backend=self.backend, schedule=sched)
-        loaded_exp = RoughDrag.from_config(exp.config)
+        loaded_exp = RoughDrag.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 

--- a/test/calibration/experiments/test_fine_amplitude.py
+++ b/test/calibration/experiments/test_fine_amplitude.py
@@ -269,7 +269,7 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = FineSXAmplitudeCal(0, self.cals, "sx")
-        loaded_exp = FineSXAmplitudeCal.from_config(exp.config)
+        loaded_exp = FineSXAmplitudeCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 

--- a/test/calibration/experiments/test_fine_drag.py
+++ b/test/calibration/experiments/test_fine_drag.py
@@ -79,10 +79,10 @@ class TestFineDrag(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = FineDrag(0, Gate("Drag", num_qubits=1, params=[]))
-        config = exp.config
+        config = exp.config()
         loaded_exp = FineDrag.from_config(config)
         self.assertNotEqual(exp, loaded_exp)
-        self.assertEqual(config, loaded_exp.config)
+        self.assertEqual(config, loaded_exp.config())
 
 
 class TestFineDragCal(QiskitExperimentsTestCase):
@@ -100,10 +100,10 @@ class TestFineDragCal(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = FineDragCal(0, self.cals, schedule_name="x")
-        config = exp.config
+        config = exp.config()
         loaded_exp = FineDragCal.from_config(config)
         self.assertNotEqual(exp, loaded_exp)
-        self.assertEqual(config, loaded_exp.config)
+        self.assertEqual(config, loaded_exp.config())
 
     def test_update_cals(self):
         """Test that the calibrations are updated."""

--- a/test/calibration/experiments/test_rabi.py
+++ b/test/calibration/experiments/test_rabi.py
@@ -96,7 +96,7 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = Rabi(0, self.sched)
-        loaded_exp = Rabi.from_config(exp.config)
+        loaded_exp = Rabi.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 
@@ -165,7 +165,7 @@ class TestEFRabi(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = EFRabi(0, self.sched)
-        loaded_exp = EFRabi.from_config(exp.config)
+        loaded_exp = EFRabi.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 

--- a/test/calibration/experiments/test_ramsey_xy.py
+++ b/test/calibration/experiments/test_ramsey_xy.py
@@ -70,7 +70,7 @@ class TestRamseyXY(QiskitExperimentsTestCase):
     def test_ramseyxy_experiment_config(self):
         """Test RamseyXY config roundtrips"""
         exp = RamseyXY(0)
-        loaded_exp = RamseyXY.from_config(exp.config)
+        loaded_exp = RamseyXY.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 
@@ -82,7 +82,7 @@ class TestRamseyXY(QiskitExperimentsTestCase):
     def test_cal_experiment_config(self):
         """Test FrequencyCal config roundtrips"""
         exp = FrequencyCal(0, self.cals)
-        loaded_exp = FrequencyCal.from_config(exp.config)
+        loaded_exp = FrequencyCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 

--- a/test/calibration/experiments/test_rough_amplitude.py
+++ b/test/calibration/experiments/test_rough_amplitude.py
@@ -69,10 +69,10 @@ class TestRoughAmpCal(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = RoughXSXAmplitudeCal(0, self.cals)
-        config = exp.config
+        config = exp.config()
         loaded_exp = RoughXSXAmplitudeCal.from_config(config)
         self.assertNotEqual(exp, loaded_exp)
-        self.assertEqual(config, loaded_exp.config)
+        self.assertEqual(config, loaded_exp.config())
 
 
 class TestSpecializations(QiskitExperimentsTestCase):

--- a/test/calibration/experiments/test_rough_frequency.py
+++ b/test/calibration/experiments/test_rough_frequency.py
@@ -72,6 +72,6 @@ class TestRoughFrequency(QiskitExperimentsTestCase):
         cals = BackendCalibrations(FakeArmonk())
         frequencies = [1, 2, 3]
         exp = RoughFrequencyCal(0, cals, frequencies)
-        loaded_exp = RoughFrequencyCal.from_config(exp.config)
+        loaded_exp = RoughFrequencyCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))

--- a/test/calibration/test_setup_library.py
+++ b/test/calibration/test_setup_library.py
@@ -144,7 +144,7 @@ class TestFixedFrequencyTransmon(QiskitExperimentsTestCase):
             link_parameters=False,
         )
 
-        lib2 = FixedFrequencyTransmon.from_config(lib1.config)
+        lib2 = FixedFrequencyTransmon.from_config(lib1.config())
 
         self.assertEqual(lib2.basis_gates, lib1.basis_gates)
 

--- a/test/quantum_volume/test_qv.py
+++ b/test/quantum_volume/test_qv.py
@@ -245,7 +245,7 @@ class TestQuantumVolume(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = QuantumVolume([0, 1, 2], seed=42)
-        loaded_exp = QuantumVolume.from_config(exp.config)
+        loaded_exp = QuantumVolume.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 

--- a/test/randomized_benchmarking/test_rb.py
+++ b/test/randomized_benchmarking/test_rb.py
@@ -161,7 +161,7 @@ class TestStandardRB(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = StandardRB([0, 1], lengths=[10, 20, 30, 40], num_samples=10)
-        loaded_exp = StandardRB.from_config(exp.config)
+        loaded_exp = StandardRB.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 
@@ -261,7 +261,7 @@ class TestInterleavedRB(TestStandardRB):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = InterleavedRB(CXGate(), [0, 1], lengths=[10, 20, 30, 40], num_samples=10)
-        loaded_exp = InterleavedRB.from_config(exp.config)
+        loaded_exp = InterleavedRB.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 

--- a/test/test_cross_resonance_hamiltonian.py
+++ b/test/test_cross_resonance_hamiltonian.py
@@ -337,7 +337,7 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
             sigma=20,
             risefall=2,
         )
-        loaded_exp = cr_hamiltonian.CrossResonanceHamiltonian.from_config(exp.config)
+        loaded_exp = cr_hamiltonian.CrossResonanceHamiltonian.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 

--- a/test/test_half_angle.py
+++ b/test/test_half_angle.py
@@ -82,7 +82,7 @@ class TestHalfAngle(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = HalfAngle(1)
-        config = exp.config
+        config = exp.config()
         loaded_exp = HalfAngle.from_config(config)
         self.assertNotEqual(exp, loaded_exp)
-        self.assertEqual(config, loaded_exp.config)
+        self.assertEqual(config, loaded_exp.config())

--- a/test/test_qubit_spectroscopy.py
+++ b/test/test_qubit_spectroscopy.py
@@ -145,7 +145,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = QubitSpectroscopy(1, np.linspace(100, 150, 20), unit="MHz")
-        loaded_exp = QubitSpectroscopy.from_config(exp.config)
+        loaded_exp = QubitSpectroscopy.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 

--- a/test/test_t1.py
+++ b/test/test_t1.py
@@ -216,7 +216,7 @@ class TestT1(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = T1(0, [1, 2, 3, 4, 5], unit="s")
-        loaded_exp = T1.from_config(exp.config)
+        loaded_exp = T1.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 

--- a/test/test_t2ramsey.py
+++ b/test/test_t2ramsey.py
@@ -202,7 +202,7 @@ class TestT2Ramsey(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = T2Ramsey(0, [1, 2, 3, 4, 5], unit="s")
-        loaded_exp = T2Ramsey.from_config(exp.config)
+        loaded_exp = T2Ramsey.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 

--- a/test/test_tomography.py
+++ b/test/test_tomography.py
@@ -269,7 +269,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = StateTomography(QuantumCircuit(3), measurement_qubits=[0, 2], qubits=[5, 7, 1])
-        loaded_exp = StateTomography.from_config(exp.config)
+        loaded_exp = StateTomography.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 
@@ -481,7 +481,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = ProcessTomography(teleport_circuit(), measurement_qubits=[2], preparation_qubits=[0])
-        loaded_exp = ProcessTomography.from_config(exp.config)
+        loaded_exp = ProcessTomography.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.experiments_equiv(exp, loaded_exp))
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Changes the `config` property added to BaseExperiment and Calibrations to a method.

Since this is doing some computation and returning a derived quantity it isn't really a property so a method call seems more intuitive and safer. This change should probably be included before release because changing from a property to method later is a difficult thing to handle with deprecations.

### Details and comments


