### PR TITLE
Copy run options from V2 backend

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -21,7 +21,7 @@ import warnings
 
 from qiskit import transpile, assemble, QuantumCircuit
 from qiskit.providers import BaseJob
-from qiskit.providers import Backend, BaseBackend
+from qiskit.providers import Backend, BaseBackend, BackendV2
 from qiskit.providers.basebackend import BaseBackend as LegacyBackend
 from qiskit.exceptions import QiskitError
 from qiskit.qobj.utils import MeasLevel
@@ -141,6 +141,12 @@ class BaseExperiment(ABC, StoreInitArgs):
         properties from the supplied backend if required.
         """
         self._backend = backend
+
+        # V2 backend object will provide a set of dynamic parameters with default values.
+        # These options are copied to the experiment instance so that we can
+        # reproduce the experiment afterward, and user can know a set of available options.
+        if isinstance(backend, BackendV2):
+            self.set_experiment_options(**backend.options.__dict__)
 
     def copy(self) -> "BaseExperiment":
         """Return a copy of the experiment"""
@@ -423,7 +429,7 @@ class BaseExperiment(ABC, StoreInitArgs):
     @classmethod
     def _default_run_options(cls) -> Options:
         """Default options values for the experiment :meth:`run` method."""
-        return Options(meas_level=MeasLevel.CLASSIFIED)
+        return Options()
 
     @property
     def run_options(self) -> Options:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR updates `BaseExperiment._set_backend` to copy run options from the backend when V2 backend is specified.


### Details and comments

on hold until terra 0.19 is released
