### PR TITLE
Fix path for tox lint incremental command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,8 @@ allowlist_externals = git
 commands =
   black --check {posargs} qiskit_experiments test tools setup.py
   -git fetch -q https://github.com/Qiskit/qiskit-experiments :lint_incr_latest
-  {toxinidir}/tools/pylint_incr.py -rn -j4 -sn --paths :/qiskit/*.py :/test/*.py :/tools/*.py
-  {toxinidir}/tools/verify_headers.py qiskit test tools
+  {toxinidir}/tools/pylint_incr.py -rn -j4 -sn --paths :/qiskit_experiments/*.py :/test/*.py :/tools/*.py
+  {toxinidir}/tools/verify_headers.py qiskit_experiments test tools
 
 [testenv:black]
 envdir = .tox/lint


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Currently incremental mode searches `qiskit` dir which does not exist. The wrong path is corrected in this PR.


### Details and comments


