### PR TITLE
Fix Sphinx build on Python 3.9+

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -14,7 +14,7 @@ Experiment Data class
 """
 from __future__ import annotations
 import logging
-from typing import Dict, Optional, List, Union
+from typing import Dict, Optional, List, Union, TYPE_CHECKING
 from datetime import datetime
 import warnings
 from qiskit.exceptions import QiskitError
@@ -24,6 +24,13 @@ from qiskit_experiments.database_service.database_service import (
     DatabaseServiceV1 as DatabaseService,
 )
 from qiskit_experiments.database_service.utils import ThreadSafeOrderedDict
+
+if TYPE_CHECKING:
+    # There is a cyclical dependency here, but the name needs to exist for
+    # Sphinx on Python 3.9+ to link type hints correctly.  The gating on
+    # `TYPE_CHECKING` means that the import will never be resolved by an actual
+    # interpreter, only static analysis.
+    from . import BaseExperiment
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Summary

On Python 3.9, Sphinx requires that forwards references (type hints with
their names in strings) resolve to actual names after the document is
parsed.  There is a cyclical dependency that prevents the name from
being imported properly, but we can using `typing.TYPE_CHECKING` to
limit the import to only analysis tools (like Sphinx here) that are able
to handle it.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

Part of my efforts to ensure that all the components can build on Python 3.9 and Sphinx 4.4 (Qiskit/qiskit#1400).

The current documentation build on Python 3.8 doesn't raise a warning, but it silently does the wrong thing: here's the built version of the documentation, where the `experiment` parameter's type is called `Optional[ForwardRef]` instead of `Optional[BaseExperiment]`.  After this PR, it will be the latter, and the correct crossref will be in place.

<img width="829" alt="Screenshot 2022-01-18 at 11 27 17" src="https://user-images.githubusercontent.com/5968590/149929243-3b8d7bd2-19e7-4921-bd7f-0fe64cc9cfc9.png">

