### PR TITLE
Pin black version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black
+black~=22.0
 stestr
 astroid==2.5
 pylint==2.7.1


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit sets a pin on the black version we use in CI and in local
tox jobs. This has historically been done because black was "beta"
software and didn't provide any guarantees on formatting stability
between releases. However, with the recent 22.1.0 release this has
changed and black now guarantees that all formatting will be stable on a
given major version (which is just the year)[1]. This commit pins
experiments to use black 22.x.y to ensure that we don't get spurious
formatting changes moving forward until we're ready to take on a new
major version of black. This will ensure that all contributors will have
consistent formatting locally and in CI.

### Details and comments

[1] https://black.readthedocs.io/en/latest/the_black_code_style/index.html#stability-policy