### PR TITLE
add qubits property to Experiment

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -58,7 +58,6 @@ class BaseExperiment(ABC, StoreInitArgs):
 
         # Circuit parameters
         self._num_qubits = len(qubits)
-        self._qubits = tuple(qubits)
         self._physical_qubits = tuple(qubits)
         if self._num_qubits != len(set(self._physical_qubits)):
             raise QiskitError("Duplicate qubits in physical qubits list.")
@@ -105,7 +104,7 @@ class BaseExperiment(ABC, StoreInitArgs):
     @property
     def qubits(self) -> Tuple[int, ...]:
         """Return the qubits for the experiment."""
-        return self._qubits
+        return self._physical_qubits
 
     @property
     def physical_qubits(self) -> Tuple[int, ...]:

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -58,6 +58,7 @@ class BaseExperiment(ABC, StoreInitArgs):
 
         # Circuit parameters
         self._num_qubits = len(qubits)
+        self._qubits = tuple(qubits)
         self._physical_qubits = tuple(qubits)
         if self._num_qubits != len(set(self._physical_qubits)):
             raise QiskitError("Duplicate qubits in physical qubits list.")
@@ -100,6 +101,11 @@ class BaseExperiment(ABC, StoreInitArgs):
     def experiment_type(self) -> str:
         """Return experiment type."""
         return self._type
+
+    @property
+    def qubits(self) -> Tuple[int, ...]:
+        """Return the qubits for the experiment."""
+        return self._qubits
 
     @property
     def physical_qubits(self) -> Tuple[int, ...]:

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -55,6 +55,12 @@ class TestFramework(QiskitExperimentsTestCase):
                 num_jobs += 1
         self.assertEqual(len(job_ids), num_jobs)
 
+    def test_properties(self):
+        """Test experiment properties"""
+        qubits = (0, 2, 3)
+        exp = FakeExperiment(qubits=qubits)
+        self.assertEqual(exp.qubits, qubits)
+
     def test_analysis_replace_results_true(self):
         """Test running analysis with replace_results=True"""
         analysis = FakeAnalysis()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #627 .


### Details and comments
Saves the qubits passed in to the initialization as `experiment._qubits` and adds the `qubits` read-only property to access it.

