### PR TITLE
Fix the qantum volume sample code

### DIFF
--- a/docs/tutorials/quantum_volume.rst
+++ b/docs/tutorials/quantum_volume.rst
@@ -82,7 +82,7 @@ Extra data included in the analysis results includes
 
 .. jupyter-execute::
 
-    qubits = range(4) # Can use specific qubits. for example [2, 4, 7, 10]
+    qubits = tuple(range(4)) # Can use specific qubits. for example [2, 4, 7, 10]
     
     qv_exp = QuantumVolume(qubits, seed=42)
     # Transpile options like optimization_level affect only the real device run and not the simulation run
@@ -142,7 +142,10 @@ enhancements might be required (See Ref. [2] for details).
 
 .. jupyter-execute::
 
-    exps = [QuantumVolume(range(i), trials=200) for i in range(3, 6)]
+    exps = []
+    for i in range(3,6):
+        exps.append(QuantumVolume(tuple(range(i)), trials=200))
+
     batch_exp = BatchExperiment(exps)
     batch_exp.set_transpile_options(optimization_level=3)
     


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Starting from the qiskit-experiments 0.2.0, the QuantumVolume class only accept a list of qubits, thus update the sample code to make it work w/ the latest QuantumVolume class.

### Details and comments
Per PR https://github.com/Qiskit/qiskit-experiments/pull/431, QuantumVolume class only accept a list of qubits, thus update https://github.com/Qiskit/qiskit-experiments/blob/main/docs/tutorials/quantum_volume.rst to apply this change or it cannot work w/ the latest code.

The code has been tested on my Mac env fyi:
```
# packages in environment at /Users/dcc/opt/anaconda3/envs/qiskit:
qiskit                    0.34.2                   pypi_0    pypi
qiskit-aer                0.10.3                   pypi_0    pypi
qiskit-experiments        0.3.0                    pypi_0    pypi
qiskit-ibmq-provider      0.18.3                   pypi_0    pypi
qiskit-ignis              0.7.0                    pypi_0    pypi
qiskit-terra              0.19.2                   pypi_0    pypi

```