### PR TITLE
[WIP] Fix bug with json decoder for classes defined in __main__

### DIFF
--- a/qiskit_experiments/framework/json.py
+++ b/qiskit_experiments/framework/json.py
@@ -254,22 +254,14 @@ def _deserialize_type(value: Dict):
             method_cls = None
             name = qualname[0]
         mod = value["module"]
+        mod_scope = importlib.import_module(mod)
         scope = None
-        if mod == "__main__":
-            if method_cls is None:
-                if name in globals():
-                    return globals()[name]
-            else:
-                scope = globals().get(method_cls, None)
+        if method_cls is None:
+            scope = mod_scope
         else:
-            mod_scope = importlib.import_module(mod)
-            if method_cls is None:
-                scope = mod_scope
-            else:
-                for name_, obj in inspect.getmembers(mod_scope, inspect.isclass):
-                    if name_ == method_cls:
-                        scope = obj
-
+            for name_, obj in inspect.getmembers(mod_scope, inspect.isclass):
+                if name_ == method_cls:
+                    scope = obj
         if scope is not None:
             for name_, obj in inspect.getmembers(scope, istype):
                 if name_ == name:

--- a/releasenotes/notes/fix-json-main-bedf4b9b18c851ac.yaml
+++ b/releasenotes/notes/fix-json-main-bedf4b9b18c851ac.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes a bug with JSON deserialization using the :class:`.ExperimentDecoder`
+    failing to decode custom user classes defined in the ``__main__`` scope of
+    python scripts and notebooks.

--- a/test/database_service/test_json.py
+++ b/test/database_service/test_json.py
@@ -120,3 +120,48 @@ class TestJSON(QiskitExperimentsTestCase):
         """Test roundtrip serialization of custom class object"""
         obj = CustomClass.static_method
         self.assertRoundTripSerializable(obj)
+
+    def test_roundtrip_main_function(self):
+        """Test roundtrip serialization of __main__ custom class object"""
+        import __main__ as main_mod
+
+        main_mod.custom_function = custom_function
+        main_mod.custom_function.__module__ = "__main__"
+        obj = main_mod.custom_function
+        self.assertRoundTripSerializable(obj)
+
+    def test_roundtrip_main_class_type(self):
+        """Test roundtrip serialization of __main__ custom class"""
+        import __main__ as main_mod
+
+        main_mod.CustomClass = CustomClass
+        main_mod.CustomClass.__module__ = "__main__"
+        obj = main_mod.CustomClass
+        self.assertRoundTripSerializable(obj)
+
+    def test_roundtrip_main_class_object(self):
+        """Test roundtrip serialization of __main__ custom class object"""
+        import __main__ as main_mod
+
+        main_mod.CustomClass = CustomClass
+        main_mod.CustomClass.__module__ = "__main__"
+        obj = main_mod.CustomClass(123)
+        self.assertRoundTripSerializable(obj)
+
+    def test_roundtrip_main_class_method(self):
+        """Test roundtrip serialization of __main__ custom class object"""
+        import __main__ as main_mod
+
+        main_mod.CustomClass = CustomClass
+        main_mod.CustomClass.__module__ = "__main__"
+        obj = main_mod.CustomClass.class_method
+        self.assertRoundTripSerializable(obj)
+
+    def test_roundtrip_main_custom_static_method(self):
+        """Test roundtrip serialization of __main__ custom class object"""
+        import __main__ as main_mod
+
+        main_mod.CustomClass = CustomClass
+        main_mod.CustomClass.__module__ = "__main__"
+        obj = main_mod.CustomClass.static_method
+        self.assertRoundTripSerializable(obj)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes a bug with JSON deserialization of custom user classes defined in the __main__ scope of python scripts and notebooks.

Adds JSON unittests for testing classes, methods, and functions defined in the __main__ module. The previous tests which aimed to do this were not working correctly since their module was being serialized as test.path_to_test_file instead of __main__.

### Details and comments


