### PR TITLE
Reverse sign of fine frequency update

### DIFF
--- a/qiskit_experiments/library/calibration/fine_frequency_cal.py
+++ b/qiskit_experiments/library/calibration/fine_frequency_cal.py
@@ -140,7 +140,7 @@ class FineFrequencyCal(BaseCalibrationExperiment, FineFrequency):
         dt = experiment_data.metadata["dt"]
 
         d_theta = BaseUpdater.get_value(experiment_data, "d_theta", result_index)
-        new_freq = prev_freq - d_theta / (2 * np.pi * tau * dt)
+        new_freq = prev_freq + d_theta / (2 * np.pi * tau * dt)
 
         BaseUpdater.add_parameter_value(
             self._cals, experiment_data, new_freq, self._param_name, self._sched_name, group

--- a/test/calibration/experiments/test_fine_frequency.py
+++ b/test/calibration/experiments/test_fine_frequency.py
@@ -86,7 +86,7 @@ class TestFineFreqEndToEnd(QiskitExperimentsTestCase):
         freq_after = self.cals.get_parameter_value(self.cals.__drive_freq_parameter__, 0)
 
         # Test equality up to 10kHz on a 100 kHz shift
-        self.assertAlmostEqual(freq_after, armonk_freq - freq_shift, delta=1e4)
+        self.assertAlmostEqual(freq_after, armonk_freq + freq_shift, delta=1e4)
 
     def test_experiment_config(self):
         """Test converting to and from config works"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The sign of the fine frequency update was backwards

### Details and comments

When the actual frequency of the qubit is larger than the drive's by an amount `d_freq`, it will accumulate a phase `d_theta = 2 * pi * delay * d_freq`. To correct, this error the inferred `d_freq` from `d_theta` needs to be added to the old freq. In the current code, it is subtracted.
