### PR TITLE
Add timeout to assertExperimentDone

### DIFF
--- a/test/base.py
+++ b/test/base.py
@@ -42,7 +42,8 @@ class QiskitExperimentsTestCase(QiskitTestCase):
         Args:
             experiment_data: Experiment data to evaluate.
         """
-        experiment_data.block_for_results()
+        # 10 minutes should be enough for unittest without queueing
+        experiment_data.block_for_results(timeout=600)
 
         self.assertEqual(
             experiment_data.status(),

--- a/test/base.py
+++ b/test/base.py
@@ -47,7 +47,6 @@ class QiskitExperimentsTestCase(QiskitTestCase):
             experiment_data: Experiment data to evaluate.
             timeout: The maximum time in seconds to wait for executor to complete.
         """
-        # 10 minutes should be enough for unittest without queueing
         experiment_data.block_for_results(timeout=timeout)
 
         self.assertEqual(

--- a/test/base.py
+++ b/test/base.py
@@ -45,7 +45,7 @@ class QiskitExperimentsTestCase(QiskitTestCase):
 
         Args:
             experiment_data: Experiment data to evaluate.
-            timeout: The maximum time we wait for executor to complete.
+            timeout: The maximum time in seconds to wait for executor to complete.
         """
         # 10 minutes should be enough for unittest without queueing
         experiment_data.block_for_results(timeout=timeout)

--- a/test/base.py
+++ b/test/base.py
@@ -38,7 +38,7 @@ class QiskitExperimentsTestCase(QiskitTestCase):
     def assertExperimentDone(
         self,
         experiment_data: ExperimentData,
-        timeout: float = 600,
+        timeout: float = 120,
     ):
         """Blocking execution of next line until all threads are completed then
         checks if status returns Done.

--- a/test/base.py
+++ b/test/base.py
@@ -35,15 +35,20 @@ from qiskit_experiments.data_processing import DataAction, DataProcessor
 class QiskitExperimentsTestCase(QiskitTestCase):
     """Qiskit Experiments specific extra functionality for test cases."""
 
-    def assertExperimentDone(self, experiment_data: ExperimentData):
+    def assertExperimentDone(
+        self,
+        experiment_data: ExperimentData,
+        timeout: float = 600,
+    ):
         """Blocking execution of next line until all threads are completed then
         checks if status returns Done.
 
         Args:
             experiment_data: Experiment data to evaluate.
+            timeout: The maximum time we wait for executor to complete.
         """
         # 10 minutes should be enough for unittest without queueing
-        experiment_data.block_for_results(timeout=600)
+        experiment_data.block_for_results(timeout=timeout)
 
         self.assertEqual(
             experiment_data.status(),

--- a/test/test_cross_resonance_hamiltonian.py
+++ b/test/test_cross_resonance_hamiltonian.py
@@ -247,7 +247,7 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
             qubits=(0, 1), flat_top_widths=durations, sigma=sigma, risefall=2
         )
         exp_data = expr.run(backend, shots=2000)
-        self.assertExperimentDone(exp_data)
+        self.assertExperimentDone(exp_data, timeout=300)
 
         self.assertEqual(exp_data.analysis_results(0).quality, "good")
         self.assertAlmostEqual(exp_data.analysis_results("omega_ix").value.value, ix, delta=2e4)

--- a/test/test_t2hahn.py
+++ b/test/test_t2hahn.py
@@ -61,7 +61,7 @@ class TestT2Hahn(QiskitExperimentsTestCase):
                 p0={"amp": 0.5, "tau": estimated_t2hahn, "base": 0.5}, plot=True
             )
             expdata = exp.run(backend=backend, shots=1000)
-            expdata.block_for_results()  # Wait for job/analysis to finish.
+            self.assertExperimentDone(expdata, timeout=300)
             result = expdata.analysis_results("T2")
             fitval = result.value
             if num_of_echoes != 0:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR should improve debugging experience of buggy code. This is the worst situation I encountered; there is a bug in analysis code and it silently failed. Some experiments such as calibrations inject a post analysis hook (i.e. callback) that uses completed analysis results, however, because the analysis has failed, the second thread for the post hook will wait forever to poll the analysis result. This hangs up tox test without raising any error message and it will be quite tough to find the bug (we may need to run every test one by one and find what is failing).

### Details and comments


