### PR TITLE
Update error amplification boundary

### DIFF
--- a/qiskit_experiments/curve_analysis/standard_analysis/error_amplification_analysis.py
+++ b/qiskit_experiments/curve_analysis/standard_analysis/error_amplification_analysis.py
@@ -73,8 +73,8 @@ class ErrorAmplificationAnalysis(curve.CurveAnalysis):
                 Extra guesses are added based on curve data when either :math:`\rm amp` or
                 :math:`\rm base` is :math:`\pi/2`. See fit model for details.
             bounds: [-0.8 pi, 0.8 pi]. The bounds do not include plus and minus pi since these values
-                often correspond to symmetry points of the fit function. Furthermore, this type of analysis
-                is intended for values of :math:`d\theta` close to zero.
+                often correspond to symmetry points of the fit function. Furthermore,
+                this type of analysis is intended for values of :math:`d\theta` close to zero.
 
     # section: note
 

--- a/qiskit_experiments/curve_analysis/standard_analysis/error_amplification_analysis.py
+++ b/qiskit_experiments/curve_analysis/standard_analysis/error_amplification_analysis.py
@@ -72,7 +72,9 @@ class ErrorAmplificationAnalysis(curve.CurveAnalysis):
                 where a is given by :code:`max(abs(angle_per_gate), np.pi / 2)`.
                 Extra guesses are added based on curve data when either :math:`\rm amp` or
                 :math:`\rm base` is :math:`\pi/2`. See fit model for details.
-            bounds: [-0.8 pi, 0.8 pi].
+            bounds: [-0.8 pi, 0.8 pi]. The bounds do not include plus and minus pi since these values
+                often correspond to symmetry points of the fit function. Furthermore, this type of analysis
+                is intended for values of :math:`d\theta` close to zero.
 
     # section: note
 

--- a/qiskit_experiments/curve_analysis/standard_analysis/error_amplification_analysis.py
+++ b/qiskit_experiments/curve_analysis/standard_analysis/error_amplification_analysis.py
@@ -141,7 +141,9 @@ class ErrorAmplificationAnalysis(curve.CurveAnalysis):
         max_abs_y, _ = curve.guess.max_height(curve_data.y, absolute=True)
         max_y, min_y = np.max(curve_data.y), np.min(curve_data.y)
 
-        user_opt.bounds.set_if_empty(d_theta=(-np.pi, np.pi), base=(-max_abs_y, max_abs_y))
+        user_opt.bounds.set_if_empty(
+            d_theta=(-0.8 * np.pi, 0.8 * np.pi), base=(-max_abs_y, max_abs_y)
+        )
         user_opt.p0.set_if_empty(base=(max_y + min_y) / 2)
 
         if "amp" in user_opt.p0:

--- a/qiskit_experiments/curve_analysis/standard_analysis/error_amplification_analysis.py
+++ b/qiskit_experiments/curve_analysis/standard_analysis/error_amplification_analysis.py
@@ -72,7 +72,7 @@ class ErrorAmplificationAnalysis(curve.CurveAnalysis):
                 where a is given by :code:`max(abs(angle_per_gate), np.pi / 2)`.
                 Extra guesses are added based on curve data when either :math:`\rm amp` or
                 :math:`\rm base` is :math:`\pi/2`. See fit model for details.
