### PR TITLE
Add incremental pylint tox job

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,6 +269,12 @@ If there is a code formatting issue identified by black you can just run
 ``black`` locally to fix this (or ``tox -eblack`` which will install it and
 run it).
 
+Because `pylint` analysis can be slow, there is also a `tox -elint-incr` target,
+which only applies `pylint` to files which have changed from the source github.
+On rare occasions this will miss some issues that would have been caught by
+checking the complete source tree, but makes up for this by being much faster
+(and those rare oversights will still be caught by the CI after you open a pull
+request).
 
 ### Development Cycle
 

--- a/setup.py
+++ b/setup.py
@@ -16,20 +16,18 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-with open('requirements.txt') as f:
+with open("requirements.txt") as f:
     REQUIREMENTS = f.read().splitlines()
 
 
 version_path = os.path.abspath(
-        os.path.join(
-            os.path.join(os.path.dirname(__file__), 'qiskit_experiments'),
-        'VERSION.txt'))
-with open(version_path, 'r') as fd:
+    os.path.join(os.path.join(os.path.dirname(__file__), "qiskit_experiments"), "VERSION.txt")
+)
+with open(version_path, "r") as fd:
     version = fd.read().rstrip()
 
 # Read long description from README.
-README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                           'README.md')
+README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md")
 with open(README_PATH) as readme_file:
     README = readme_file.read()
 
@@ -38,7 +36,7 @@ setup(
     version=version,
     description="Software for developing quantum computing programs",
     long_description=README,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     url="https://github.com/Qiskit/qiskit-experiments",
     author="Qiskit Development Team",
     author_email="hello@qiskit.org",
@@ -58,7 +56,7 @@ setup(
         "Topic :: Scientific/Engineering",
     ],
     keywords="qiskit sdk quantum",
-    packages=find_packages(exclude=['test*']),
+    packages=find_packages(exclude=["test*"]),
     install_requires=REQUIREMENTS,
     include_package_data=True,
     python_requires=">=3.7",
@@ -67,5 +65,5 @@ setup(
         "Documentation": "https://qiskit.org/documentation/",
         "Source Code": "https://github.com/Qiskit/qiskit-experiments",
     },
-    zip_safe=False
+    zip_safe=False,
 )

--- a/tools/pylint_incr.py
+++ b/tools/pylint_incr.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Run pylint incrementally on only changed files"""
+
+import subprocess
+import argparse
+import os
+import sys
+
+from pylint import lint
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _minimal_ext_cmd(cmd):
+    # construct minimal environment
+    env = {}
+    for k in ["SYSTEMROOT", "PATH"]:
+        v = os.environ.get(k)
+        if v is not None:
+            env[k] = v
+    # LANGUAGE is used on win32
+    env["LANGUAGE"] = "C"
+    env["LANG"] = "C"
+    env["LC_ALL"] = "C"
+    with subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        cwd=os.path.join(os.path.dirname(ROOT_DIR)),
+    ) as proc:
+        stdout, stderr = proc.communicate()
+    return proc.returncode, stdout, stderr
+
+
+def _run_pylint(ref, paths, pylint_args):
+    code, stdout, stderr = _minimal_ext_cmd(
+        [
+            "git",
+            "diff-index",
+            "--name-only",
+            "--diff-filter=d",
+            "--merge-base",
+            "-z",
+            ref,
+            "--",
+            *paths,
+        ]
+    )
+    if code != 0:
+        print(
+            f"{__file__}: unable to get list of changed files. Git returncode: {code}\n"
+            f"Git must be installed, and you need to be in a git tree with a ref `{ref}`\n"
+            f"{stderr.strip().decode('ascii')}"
+        )
+        sys.exit(128)
+    changed_paths = [path.decode("ascii") for path in stdout.split(b"\x00") if len(path) > 0]
+    if len(changed_paths) == 0:
+        print(f"No changed files in {' '.join(paths)}")
+        sys.exit(0)
+    changed_paths_pretty = "\n    ".join(changed_paths)
+    print(f"Running pylint on {len(changed_paths)} changed files:\n    {changed_paths_pretty}")
+    lint.Run([*pylint_args, "--", *changed_paths])
+
+
+def _main():
+    parser = argparse.ArgumentParser(
+        description="Incremental pylint.",
+        epilog="Unknown arguments passed through to pylint",
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "--paths",
+        required=True,
+        type=str,
+        nargs="+",
+        help="Git <pathspec>s to resolve (and pass any changed files to pylint)",
+    )
+    args, pylint_args = parser.parse_known_args()
+    _run_pylint("lint_incr_latest", args.paths, pylint_args)
+
+
+if __name__ == "__main__":
+    _main()

--- a/tox.ini
+++ b/tox.ini
@@ -18,12 +18,23 @@ commands = stestr run {posargs}
 [testenv:lint]
 envdir = .tox/lint
 commands =
-  black --check {posargs} qiskit_experiments test
+  black --check {posargs} qiskit_experiments test tools setup.py
   pylint -rn -j 0 --rcfile={toxinidir}/.pylintrc qiskit_experiments/ test/ tools/
   python tools/verify_headers.py
 
+[testenv:lint-incr]
+envdir = .tox/lint
+basepython = python3
+allowlist_externals = git
+commands =
+  black --check {posargs} qiskit_experiments test tools setup.py
+  -git fetch -q https://github.com/Qiskit/qiskit-experiments :lint_incr_latest
+  {toxinidir}/tools/pylint_incr.py -rn -j4 -sn --paths :/qiskit/*.py :/test/*.py :/tools/*.py
+  {toxinidir}/tools/verify_headers.py qiskit test tools
+
 [testenv:black]
-commands = black {posargs} qiskit_experiments test tools
+envdir = .tox/lint
+commands = black {posargs} qiskit_experiments test tools setup.py
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Pylint is slow enough that seems like many contributors leave it to CI,
which is an awkward way of working and ties up CI resources. This
commit adds a new tox job, lint-incr, that only runs pylint on files
that are different compared to the upstream HEAD and additionally turns
on pylint parallelism. This can miss a few issues (especially
cyclic-import) but its better than not running pylint at all and is a
huge speedup for typical PRs that only touch a few files.

This works by updating a local reference to track HEAD of upstream
github, and using this ref as merge-base for finding the files that are
changed on the local branch. If working offline, this ref won't be
updated, but this will merely have the effect that the merge-base may
be further into the past than it could be (eg if the changes have been
from main into the local branch since it was created) and more files
get pylinted than is strictly necessary. This is only a performance
issue, and either way is faster than the current approach of always
pylinting all files.

### Details and comments

This commit was ported from Qiskit/qiskit-terra#6597 which added an
identical target to Qiskit/qiskit-terra. It is basically identical
except that the paths and urls are updated for experiments instead of
terra.

Co-authored-by: Lev S. Bishop <18673315+levbishop@users.noreply.github.com>