### PR TITLE
Compare sorted tags in test_save_all

### DIFF
--- a/test/database_service/test_experiment_data_integration.py
+++ b/test/database_service/test_experiment_data_integration.py
@@ -315,7 +315,9 @@ class TestExperimentDataIntegration(QiskitTestCase):
         exp_data.save()
 
         rexp = DbExperimentData.load(exp_data.experiment_id, self.experiment)
-        self.assertEqual(["foo", "bar"], rexp.tags)
+        # Experiment tag order is not necessarily preserved
+        # so compare tags with a predictable sort order.
+        self.assertEqual(["bar", "foo"], sorted(rexp.tags))
         self.assertEqual(aresult.result_id, rexp.analysis_results(0).result_id)
         self.assertEqual(hello_bytes, rexp.figure(0))
 


### PR DESCRIPTION
### Summary

qiskit-experiments does not maintain order on experiment
tags since #522 so we need to compare experiment tags in
the `test_save_all` test with a predictable sort order.

### Details and comments

This was originally fixed in qiskit-ibm-provider:

https://github.com/Qiskit/qiskit-ibm-provider/pull/214

Closes #708