### PR TITLE
Fix experiment equiv check in unittest

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -14,7 +14,7 @@ Experiment Data class
 """
 from __future__ import annotations
 import logging
-from typing import Dict, Optional, List, Union
+from typing import Dict, Optional, List, Union, TYPE_CHECKING
 from datetime import datetime
 import warnings
 from qiskit.exceptions import QiskitError
@@ -24,6 +24,13 @@ from qiskit_experiments.database_service.database_service import (
     DatabaseServiceV1 as DatabaseService,
 )
 from qiskit_experiments.database_service.utils import ThreadSafeOrderedDict
+
+if TYPE_CHECKING:
+    # There is a cyclical dependency here, but the name needs to exist for
+    # Sphinx on Python 3.9+ to link type hints correctly.  The gating on
+    # `TYPE_CHECKING` means that the import will never be resolved by an actual
+    # interpreter, only static analysis.
+    from . import BaseExperiment
 
 LOG = logging.getLogger(__name__)
 

--- a/test/base.py
+++ b/test/base.py
@@ -71,7 +71,7 @@ def _test_all_elements_equiv(data1, data2) -> bool:
     """A helper function to check if two data are equivalent."""
     # pylint: disable = too-many-return-statements
     configrable_type = (BaseExperiment, BaseAnalysis)
-    list_type = (list, tuple)
+    list_type = (list, tuple, set)
 
     if isinstance(data1, configrable_type) and isinstance(data2, configrable_type):
         return _test_all_elements_equiv(data1.config(), data2.config())

--- a/test/calibration/experiments/test_drag.py
+++ b/test/calibration/experiments/test_drag.py
@@ -166,13 +166,13 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
         exp = RoughDragCal(0, self.cals, backend=self.backend)
         loaded_exp = RoughDragCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     @unittest.skip("Calibration experiments are not yet JSON serializable")
     def test_dragcal_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = RoughDragCal(0, self.cals)
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)
 
     def test_drag_experiment_config(self):
         """Test RoughDrag config can roundtrip"""
@@ -181,7 +181,7 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
         exp = RoughDrag(0, backend=self.backend, schedule=sched)
         loaded_exp = RoughDrag.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     @unittest.skip("Schedules are not yet JSON serializable")
     def test_drag_roundtrip_serializable(self):
@@ -189,4 +189,4 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
         with pulse.build(name="xp") as sched:
             pulse.play(pulse.Drag(160, 0.5, 40, Parameter("β")), pulse.DriveChannel(0))
         exp = RoughDrag(0, backend=self.backend, schedule=sched)
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/calibration/experiments/test_fine_amplitude.py
+++ b/test/calibration/experiments/test_fine_amplitude.py
@@ -271,10 +271,10 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         exp = FineSXAmplitudeCal(0, self.cals, "sx")
         loaded_exp = FineSXAmplitudeCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     @unittest.skip("Calbrations are not yet serializable")
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = FineSXAmplitudeCal(0, self.cals, "sx")
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/calibration/experiments/test_fine_frequency.py
+++ b/test/calibration/experiments/test_fine_frequency.py
@@ -91,9 +91,9 @@ class TestFineFreqEndToEnd(QiskitExperimentsTestCase):
         exp = FineFrequency(0, 160)
         loaded_exp = FineFrequency.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = FineFrequency(0, 160)
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/calibration/experiments/test_rabi.py
+++ b/test/calibration/experiments/test_rabi.py
@@ -98,13 +98,13 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
         exp = Rabi(0, self.sched)
         loaded_exp = Rabi.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     @unittest.skip("Schedules are not yet JSON serializable")
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = Rabi(0, self.sched)
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)
 
 
 class TestEFRabi(QiskitExperimentsTestCase):
@@ -167,13 +167,13 @@ class TestEFRabi(QiskitExperimentsTestCase):
         exp = EFRabi(0, self.sched)
         loaded_exp = EFRabi.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     @unittest.skip("Schedules are not yet JSON serializable")
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = EFRabi(0, self.sched)
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)
 
 
 class TestRabiCircuits(QiskitExperimentsTestCase):

--- a/test/calibration/experiments/test_ramsey_xy.py
+++ b/test/calibration/experiments/test_ramsey_xy.py
@@ -74,22 +74,22 @@ class TestRamseyXY(QiskitExperimentsTestCase):
         exp = RamseyXY(0)
         loaded_exp = RamseyXY.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_ramseyxy_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = RamseyXY(0)
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)
 
     def test_cal_experiment_config(self):
         """Test FrequencyCal config roundtrips"""
         exp = FrequencyCal(0, self.cals)
         loaded_exp = FrequencyCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     @unittest.skip("Cal experiments are not yet JSON serializable")
     def test_freqcal_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = FrequencyCal(0, self.cals)
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/calibration/experiments/test_rough_frequency.py
+++ b/test/calibration/experiments/test_rough_frequency.py
@@ -73,4 +73,4 @@ class TestRoughFrequency(QiskitExperimentsTestCase):
         exp = RoughFrequencyCal(0, cals, frequencies)
         loaded_exp = RoughFrequencyCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))

--- a/test/database_service/test_json.py
+++ b/test/database_service/test_json.py
@@ -60,7 +60,7 @@ class TestJSON(QiskitExperimentsTestCase):
         obj = FakeExperiment([0])
         obj.set_transpile_options(optimization_level=3, basis_gates=["rx", "ry", "cz"])
         obj.set_run_options(shots=2000)
-        self.assertRoundTripSerializable(obj, self.experiments_equiv)
+        self.assertRoundTripSerializable(obj, self.json_equiv)
 
     def test_roundtrip_quantum_circuit(self):
         """Test round-trip serialization of a circuits"""

--- a/test/quantum_volume/test_qv.py
+++ b/test/quantum_volume/test_qv.py
@@ -247,9 +247,9 @@ class TestQuantumVolume(QiskitExperimentsTestCase):
         exp = QuantumVolume([0, 1, 2], seed=42)
         loaded_exp = QuantumVolume.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = QuantumVolume([0, 1, 2], seed=42)
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/randomized_benchmarking/test_rb.py
+++ b/test/randomized_benchmarking/test_rb.py
@@ -163,12 +163,12 @@ class TestStandardRB(QiskitExperimentsTestCase):
         exp = StandardRB([0, 1], lengths=[10, 20, 30, 40], num_samples=10)
         loaded_exp = StandardRB.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = StandardRB([0, 1], lengths=[10, 20, 30, 40], num_samples=10)
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)
 
 
 @ddt
@@ -263,9 +263,9 @@ class TestInterleavedRB(TestStandardRB):
         exp = InterleavedRB(CXGate(), [0, 1], lengths=[10, 20, 30, 40], num_samples=10)
         loaded_exp = InterleavedRB.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = InterleavedRB(CXGate(), [0, 1], lengths=[10, 20, 30, 40], num_samples=10)
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -77,7 +77,7 @@ class TestComposite(QiskitExperimentsTestCase):
 
         loaded_exp = BatchExperiment.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
@@ -88,7 +88,7 @@ class TestComposite(QiskitExperimentsTestCase):
 
         exp = BatchExperiment([exp1, exp2])
 
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)
 
 
 class TestCompositeExperimentData(QiskitExperimentsTestCase):

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -66,6 +66,30 @@ class TestComposite(QiskitExperimentsTestCase):
 
             par_exp.run(FakeBackend())
 
+    def test_experiment_config(self):
+        """Test converting to and from config works"""
+        exp1 = FakeExperiment([0])
+        exp1.set_run_options(shots=1000)
+        exp2 = FakeExperiment([2])
+        exp2.set_run_options(shots=2000)
+
+        exp = BatchExperiment([exp1, exp2])
+
+        loaded_exp = BatchExperiment.from_config(exp.config())
+        self.assertNotEqual(exp, loaded_exp)
+        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+
+    def test_roundtrip_serializable(self):
+        """Test round trip JSON serialization"""
+        exp1 = FakeExperiment([0])
+        exp1.set_run_options(shots=1000)
+        exp2 = FakeExperiment([2])
+        exp2.set_run_options(shots=2000)
+
+        exp = BatchExperiment([exp1, exp2])
+
+        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+
 
 class TestCompositeExperimentData(QiskitExperimentsTestCase):
     """

