### PR TITLE
Fix for hang in analysis callbacks (#700)

### DIFF
--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -1424,6 +1424,9 @@ class DbExperimentDataV1(DbExperimentData):
         .. note:
             If analysis results and figures are copied they will also have
             new result IDs and figure names generated for the copies.
+
+            This method can not be called from an analysis callback. It waits
+            for analysis callbacks to complete before copying analysis results.
         """
         new_instance = self.__class__()
         LOG.debug(

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -1377,7 +1377,7 @@ class DbExperimentDataV1(DbExperimentData):
 
         # Get any job futures errors:
         for jid, fut in self._job_futures.items():
-            if fut and fut.exception():
+            if fut and fut.done() and fut.exception():
                 ex = fut.exception()
                 errors.append(
                     f"[Job ID: {jid}]"

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -1392,14 +1392,6 @@ class DbExperimentDataV1(DbExperimentData):
             if callback.status == AnalysisStatus.ERROR:
                 errors.append(f"\n[Analysis ID: {cid}]: {callback.error_msg}")
 
-        # Get any callback futures errors:
-        for cid, fut in self._analysis_futures.items():
-            ex = fut.exception()
-            if fut.exception():
-                errors.append(
-                    f"[Analysis ID: {cid}]"
-                    "\n".join(traceback.format_exception(type(ex), ex, ex.__traceback__))
-                )
         return "".join(errors)
 
     def errors(self) -> str:

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -503,9 +503,8 @@ class DbExperimentDataV1(DbExperimentData):
             return callback_id, True
         except Exception as ex:  # pylint: disable=broad-except
             self._analysis_callbacks[callback_id].status = AnalysisStatus.ERROR
-            error_msg = f"Analysis callback failed [Analysis ID: {callback_id}]:\n" "".join(
-                traceback.format_exception(type(ex), ex, ex.__traceback__)
-            )
+            tb_text = "".join(traceback.format_exception(type(ex), ex, ex.__traceback__))
+            error_msg = f"Analysis callback failed [Analysis ID: {callback_id}]:\n{tb_text}"
             self._analysis_callbacks[callback_id].error_msg = error_msg
             LOG.warning(error_msg)
             return callback_id, False

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -873,12 +873,12 @@ class DbExperimentDataV1(DbExperimentData):
 
         if isinstance(index, int):
             if index >= len(self._analysis_results.values()):
-                raise DbExperimentEntryNotFound(make_not_found_message(index))
+                raise DbExperimentEntryNotFound(_make_not_found_message(index))
             return self._analysis_results.values()[index]
         if isinstance(index, slice):
             results = self._analysis_results.values()[index]
             if not results:
-                raise DbExperimentEntryNotFound(make_not_found_message(index))
+                raise DbExperimentEntryNotFound(_make_not_found_message(index))
             return results
         if isinstance(index, str):
             # Check by result ID
@@ -889,7 +889,7 @@ class DbExperimentDataV1(DbExperimentData):
                 result for result in self._analysis_results.values() if result.name == index
             ]
             if not filtered:
-                raise DbExperimentEntryNotFound(make_not_found_message(index))
+                raise DbExperimentEntryNotFound(_make_not_found_message(index))
             if len(filtered) == 1:
                 return filtered[0]
             else:

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -863,7 +863,7 @@ class DbExperimentDataV1(DbExperimentData):
         if index is None:
             return self._analysis_results.values()
 
-        def make_not_found_message(index):
+        def _make_not_found_message(index: Union[int, slice, str]) -> str:
             """Helper to make error message for index not found"""
             msg = [f"Analysis result {index} not found."]
             errors = self.errors()

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -862,18 +862,23 @@ class DbExperimentDataV1(DbExperimentData):
         self._retrieve_analysis_results(refresh=refresh)
         if index is None:
             return self._analysis_results.values()
+
+        def make_not_found_message(index):
+            """Helper to make error message for index not found"""
+            msg = [f"Analysis result {index} not found."]
+            errors = self.errors()
+            if errors:
+                msg.append(f"Errors: {errors}")
+            return "\n".join(msg)
+
         if isinstance(index, int):
             if index >= len(self._analysis_results.values()):
-                raise DbExperimentEntryNotFound(
-                    f"Analysis result {index} not found. " f"Errors: {self.errors()}"
-                )
+                raise DbExperimentEntryNotFound(make_not_found_message(index))
             return self._analysis_results.values()[index]
         if isinstance(index, slice):
             results = self._analysis_results.values()[index]
             if not results:
-                raise DbExperimentEntryNotFound(
-                    f"Analysis result {index} not found. " f"Errors: {self.errors()}"
-                )
+                raise DbExperimentEntryNotFound(make_not_found_message(index))
             return results
         if isinstance(index, str):
             # Check by result ID
@@ -884,9 +889,7 @@ class DbExperimentDataV1(DbExperimentData):
                 result for result in self._analysis_results.values() if result.name == index
             ]
             if not filtered:
-                raise DbExperimentEntryNotFound(
-                    f"Analysis result {index} not found. " f"Errors: {self.errors()}"
-                )
+                raise DbExperimentEntryNotFound(make_not_found_message(index))
             if len(filtered) == 1:
                 return filtered[0]
             else:

--- a/test/calibration/experiments/test_ramsey_xy.py
+++ b/test/calibration/experiments/test_ramsey_xy.py
@@ -81,7 +81,7 @@ class TestRamseyXY(QiskitExperimentsTestCase):
         """
         backend = MockRamseyXY(freq_shift=0)
 
-        class NoResults((BaseAnalysis)):
+        class NoResults(BaseAnalysis):
             """Simple analysis class that generates no results"""
 
             def _run_analysis(self, experiment_data):

--- a/test/calibration/experiments/test_ramsey_xy.py
+++ b/test/calibration/experiments/test_ramsey_xy.py
@@ -18,6 +18,7 @@ from qiskit.test.mock import FakeArmonk
 
 from qiskit_experiments.calibration_management.calibrations import Calibrations
 from qiskit_experiments.calibration_management.basis_gate_library import FixedFrequencyTransmon
+from qiskit_experiments.framework import AnalysisStatus, BaseAnalysis
 from qiskit_experiments.library import RamseyXY, FrequencyCal
 from qiskit_experiments.test.mock_iq_backend import MockRamseyXY
 
@@ -70,6 +71,27 @@ class TestRamseyXY(QiskitExperimentsTestCase):
         f01 = self.cals.get_parameter_value(freq_name, 0)
         self.assertTrue(len(self.cals.parameters_table(parameters=[freq_name])["data"]), 2)
         self.assertTrue(abs(f01 - (freq_shift + FakeArmonk().defaults().qubit_freq_est[0])) < tol)
+
+    def test_update_with_failed_analysis(self):
+        """Test that calibration update handles analysis producing no results
+
+        Here we test that the experiment does not raise an unexpected exception
+        or hang indefinitely. Since there are no analysis results, we expect
+        that the calibration update will result in an ERROR status.
+        """
+        backend = MockRamseyXY(freq_shift=0)
+
+        class NoResults((BaseAnalysis)):
+            """Simple analysis class that generates no results"""
+
+            def _run_analysis(self, experiment_data):
+                return ([], [])
+
+        expt = FrequencyCal(0, self.cals, backend, auto_update=True)
+        expt.analysis = NoResults()
+        expdata = expt.run()
+        expdata.block_for_results(timeout=3)
+        self.assertEqual(expdata.analysis_status(), AnalysisStatus.ERROR)
 
     def test_ramseyxy_experiment_config(self):
         """Test RamseyXY config roundtrips"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fixes #700 by removing a call to `.exception()` on the futures in `ExperimentData.analysis_errors()`. This call could be made from a future in which case it will block itself indefinitely.

### Details and comments

The individual commit messages explain the changes. Besides removing the `.exception()` call, I modified the way the error message are formatted since it did not look very good once I removed the `.exception()` call and could see the message for the sample code in #700.

Commit messages:

* Do not report futures errors in analysis_errors
Analysis callbacks are executed sequentially and any exceptions are
caught and stored in the callback objects, so checking the futures
directly is redundant. Additionally, it causes a deadlock as a future
checking the errors then calls `fut.exception()` on itself.
* Fix formatting on analysis callback errors
"Analysis callback failed ..." does not need to be prefixed to every
entry of the traceback.
* Do not show empty "Errors:" in exception message
If there are no errors, the "Errors" part of the string is omitted.