-            bounds: [-pi, pi].
+            bounds: [-0.8 pi, 0.8 pi].
 
     # section: note
 

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -14,7 +14,7 @@ Experiment Data class
 """
 from __future__ import annotations
 import logging
-from typing import Dict, Optional, List, Union
+from typing import Dict, Optional, List, Union, TYPE_CHECKING
 from datetime import datetime
 import warnings
 from qiskit.exceptions import QiskitError
@@ -24,6 +24,13 @@ from qiskit_experiments.database_service.database_service import (
     DatabaseServiceV1 as DatabaseService,
 )
 from qiskit_experiments.database_service.utils import ThreadSafeOrderedDict
+
+if TYPE_CHECKING:
+    # There is a cyclical dependency here, but the name needs to exist for
+    # Sphinx on Python 3.9+ to link type hints correctly.  The gating on
+    # `TYPE_CHECKING` means that the import will never be resolved by an actual
+    # interpreter, only static analysis.
+    from . import BaseExperiment
 
 LOG = logging.getLogger(__name__)
 

--- a/releasenotes/notes/fix-error-amp-analysis-bounds-784f3aa66d16048a.yaml
+++ b/releasenotes/notes/fix-error-amp-analysis-bounds-784f3aa66d16048a.yaml
@@ -3,6 +3,9 @@ other:
   - |
     Default fit bounds for ``d_theta`` parameter of
     :py:class:`qiskit_experiments.curve_analysis.ErrorAmplificationAnalysis`
-    class has been updated from [-pi, pi] to [-0.8 pi, 0.8 pi]. This change will improve
-    the bad fit when the error value is really close to zero.
+    class has been updated from [-pi, pi] to [-0.8 pi, 0.8 pi].
+    This change will improve the bad fit when the error value is really close to zero.
     This has sometimes yielded in ``d_theta`` ~ pi rather than zero.
+    Though 0.8 is the empirical factor, this is okey for most situations since
+    the amplification analysis is applied to experiments in the small error regime
+    (this is often sufficiently smaller than pi).

--- a/releasenotes/notes/fix-error-amp-analysis-bounds-784f3aa66d16048a.yaml
+++ b/releasenotes/notes/fix-error-amp-analysis-bounds-784f3aa66d16048a.yaml
@@ -1,0 +1,8 @@
+---
+other:
+  - |
+    Default fit bounds for ``d_theta`` parameter of
+    :py:class:`qiskit_experiments.curve_analysis.ErrorAmplificationAnalysis`
+    class has been updated from [-pi, pi] to [-0.8 pi, 0.8 pi]. This change will improve
+    the bad fit when the error value is really close to zero.
+    This has sometimes yielded in ``d_theta`` ~ pi rather than zero.

--- a/test/curve_analysis/test_standard_analysis.py
+++ b/test/curve_analysis/test_standard_analysis.py
@@ -10,8 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Test parameter guess functions."""
-# pylint: disable=invalid-name
+"""Test standard analysis base classes."""
 
 from test.base import QiskitExperimentsTestCase
 import numpy as np

--- a/test/curve_analysis/test_standard_analysis.py
+++ b/test/curve_analysis/test_standard_analysis.py
@@ -1,0 +1,77 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test parameter guess functions."""
+# pylint: disable=invalid-name
+
+from test.base import QiskitExperimentsTestCase
+import numpy as np
+from ddt import ddt, data
+
+from qiskit_experiments.curve_analysis import ErrorAmplificationAnalysis
+from qiskit_experiments.data_processing import DataProcessor
+from qiskit_experiments.data_processing.nodes import Probability
+from qiskit_experiments.framework import Options, ExperimentData
+
+
+@ddt
+class TestErrorAmplificationAnalysis(QiskitExperimentsTestCase):
+    """Test for error amplification analysis."""
+
+    @staticmethod
+    def create_data(xvals, d_theta, shots=1000, noise_seed=123):
+        """Create experiment data for testing."""
+        np.random.seed(noise_seed)
+        noise = np.random.normal(0, 0.03, len(xvals))
+        yvals = 0.5 * np.cos((d_theta + np.pi) * xvals - np.pi / 2) + 0.5 + noise
+
+        results = []
+        for x, y in zip(xvals, yvals):
+            n1 = int(shots * y)
+            results.append({"counts": {"0": shots - n1, "1": n1}, "metadata": {"xval": x}})
+
+        expdata = ExperimentData()
+        expdata.add_data(results)
+
+        return expdata
+
+    @data(-0.1, -0.08, -0.06, -0.04, -0.02, -0.01, 0.0, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1)
+    def test_fit_vals(self, d_theta_targ):
+        """Test for fitting."""
+
+        class FakeAmpAnalysis(ErrorAmplificationAnalysis):
+            """Analysis class for testing."""
+
+            __fixed_parameters__ = ["angle_per_gate", "phase_offset", "amp"]
+
+            @classmethod
+            def _default_options(cls) -> Options:
+                """Default analysis options."""
+                options = super()._default_options()
+                options.angle_per_gate = np.pi
+                options.phase_offset = np.pi / 2
+                options.amp = 1.0
+
+                return options
+
+        reps = np.arange(0, 21, 1)
+        fake_data = self.create_data(reps, d_theta=d_theta_targ)
+        processor = DataProcessor("counts", data_actions=[Probability("1")])
+
+        analysis = FakeAmpAnalysis()
+        analysis.set_options(data_processor=processor)
+
+        fake_data = analysis.run(fake_data).block_for_results()
+
+        self.assertAlmostEqual(
+            fake_data.analysis_results("d_theta").value.value, d_theta_targ, delta=0.01
+        )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR reduces default fit boundary of error amplification analysis.

This sometimes results in the poor fit result due to bad boundary condition. Usually this analysis is applied when the error is expected to be quite small, i.e. fine characterizations, thus current boundary is too large. 

![image](https://user-images.githubusercontent.com/39517270/150713471-7b2fbc4f-f2fb-43f1-89b8-57dfd098c59b.png)


### Details and comments