--- a/test/test_cross_resonance_hamiltonian.py
+++ b/test/test_cross_resonance_hamiltonian.py
@@ -267,7 +267,7 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
         )
         loaded_exp = cr_hamiltonian.CrossResonanceHamiltonian.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
@@ -278,4 +278,4 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
             sigma=64,
             risefall=2,
         )
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/test_qubit_spectroscopy.py
+++ b/test/test_qubit_spectroscopy.py
@@ -147,9 +147,9 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         exp = QubitSpectroscopy(1, np.linspace(100, 150, 20) * 1e6)
         loaded_exp = QubitSpectroscopy.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = QubitSpectroscopy(1, np.linspace(int(100e6), int(150e6), int(20e6)))
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/test_t1.py
+++ b/test/test_t1.py
@@ -202,12 +202,12 @@ class TestT1(QiskitExperimentsTestCase):
         exp = T1(0, [1, 2, 3, 4, 5])
         loaded_exp = T1.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = T1(0, [1, 2, 3, 4, 5])
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)
 
     def test_analysis_config(self):
         """ "Test converting analysis to and from config works"""

--- a/test/test_t2ramsey.py
+++ b/test/test_t2ramsey.py
@@ -192,12 +192,12 @@ class TestT2Ramsey(QiskitExperimentsTestCase):
         exp = T2Ramsey(0, [1, 2, 3, 4, 5])
         loaded_exp = T2Ramsey.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = T2Ramsey(0, [1, 2, 3, 4, 5])
-        self.assertRoundTripSerializable(exp, self.experiments_equiv)
+        self.assertRoundTripSerializable(exp, self.json_equiv)
 
     def test_analysis_config(self):
         """ "Test converting analysis to and from config works"""

--- a/test/test_tomography.py
+++ b/test/test_tomography.py
@@ -272,7 +272,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
         exp = StateTomography(QuantumCircuit(3), measurement_qubits=[0, 2], qubits=[5, 7, 1])
         loaded_exp = StateTomography.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_analysis_config(self):
         """ "Test converting analysis to and from config works"""
@@ -491,7 +491,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         exp = ProcessTomography(teleport_circuit(), measurement_qubits=[2], preparation_qubits=[0])
         loaded_exp = ProcessTomography.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.experiments_equiv(exp, loaded_exp))
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_analysis_config(self):
         """ "Test converting analysis to and from config works"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In current equivalence checking we assume all args or kwargs value are not Experiment nor Analysis object. However if we need to write round-trip json test for composite experiment indeed args contain these objects and test fails. New code checks each element in the arg and apply special equivalence check if the element is Experiment or Analysis.

### Details and comments


