### PR TITLE
Remove `get_processor` job metadata dependence

### DIFF
--- a/qiskit_experiments/data_processing/processor_library.py
+++ b/qiskit_experiments/data_processing/processor_library.py
@@ -24,7 +24,6 @@ from qiskit_experiments.data_processing import nodes
 def get_processor(
     experiment_data: ExperimentData,
     analysis_options: Options,
-    index: int = -1,
 ) -> DataProcessor:
     """Get a DataProcessor that produces a continuous signal given the options.
 
@@ -45,7 +44,6 @@ def get_processor(
             - outcome (string): The measurement outcome that will be passed to a Probability node.
               The default value is a string of 1's where the length of the string is the number of
               qubits, e.g. '111' for three qubits.
-        index: The index of the job for which to get a data processor. The default value is -1.
 
     Returns:
         An instance of DataProcessor capable of processing the data for the corresponding job.
@@ -60,10 +58,9 @@ def get_processor(
         DataProcessorError: if the wrong dimensionality reduction for kerneled data
             is specified.
     """
-    run_options = experiment_data.metadata["job_metadata"][index].get("run_options", {})
-
-    meas_level = run_options.get("meas_level", MeasLevel.CLASSIFIED)
-    meas_return = run_options.get("meas_return", MeasReturnType.AVERAGE)
+    first_data = experiment_data.data()[0]
+    meas_level = first_data.get("meas_level", MeasLevel.CLASSIFIED)
+    meas_return = first_data.get("meas_return", MeasReturnType.AVERAGE)
     normalize = analysis_options.get("normalization", True)
     dimensionality_reduction = analysis_options.get("dimensionality_reduction", ProjectorType.SVD)
 

--- a/qiskit_experiments/test/mock_iq_backend.py
+++ b/qiskit_experiments/test/mock_iq_backend.py
@@ -122,6 +122,7 @@ class MockIQBackend(FakeOpenPulse2Q):
                 "success": True,
                 "header": {"metadata": circ.metadata},
                 "meas_level": meas_level,
+                "meas_return": meas_return,
             }
 
             prob = self._compute_probability(circ)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR is to remove the dependence on the `get_processor` function of job run_options metadata in the experiment data and instead extracts this information from the circuit result data where it should already be stored by the backend.

### Details and comments

This should also help data processor based analysis be a bit more robust for experiment data reconstructed directly from jobs where metadata may be missing.