### PR TITLE
Improve ability to cancel analysis jobs

### DIFF
--- a/qiskit_experiments/framework/json.py
+++ b/qiskit_experiments/framework/json.py
@@ -442,6 +442,8 @@ class ExperimentEncoder(json.JSONEncoder):
     def default(self, obj: Any) -> Any:  # pylint: disable=arguments-differ
         if istype(obj):
             return _serialize_type(obj)
+        if hasattr(obj, "__json_encode__"):
+            return _serialize_object(obj)
         if isinstance(obj, complex):
             return _serialize_safe_float(obj)
         if isinstance(obj, set):

--- a/releasenotes/notes/improve-cancel-a1e7b6dc331014cd.yaml
+++ b/releasenotes/notes/improve-cancel-a1e7b6dc331014cd.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixes some issues with :meth:`.ExperimentData.cancel_analysis`
+    and :meth:`.ExperimentData.cancel` to make cancelling analysis
+    callbacks more robust.
+  - |
+    Fixes :meth:`.ExperimentData.block_for_results` to handle blocking
+    in recursive cases where an analysis callback adds another
+    job or analysis callback.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The PR aims to improve the functionality of the `ExperimentData.cancel_analysis` (and hence also the `ExperimentData.cancel` methods to make them more robust for cancelling analysis that is waiting on job execution.

### Details and comments

Since analysis callbacks are run as futures they cannot be directly cancelled using the `Future.cancel` method if the future has started running. This means that in general for any experiment data there will always be at least one analysis future running which prevents cancelation.

This PR updates the handling of futures to allow canceling futures that have started, but the actual callback function hasn't been run yet (because it is waiting for jobs, or other callbacks to finish for example), by using a separate monitoring future that checks for an cancellation Event to be set.

This PR also updates the `block_for_results` and `cancel` methods to remove job and analysis futures that are finished or cancelled and hence no longer needed.