### PR TITLE
[WIP] Iterated experiment

### DIFF
--- a/qiskit_experiments/framework/iterated_experiment.py
+++ b/qiskit_experiments/framework/iterated_experiment.py
@@ -1,0 +1,149 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Iterated Experiment class."""
+
+from typing import Callable, List, Optional, Union
+
+from qiskit import QuantumCircuit
+from qiskit.providers import Backend
+from qiskit.providers.options import Options
+
+from qiskit_experiments.framework.base_experiment import BaseExperiment
+from qiskit_experiments.framework.base_analysis import BaseAnalysis
+from qiskit_experiments.framework.experiment_data import ExperimentData
+
+
+class IteratedExperiment(BaseExperiment):
+    """Iterated experiments class.
+
+    This experiment is initialized from another experiment and will iterate that experiment
+    until a condition specified by a callback function is reached. Iterated experiments
+    make most sense for error amplifying calibration experiments where the parameter of
+    a pulse is updated until a given threshold is reached. The code below is an example
+    of how to use this class to run an iterative fine amplitude calibration experiment
+
+    .. code::
+
+        amp_cal = FineXAmplitudeCal(0, cals, "x", backend=backend)
+        amp_iter = IteratedExperiment(amp_cal)
+        exp_data = iter_exp.run()
+
+    Note: the transpile options of this class are irrelevant. The options of the experiment
+    being iterated are set by accessing the experiment directly, e.g.
+
+    .. code::
+
+        amp_iter.experiment.set_transpile_options(**options_to_set)
+
+    The run options of :class:`IteratedExperiment` control the behaviour of the iterated
+    experiment such as the maximum number of iterations and can be used to influence
+    the stopping condition by passing them to the callback function used to determine
+    if another iteration is needed.
+    """
+
+    def __init__(self, experiment: BaseExperiment, callback: Optional[Callable] = None):
+        """Initialize the iterated experiment.
+
+        Args:
+            experiment: The experiment to iterate.
+            callback: A callback function to determine if the experiment should keep iterating.
+                This callback function is called at each iteration and must have the signature
+                :code:`def callback(exp_data: ExperimentData, run_options: Options) -> bool`.
+        """
+        super().__init__(experiment.physical_qubits)
+
+        self._experiment = experiment
+        self._callback = callback or self.tolerance
+        self._iter_count = None
+
+    @property
+    def experiment(self) -> BaseExperiment:
+        """Return the experiment that is iterated."""
+        return self._experiment
+
+    @classmethod
+    def _default_run_options(cls):
+        """Default options for an iterated experiment."""
+        options = Options(n_iter=10, tol=0.001)
+
+        return options
+
+    def run(
+        self,
+        backend: Optional[Backend] = None,
+        analysis: Optional[Union[BaseAnalysis, None]] = "default",
+        timeout: Optional[float] = None,
+        **run_options,
+    ) -> ExperimentData:
+        """Run the iterated experiment.
+
+        The iterated experiment is run by iteratively running the sub-experiment. This experiment
+        is run until a stopping condition is met.
+
+        Returns:
+            An instance of :class:`ExperimentData` that contains links to all the child
+            experiment data obtained while running the experiment.
+        """
+        self._iter_count = 0
+
+        exp_data = None
+        all_exp_data = ExperimentData(experiment=self)
+
+        while self._keep_running(exp_data):
+            exp_data = self._experiment.run(
+                backend=backend, analysis=analysis, timeout=timeout, **run_options
+            )
+
+            exp_data.block_for_results()
+
+            self._iter_count += 1
+
+            all_exp_data.add_child_data(exp_data)
+
+        return all_exp_data
+
+    def _keep_running(self, exp_data: ExperimentData) -> bool:
+        """This function determines if the iterated experiment should keep running.
+
+        Args:
+            exp_data: The experiment data that this method will use in conjunction with the
+                run options tto determine if the experiment must be run again.
+
+        Returns:
+            True if another iteration should be run and False if the experiment should not
+            continue iterating.
+        """
+
+        # First guard against running an infinite number of times.
+        if self._iter_count > self.run_options.n_iter:
+            return False
+
+        # Edge case where the experiment has not been run yet.
+        if exp_data is None:
+            return True
+
+        # Use the callback to determine if the halting condition is reached.
+        return self._callback(exp_data, self.run_options)
+
+    def circuits(self) -> List[QuantumCircuit]:
+        """Return the circuits of the experiment being iterated."""
+        return self._experiment.circuits()
+
+    @staticmethod
+    def tolerance(exp_data: ExperimentData, options: Options):
+        """Return true if the last value is below the tolerance."""
+
+        if exp_data.analysis_results(-1).value.value < options.tol:
+            return False
+
+        return True

--- a/test/test_iterated_experiment.py
+++ b/test/test_iterated_experiment.py
@@ -1,0 +1,82 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Classes to test the IteratedExperiment class."""
+
+import numpy as np
+
+from qiskit.test import QiskitTestCase
+
+from qiskit_experiments.framework import ExperimentData, Options
+from qiskit_experiments.framework.iterated_experiment import IteratedExperiment
+from qiskit_experiments.test.mock_iq_backend import MockFineAmp
+from qiskit_experiments.library.calibration.fine_amplitude import FineXAmplitudeCal
+from qiskit_experiments.calibration_management.basis_gate_library import FixedFrequencyTransmon
+from qiskit_experiments.calibration_management import Calibrations
+
+
+class TestIteratedExperiment(QiskitTestCase):
+    """Test the iterated experiment class.
+
+    Meaningful tests require calibration experiments.
+    """
+
+    def setUp(self):
+        """Setup the tests"""
+        super().setUp()
+
+        library = FixedFrequencyTransmon()
+
+        error = 0.01 * np.pi
+        self.backend = MockFineAmp(error, np.pi, "x")
+        self.cals = Calibrations.from_backend(self.backend, library)
+
+    def test_iterated_fine_amp(self):
+        """Test that we can iterate a fine amplitude experiment."""
+
+        def callback_for_test(exp_data: ExperimentData, options: Options):
+            """Callback to modify the error of the backend to fake a real setting."""
+            error = options.backend.angle_error
+            options.backend.angle_error = error / 2
+
+            if exp_data.analysis_results(-1).value.value < options.tol:
+                return False
+
+            return True
+
+        # Before the experiment runs, the amp parameter should have two values.
+        self.assertTrue(len(self.cals.parameters_table(parameters=["amp"])["data"]) == 2)
+
+        amp_cal = FineXAmplitudeCal(0, self.cals, "x", backend=self.backend)
+        iter_exp = IteratedExperiment(amp_cal, callback=callback_for_test)
+
+        # Add the backend to pass it to the callback through the options to fake a real setting.
+        iter_exp.set_run_options(backend=self.backend, tol=0.005)
+
+        # Run the experiment. With the chosen settings there should be more than one child exp_data.
+        exp_data = iter_exp.run()
+
+        self.assertTrue(len(exp_data.child_data()) > 4)
+        self.assertTrue(len(exp_data.child_data()) < 10)  # max number of iterations.
+
+        # The last result should be below the tolerance and all other ones above.
+        tol = iter_exp.run_options.tol
+        n_iter = len(exp_data.child_data())
+        for idx, child_data in enumerate(exp_data.child_data()):
+            if idx < n_iter - 1:
+                self.assertTrue(child_data.analysis_results(-1).value.value > tol)
+            else:
+                self.assertTrue(child_data.analysis_results(-1).value.value < tol)
+
+        # After the experiment runs, the amp parameter should have more than two values.
+        amp_params = self.cals.parameters_table(parameters=["amp"], most_recent_only=False)["data"]
+        self.assertTrue(len(amp_params) == (2 + n_iter))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is a proposal for an iterated experiment framework.

### Details and comments

Iterating experiments makes most sense in the calibration context. Typically, a fine calibration experiment is iterated until the angle error `d_theta` reaches a given tolerance. An iterated experiment can be run by doing:
```python
amp_cal = FineXAmplitudeCal(0, cals, "x", backend=backend)
amp_iter = IteratedExperiment(amp_cal)
exp_data = iter_exp.run()
```
This will also automatically update the `Calibrations` instance `cal`. This frame work would also allow one, for example, to iterate a characterization experiment such as T1 at a given time interval.