### PR TITLE
Fix CompositeExperiment.copy to preserve analysis referances

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -279,7 +279,7 @@ class BaseExperiment(ABC, StoreInitArgs):
 
         # Optionally run analysis
         if analysis and experiment.analysis:
-            return self.analysis.run(experiment_data)
+            return experiment.analysis.run(experiment_data)
         else:
             return experiment_data
 

--- a/qiskit_experiments/framework/composite/composite_analysis.py
+++ b/qiskit_experiments/framework/composite/composite_analysis.py
@@ -60,6 +60,12 @@ class CompositeAnalysis(BaseAnalysis):
             return self._analyses
         return self._analyses[index]
 
+    def copy(self):
+        ret = super().copy()
+        # Recursively copy analysis
+        ret._analyses = [analysis.copy() for analysis in ret._analyses]
+        return ret
+
     def _run_analysis(self, experiment_data: ExperimentData):
         # Return list of experiment data containers for each component experiment
         # containing the marginalied data from the composite experiment

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -87,6 +87,15 @@ class CompositeExperiment(BaseExperiment):
         ret = super().copy()
         # Recursively call copy of component experiments
         ret._experiments = [exp.copy() for exp in self._experiments]
+
+        # Check if the analysis in CompositeAnalysis was a reference to the
+        # original component experiment analyses and if so update the copies
+        # to preserve this relationship
+        if isinstance(self.analysis, CompositeAnalysis):
+            for i, orig_exp in enumerate(self._experiments):
+                if orig_exp.analysis is self.analysis._analyses[i]:
+                    # Update copies analysis with reference to experiment analysis
+                    ret.analysis._analyses[i] = ret._experiments[i].analysis
         return ret
 
     def _set_backend(self, backend):

--- a/releasenotes/notes/fix-composite-copy-a869e9773f6a4d48.yaml
+++ b/releasenotes/notes/fix-composite-copy-a869e9773f6a4d48.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fix :meth:`.ParallelExperiment.copy` and :meth:`.BatchExperiment.copy`
+    so that the copies preserves any references between the original
+    component experiments analysis classes and the :class:`.CompositeAnalysis`
+    classes component analysis classes.
+  - |
+    Fixes :meth:`.CompositeAnalysis.copy` to recursively make a copy of the
+    component analysis classes.

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -187,6 +187,35 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         self.check_attributes(new_instance)
         self.assertEqual(new_instance.parent_id, None)
 
+    def test_composite_copy_analysis_ref(self):
+        """Test copy of composite expeirment preserves component analysis refs"""
+
+        class Analysis(FakeAnalysis):
+            """Fake analysis class with options"""
+
+            @classmethod
+            def _default_options(cls):
+                opts = super()._default_options()
+                opts.option1 = None
+                opts.option2 = None
+                return opts
+
+        exp1 = FakeExperiment([0])
+        exp1.analysis = Analysis()
+        exp2 = FakeExperiment([1])
+        exp2.analysis = Analysis()
+
+        # Generate a copy
+        par_exp = ParallelExperiment([exp1, exp2]).copy()
+        comp_exp0 = par_exp.component_experiment(0)
+        comp_exp1 = par_exp.component_experiment(1)
+        comp_an0 = par_exp.analysis.component_analysis(0)
+        comp_an1 = par_exp.analysis.component_analysis(1)
+
+        # Check reference of analysis is preserved
+        self.assertTrue(comp_exp0.analysis is comp_an0)
+        self.assertTrue(comp_exp1.analysis is comp_an1)
+
     def test_nested_composite(self):
         """
         Test nested parallel experiments.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix bug with `CompositeExperiment.copy` so that it will preserve any analysis object references between the original component experiment analysis classes and the composite analysis component analysis classes.

### Details and comments

Currently when a copy happens this reference is broken so that the copies component experiment analysis classes are not the same object as the analysis copies component analysis classes, even if they were in the original experiment

