### PR TITLE
Add `BaseExperiment._finalize` method

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -245,13 +245,15 @@ class BaseExperiment(ABC, StoreInitArgs):
                     stacklevel=2,
                 )
 
-        if backend is not None or analysis != "default":
+        if backend is not None or analysis != "default" or run_options:
             # Make a copy to update analysis or backend if one is provided at runtime
             experiment = self.copy()
             if backend:
                 experiment._set_backend(backend)
             if isinstance(analysis, BaseAnalysis):
                 experiment.analysis = analysis
+            if run_options:
+                experiment.set_run_options(**run_options)
         else:
             experiment = self
 
@@ -261,13 +263,11 @@ class BaseExperiment(ABC, StoreInitArgs):
         # Initialize result container
         experiment_data = experiment._initialize_experiment_data()
 
-        # Run options
-        run_opts = copy.copy(experiment.run_options)
-        run_opts.update_options(**run_options)
-        run_opts = run_opts.__dict__
-
         # Generate and transpile circuits
         transpiled_circuits = experiment._transpiled_circuits()
+
+        # Run options
+        run_opts = experiment.run_options.__dict__
 
         # Run jobs
         jobs = experiment._run_jobs(transpiled_circuits, **run_opts)

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -260,6 +260,9 @@ class BaseExperiment(ABC, StoreInitArgs):
         if experiment.backend is None:
             raise QiskitError("Cannot run experiment, no backend has been set.")
 
+        # Finalize experiment before executions
+        experiment._finalize()
+
         # Initialize result container
         experiment_data = experiment._initialize_experiment_data()
 
@@ -318,6 +321,15 @@ class BaseExperiment(ABC, StoreInitArgs):
             DeprecationWarning,
         )
         return self.analysis.run(experiment_data, replace_results=replace_results, **options)
+
+    def _finalize(self):
+        """Finalize experiment object before running jobs.
+
+        Subclasses can override this method to set any final option
+        values derived from other options or attributes of the
+        experiment before `_run` is called.
+        """
+        pass
 
     def _run_jobs(self, circuits: List[QuantumCircuit], **run_options) -> List[BaseJob]:
         """Run circuits on backend as 1 or more jobs."""

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -109,7 +109,24 @@ class CompositeExperiment(BaseExperiment):
             subexp._set_backend(backend)
 
     def _finalize(self):
-        for subexp in self._experiments:
+        # NOTE: When CompositeAnalysis is updated to support level-1
+        # measurements this method should be updated to validate that all
+        # sub-experiments have the same meas level and meas return types,
+        # and update the composite experiment run option to that value.
+
+        for i, subexp in enumerate(self._experiments):
+            # Raise warning if different run options were set for individual
+            # component experiments and not through the composite experiments
+            # set_run_options
+            for key in subexp._set_run_options:
+                subval = getattr(subexp.run_options, key)
+                compval = getattr(self.run_options, key, None)
+                if subval != compval:
+                    warnings.warn(
+                        f"Component experiment {i} run option {key}={subval} is "
+                        f" differs from the the composite experiment value {compval}"
+                        " and will be overridden."
+                    )
             subexp._finalize()
 
     def _initialize_experiment_data(self):

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -130,9 +130,9 @@ class CompositeExperiment(BaseExperiment):
 
             if overridden_keys:
                 warnings.warn(
-                    f"Component experiment {i} run options {overridden_keys} values"
-                    f" {sub_vals} will be overridden with component experiment"
-                    f" values {comp_vals}.",
+                    f"Component {i} {subexp.experiment_type} experiment run options"
+                    f" {overridden_keys} values {sub_vals} will be overridden with"
+                    f" {self.experiment_type} values {comp_vals}.",
                     UserWarning,
                 )
                 # Update sub-experiment options with actual run option values so

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -134,9 +134,4 @@ class CompositeExperiment(BaseExperiment):
         for sub_metadata, sub_exp in zip(
             metadata["component_metadata"], self.component_experiment()
         ):
-            # Run and transpile options are always overridden
-            if sub_exp.run_options != sub_exp._default_run_options():
-                warnings.warn(
-                    "Sub-experiment run options" " are overridden by composite experiment options."
-                )
             sub_exp._add_job_metadata(sub_metadata, jobs, **run_options)

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -98,10 +98,19 @@ class CompositeExperiment(BaseExperiment):
                     ret.analysis._analyses[i] = ret._experiments[i].analysis
         return ret
 
+    def set_run_options(self, **fields):
+        super().set_run_options(**fields)
+        for subexp in self._experiments:
+            subexp.set_run_options(**fields)
+
     def _set_backend(self, backend):
         super()._set_backend(backend)
         for subexp in self._experiments:
             subexp._set_backend(backend)
+
+    def _finalize(self):
+        for subexp in self._experiments:
+            subexp._finalize()
 
     def _initialize_experiment_data(self):
         """Initialize the return data container for the experiment run"""

--- a/releasenotes/notes/exp-finalize-b7ca0a139ad5f872.yaml
+++ b/releasenotes/notes/exp-finalize-b7ca0a139ad5f872.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Adds a :meth:`.BaseExperiment._finalize` method to :class:`.BaseExperiment`
+    which is after configuring any runtime options, backend, or analysis
+    classes but before generation and execution of experiment
+    circuits during :class:`.BaseExperiment.run`.
+
+    This method is intended to be overridden in experiment subclasses if they
+    need to configure any analysis or runtime options based on a combination
+    of properties of the experiment, for example some combination of backend,
+    experiment and run options.

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -58,17 +58,14 @@ class TestComposite(QiskitExperimentsTestCase):
 
         par_exp = ParallelExperiment([exp0, exp2])
 
-        with self.assertWarnsRegex(
-            Warning,
-            "Sub-experiment run options" " are overridden by composite experiment options.",
-        ):
-            self.assertEqual(par_exp.experiment_options, Options())
-            self.assertEqual(par_exp.run_options, Options(meas_level=2))
-            self.assertEqual(par_exp.transpile_options, Options(optimization_level=0))
-            self.assertEqual(par_exp.analysis.options, Options())
+        self.assertEqual(par_exp.experiment_options, Options())
+        self.assertEqual(par_exp.run_options, Options(meas_level=2))
+        self.assertEqual(par_exp.transpile_options, Options(optimization_level=0))
+        self.assertEqual(par_exp.analysis.options, Options())
 
+        with self.assertWarns(Warning):
             expdata = par_exp.run(FakeBackend())
-            self.assertExperimentDone(expdata)
+        self.assertExperimentDone(expdata)
 
     def test_experiment_config(self):
         """Test converting to and from config works"""

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -63,7 +63,7 @@ class TestComposite(QiskitExperimentsTestCase):
         self.assertEqual(par_exp.transpile_options, Options(optimization_level=0))
         self.assertEqual(par_exp.analysis.options, Options())
 
-        with self.assertWarns(Warning):
+        with self.assertWarns(UserWarning):
             expdata = par_exp.run(FakeBackend())
         self.assertExperimentDone(expdata)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This adds a `_finalize` method to BaseExperiment called in run before the actual experiment is run which gives users a hook for setting any custom experiment or option values based on the final configuration of the experiment before execution. 

### Details and comments

The main goal for this is to allow developers/users to be able to set automatically calculated experiment or analysis option values that might depend on a combination of other option values when writing an experiment subclass. For example it could be used to configure a specific data processor in analysis based on the backend and run option values (@eggerdj), or to set the initial guess value for CR hamiltonian in #695 (@nkanazawa1989)