### PR TITLE
Use finalize to update init guess of CR Ham tomo

### DIFF
--- a/qiskit_experiments/library/characterization/cr_hamiltonian.py
+++ b/qiskit_experiments/library/characterization/cr_hamiltonian.py
@@ -348,15 +348,16 @@ class CrossResonanceHamiltonian(BaseExperiment):
 
                     expr_circs.append(tomo_circ)
 
-        # Set analysis option for initial guess that depends on experiment option values.
+        return expr_circs
+
+    def _finalize(self):
+        """Set analysis option for initial guess that depends on experiment option values."""
         edge_duration = np.sqrt(2 * np.pi) * self.experiment_options.sigma * self.num_pulses
 
         init_guess = self.analysis.options.p0.copy()
         init_guess["t_off"] = edge_duration * self._dt
 
         self.analysis.set_options(p0=init_guess)
-
-        return expr_circs
 
 
 class EchoedCrossResonanceHamiltonian(CrossResonanceHamiltonian):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

CR Ham tomo fit requires effective edge duration to fit oscillation (since its x value is a flat top width but non-zero rotation occurs also in the edge -- but slower). Thus this parameter depends on the experiment parameters as well as backend dt. Finalize method is good place to do that.

### Details and comments


