### PR TITLE
Fix unnecessary expdata copy for composite exps

### DIFF
--- a/qiskit_experiments/framework/base_analysis.py
+++ b/qiskit_experiments/framework/base_analysis.py
@@ -141,12 +141,7 @@ class BaseAnalysis(ABC, StoreInitArgs):
             This data can then be saved as its own experiment to a database service.
         """
         # Make a new copy of experiment data if not updating results
-        if not replace_results and (
-            experiment_data._created_in_db
-            or experiment_data._analysis_results
-            or experiment_data._figures
-            or getattr(experiment_data, "_child_data", None)
-        ):
+        if not replace_results and _requires_copy(experiment_data):
             experiment_data = experiment_data.copy()
 
         # Get experiment device components
@@ -229,3 +224,23 @@ class BaseAnalysis(ABC, StoreInitArgs):
     @classmethod
     def __json_decode__(cls, value):
         return cls.from_config(value)
+
+
+def _requires_copy(experiment_data) -> bool:
+    """Return True if a copy of the experiment data should be made."""
+    # If data is from DB or contains analysis results it should be copied
+    if (
+        experiment_data._created_in_db
+        or experiment_data._analysis_results
+        or experiment_data._figures
+    ):
+        return True
+
+    # Check child data:
+    if hasattr(experiment_data, "_child_data"):
+        for subdata in experiment_data._child_data.values():
+            if _requires_copy(subdata):
+                return True
+
+    # No Copy required
+    return False

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -186,11 +186,11 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
 
         # Additional data not part of composite experiment
         exp3 = FakeExperiment([0, 1])
-        extra_data = exp3.run(FakeBackend())
+        extra_data = exp3.run(FakeBackend()).block_for_results()
         data1.add_child_data(extra_data)
 
         # Replace results
-        data2 = par_exp.analysis.run(data1, replace_results=True)
+        data2 = par_exp.analysis.run(data1, replace_results=True).block_for_results()
         self.assertEqual(data1, data2)
         self.assertEqual(len(data1.child_data()), len(data2.child_data()))
         for sub1, sub2 in zip(data1.child_data(), data2.child_data()):
@@ -207,11 +207,11 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
 
         # Additional data not part of composite experiment
         exp3 = FakeExperiment([0, 1])
-        extra_data = exp3.run(FakeBackend())
+        extra_data = exp3.run(FakeBackend()).block_for_results()
         data1.add_child_data(extra_data)
 
         # Replace results
-        data2 = par_exp.analysis.run(data1, replace_results=False)
+        data2 = par_exp.analysis.run(data1).block_for_results()
         self.assertNotEqual(data1.experiment_id, data2.experiment_id)
         self.assertEqual(len(data1.child_data()), len(data2.child_data()))
         for sub1, sub2 in zip(data1.child_data(), data2.child_data()):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes check in BaseAnalysis for whether the ExperimentData container requires copying to avoid an unnecessary copy for empty composite experiment data containers.

### Details and comments

Adds debug msg to logger so running with log level DEBUG will show when experiment data is copied

