### PR TITLE
Remove job metadata from BaseExperiment

### DIFF
--- a/qiskit_experiments/calibration_management/base_calibration_experiment.py
+++ b/qiskit_experiments/calibration_management/base_calibration_experiment.py
@@ -222,6 +222,15 @@ class BaseCalibrationExperiment(BaseExperiment, ABC):
         """
         pass
 
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata
+
     def _transpiled_circuits(self) -> List[QuantumCircuit]:
         """Override the transpiled circuits method to bring in the inst_map.
 

--- a/qiskit_experiments/curve_analysis/curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis.py
@@ -678,7 +678,7 @@ class CurveAnalysis(BaseAnalysis, ABC):
     def _num_qubits(self) -> int:
         """Getter for qubit number."""
         try:
-            return self.__experiment_metadata["num_qubits"]
+            return len(self.__experiment_metadata["physical_qubits"])
         except (TypeError, KeyError):
             # Ignore experiment metadata is not set or key is not found
             return None
@@ -749,7 +749,6 @@ class CurveAnalysis(BaseAnalysis, ABC):
             Extra metadata explicitly added by the experiment subclass.
         """
         exclude = ["experiment_type", "num_qubits", "physical_qubits", "job_metadata"]
-
         return {k: v for k, v in self.__experiment_metadata.items() if k not in exclude}
 
     def _data(

--- a/qiskit_experiments/data_processing/processor_library.py
+++ b/qiskit_experiments/data_processing/processor_library.py
@@ -12,6 +12,7 @@
 
 """A collection of functions that return various data processors."""
 
+import warnings
 from qiskit.qobj.utils import MeasLevel, MeasReturnType
 
 from qiskit_experiments.framework import ExperimentData, Options
@@ -21,11 +22,7 @@ from qiskit_experiments.data_processing.nodes import ProjectorType
 from qiskit_experiments.data_processing import nodes
 
 
-def get_processor(
-    experiment_data: ExperimentData,
-    analysis_options: Options,
-    index: int = -1,
-) -> DataProcessor:
+def get_processor(experiment_data: ExperimentData, analysis_options: Options) -> DataProcessor:
     """Get a DataProcessor that produces a continuous signal given the options.
 
     Args:
@@ -45,30 +42,44 @@ def get_processor(
             - outcome (string): The measurement outcome that will be passed to a Probability node.
               The default value is a string of 1's where the length of the string is the number of
               qubits, e.g. '111' for three qubits.
-        index: The index of the job for which to get a data processor. The default value is -1.
 
     Returns:
         An instance of DataProcessor capable of processing the data for the corresponding job.
 
     Notes:
-        The `num_qubits` argument is extracted from the `experiment_data` metadata and is used
-        to determine the default `outcome` to extract from classified data if it was not given in the
-        analysis options.
+        The `physical_qubits` argument is extracted from the `experiment_data`
+        metadata and is used to determine the default `outcome` to extract from
+        classified data if it was not given in the analysis options.
 
     Raises:
         DataProcessorError: if the measurement level is not supported.
         DataProcessorError: if the wrong dimensionality reduction for kerneled data
             is specified.
     """
-    run_options = experiment_data.metadata["job_metadata"][index].get("run_options", {})
+    metadata = experiment_data.metadata
+    if "job_metadata" in metadata:
+        # Backwards compatibility for old experiment data
+        # remove job metadata and add required fields to new location in metadata
+        job_meta = metadata.pop("job_metadata")
+        run_options = job_meta[-1].get("run_options", {})
+        for opt in ["meas_level", "meas_return"]:
+            if opt in run_options:
+                metadata[opt] = run_options[opt]
+        warnings.warn(
+            "The analyzed ExperimentData contains deprecated data processor "
+            " job_metadata which has been been updated to current metadat format. "
+            "If this data was loaded from a database servide you should re-save it "
+            "to update the metadata in the database.",
+            DeprecationWarning,
+        )
 
-    meas_level = run_options.get("meas_level", MeasLevel.CLASSIFIED)
-    meas_return = run_options.get("meas_return", MeasReturnType.AVERAGE)
+    meas_level = metadata.get("meas_level", MeasLevel.CLASSIFIED)
+    meas_return = metadata.get("meas_return", MeasReturnType.AVERAGE)
     normalize = analysis_options.get("normalization", True)
     dimensionality_reduction = analysis_options.get("dimensionality_reduction", ProjectorType.SVD)
 
     if meas_level == MeasLevel.CLASSIFIED:
-        num_qubits = experiment_data.metadata.get("num_qubits", 1)
+        num_qubits = len(metadata.get("physical_qubits", [0]))
         outcome = analysis_options.get("outcome", "1" * num_qubits)
         return DataProcessor("counts", [nodes.Probability(outcome)])
 

--- a/qiskit_experiments/framework/__init__.py
+++ b/qiskit_experiments/framework/__init__.py
@@ -173,7 +173,7 @@ allow configuring various experiment and execution options
 - :meth:`BaseExperiment._transpiled_circuits`
   to override the default transpilation of circuits before execution.
 
-- :meth:`BaseExperiment._additional_metadata`
+- :meth:`BaseExperiment._metadata`
   to add any experiment metadata to the result data.
 
 Analysis Subclasses

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -512,6 +512,9 @@ class BaseExperiment(ABC, StoreInitArgs):
     def _metadata(self) -> Dict[str, any]:
         """Return experiment metadata for ExperimentData.
 
+        Subclasses can override this method to add custom experiment
+        metadata to the returned experiment result data.
+
         The :meth:`_add_job_metadata` method will be called for each
         experiment execution to append job metadata, including current
         option values, to the ``job_metadata`` list.
@@ -521,18 +524,7 @@ class BaseExperiment(ABC, StoreInitArgs):
             "num_qubits": self.num_qubits,
             "physical_qubits": list(self.physical_qubits),
         }
-        # Add additional metadata if subclasses specify it
-        for key, val in self._additional_metadata().items():
-            metadata[key] = val
         return metadata
-
-    def _additional_metadata(self) -> Dict[str, any]:
-        """Add additional subclass experiment metadata.
-
-        Subclasses can override this method if it is necessary to store
-        additional experiment metadata in ExperimentData.
-        """
-        return {}
 
     def _add_job_metadata(self, metadata: Dict[str, Any], jobs: BaseJob, **run_options):
         """Add runtime job metadata to ExperimentData.

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -515,12 +515,6 @@ class BaseExperiment(ABC, StoreInitArgs):
         metadata to the returned experiment result data.
         """
         metadata = {"physical_qubits": list(self.physical_qubits)}
-
-        # Store measurement level and meas return if they have been
-        # set for the experiment
-        for run_opt in ["meas_level", "meas_return"]:
-            if hasattr(self.run_options, run_opt):
-                metadata[run_opt] = getattr(self.run_options, run_opt)
         return metadata
 
     def __json_encode__(self):

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -514,16 +514,14 @@ class BaseExperiment(ABC, StoreInitArgs):
 
         Subclasses can override this method to add custom experiment
         metadata to the returned experiment result data.
-
-        The :meth:`_add_job_metadata` method will be called for each
-        experiment execution to append job metadata, including current
-        option values, to the ``job_metadata`` list.
         """
-        metadata = {
-            "experiment_type": self._type,
-            "num_qubits": self.num_qubits,
-            "physical_qubits": list(self.physical_qubits),
-        }
+        metadata = {"physical_qubits": list(self.physical_qubits)}
+
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
         return metadata
 
     def _add_job_metadata(self, metadata: Dict[str, Any], jobs: BaseJob, **run_options):

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -16,7 +16,7 @@ Base Experiment class.
 from abc import ABC, abstractmethod
 import copy
 from collections import OrderedDict
-from typing import Sequence, Optional, Tuple, List, Dict, Union, Any
+from typing import Sequence, Optional, Tuple, List, Dict, Union
 import warnings
 
 from qiskit import transpile, assemble, QuantumCircuit
@@ -275,7 +275,6 @@ class BaseExperiment(ABC, StoreInitArgs):
         # Run jobs
         jobs = experiment._run_jobs(transpiled_circuits, **run_opts)
         experiment_data.add_jobs(jobs, timeout=timeout)
-        experiment._add_job_metadata(experiment_data.metadata, jobs, **run_opts)
 
         # Optionally run analysis
         if analysis and experiment.analysis:
@@ -523,25 +522,6 @@ class BaseExperiment(ABC, StoreInitArgs):
             if hasattr(self.run_options, run_opt):
                 metadata[run_opt] = getattr(self.run_options, run_opt)
         return metadata
-
-    def _add_job_metadata(self, metadata: Dict[str, Any], jobs: BaseJob, **run_options):
-        """Add runtime job metadata to ExperimentData.
-
-        Args:
-            metadata: the metadata dict to update with job data.
-            jobs: the job objects.
-            run_options: backend run options for the job.
-        """
-        values = {
-            "job_ids": [job.job_id() for job in jobs],
-            "experiment_options": copy.copy(self.experiment_options.__dict__),
-            "transpile_options": copy.copy(self.transpile_options.__dict__),
-            "run_options": copy.copy(run_options),
-        }
-        if self.analysis is not None:
-            values["analysis_options"] = copy.copy(self.analysis.options.__dict__)
-
-        metadata["job_metadata"] = [values]
 
     def __json_encode__(self):
         """Convert to format that can be JSON serialized"""

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -159,15 +159,11 @@ class CompositeExperiment(BaseExperiment):
 
     def _metadata(self):
         """Add component experiment metadata"""
-        return {
-            "component_types": [sub_exp.experiment_type for sub_exp in self.component_experiment()],
-            "component_metadata": [sub_exp._metadata() for sub_exp in self.component_experiment()],
-        }
-
-    def _add_job_metadata(self, metadata, jobs, **run_options):
-        super()._add_job_metadata(metadata, jobs, **run_options)
-        # Add sub-experiment options
-        for sub_metadata, sub_exp in zip(
-            metadata["component_metadata"], self.component_experiment()
-        ):
-            sub_exp._add_job_metadata(sub_metadata, jobs, **run_options)
+        metadata = super()._metadata()
+        metadata["component_types"] = [
+            sub_exp.experiment_type for sub_exp in self.component_experiment()
+        ]
+        metadata["component_metadata"] = [
+            sub_exp._metadata() for sub_exp in self.component_experiment()
+        ]
+        return metadata

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -157,7 +157,7 @@ class CompositeExperiment(BaseExperiment):
             # Call sub-experiments finalize method
             subexp._finalize()
 
-    def _additional_metadata(self):
+    def _metadata(self):
         """Add component experiment metadata"""
         return {
             "component_types": [sub_exp.experiment_type for sub_exp in self.component_experiment()],

--- a/qiskit_experiments/library/characterization/cr_hamiltonian.py
+++ b/qiskit_experiments/library/characterization/cr_hamiltonian.py
@@ -358,6 +358,15 @@ class CrossResonanceHamiltonian(BaseExperiment):
 
         return expr_circs
 
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata
+
 
 class EchoedCrossResonanceHamiltonian(CrossResonanceHamiltonian):
     r"""Echoed cross resonance Hamiltonian tomography experiment.

--- a/qiskit_experiments/library/characterization/drag.py
+++ b/qiskit_experiments/library/characterization/drag.py
@@ -210,3 +210,12 @@ class RoughDrag(BaseExperiment, RestlessMixin):
                 circuits.append(assigned_circuit)
 
         return circuits
+
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata

--- a/qiskit_experiments/library/characterization/fine_amplitude.py
+++ b/qiskit_experiments/library/characterization/fine_amplitude.py
@@ -240,6 +240,15 @@ class FineAmplitude(BaseExperiment, RestlessMixin):
 
         return circuits
 
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata
+
 
 class FineXAmplitude(FineAmplitude):
     r"""A fine amplitude experiment with all the options set for the :math:`\pi`-rotation.

--- a/qiskit_experiments/library/characterization/fine_drag.py
+++ b/qiskit_experiments/library/characterization/fine_drag.py
@@ -229,6 +229,15 @@ class FineDrag(BaseExperiment, RestlessMixin):
 
         return circuits
 
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata
+
 
 class FineXDrag(FineDrag):
     """Class to fine characterize the DRAG parameter of an X gate.

--- a/qiskit_experiments/library/characterization/fine_frequency.py
+++ b/qiskit_experiments/library/characterization/fine_frequency.py
@@ -136,3 +136,12 @@ class FineFrequency(BaseExperiment):
             circuits.append(circuit)
 
         return circuits
+
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata

--- a/qiskit_experiments/library/characterization/half_angle.py
+++ b/qiskit_experiments/library/characterization/half_angle.py
@@ -140,3 +140,12 @@ class HalfAngle(BaseExperiment):
             circuits.append(circuit)
 
         return circuits
+
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata

--- a/qiskit_experiments/library/characterization/rabi.py
+++ b/qiskit_experiments/library/characterization/rabi.py
@@ -171,6 +171,15 @@ class Rabi(BaseExperiment):
 
         return circs
 
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata
+
 
 class EFRabi(Rabi):
     """An experiment that scans the amplitude of a pulse inducing rotations between 1 and 2.

--- a/qiskit_experiments/library/characterization/ramsey_xy.py
+++ b/qiskit_experiments/library/characterization/ramsey_xy.py
@@ -231,3 +231,12 @@ class RamseyXY(BaseExperiment, RestlessMixin):
             circs.extend([assigned_x, assigned_y])
 
         return circs
+
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata

--- a/qiskit_experiments/library/characterization/spectroscopy.py
+++ b/qiskit_experiments/library/characterization/spectroscopy.py
@@ -133,3 +133,12 @@ class Spectroscopy(BaseExperiment, ABC):
             "unit": "Hz",
             "schedule": str(sched),
         }
+
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata

--- a/qiskit_experiments/library/characterization/t1.py
+++ b/qiskit_experiments/library/characterization/t1.py
@@ -133,3 +133,12 @@ class T1(BaseExperiment):
             circuits.append(circ)
 
         return circuits
+
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata

--- a/qiskit_experiments/library/characterization/t2hahn.py
+++ b/qiskit_experiments/library/characterization/t2hahn.py
@@ -191,3 +191,12 @@ class T2Hahn(BaseExperiment):
             circuits.append(circ)
 
         return circuits
+
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -157,3 +157,12 @@ class T2Ramsey(BaseExperiment):
             circuits.append(circ)
 
         return circuits
+
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -234,3 +234,12 @@ class StandardRB(BaseExperiment, RestlessMixin):
                 count_ops = [(key, (value, circuit_length)) for key, value in c_count_ops.items()]
                 meta.update({"count_ops": count_ops})
         return transpiled
+
+    def _metadata(self):
+        metadata = super()._metadata()
+        # Store measurement level and meas return if they have been
+        # set for the experiment
+        for run_opt in ["meas_level", "meas_return"]:
+            if hasattr(self.run_options, run_opt):
+                metadata[run_opt] = getattr(self.run_options, run_opt)
+        return metadata

--- a/releasenotes/notes/remove-job-metadata-74ecfaa02f6182e1.yaml
+++ b/releasenotes/notes/remove-job-metadata-74ecfaa02f6182e1.yaml
@@ -1,0 +1,13 @@
+---
+upgrade:
+  - |
+    The ``"job_metadata"`` field has been removed from
+    :class:`.BaseExperiment`. Experiments which needed job metadata for
+    analysis should now directly override the ``.BaseExperiment._metadata``
+    method to store the required job metadata. :class:`.BaseExperiment`
+    has been updated to store the ``"meas_level"`` and ``"meas_return"``
+    run options in metadata if they have been set in the experiment.
+  - |
+    The ``BaseExperiment._additional_metadata` method has been removed,
+    experiments should now directly override the ``BaseExperiment._metadata``
+    method to add additional experiment metadata to the run experiment data.

--- a/releasenotes/notes/remove-job-metadata-74ecfaa02f6182e1.yaml
+++ b/releasenotes/notes/remove-job-metadata-74ecfaa02f6182e1.yaml
@@ -4,9 +4,12 @@ upgrade:
     The ``"job_metadata"`` field has been removed from
     :class:`.BaseExperiment`. Experiments which needed job metadata for
     analysis should now directly override the ``.BaseExperiment._metadata``
-    method to store the required job metadata. :class:`.BaseExperiment`
-    has been updated to store the ``"meas_level"`` and ``"meas_return"``
-    run options in metadata if they have been set in the experiment.
+    method to store the required job metadata. 
+    
+    Individual experiments using :class:`.CurveAnalysis` based analysis
+    have been updated to store the ``"meas_level"`` and ``"meas_return"``
+    run options in metadata if they have been set in the experiment for
+    use in setting the data processor during analysis.
   - |
     The ``BaseExperiment._additional_metadata` method has been removed,
     experiments should now directly override the ``BaseExperiment._metadata``

--- a/test/calibration/experiments/test_drag.py
+++ b/test/calibration/experiments/test_drag.py
@@ -92,7 +92,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
         self.assertExperimentDone(exp_data)
         result = exp_data.analysis_results(1)
 
-        meas_level = exp_data.metadata["job_metadata"][-1]["run_options"]["meas_level"]
+        meas_level = exp_data.metadata["meas_level"]
 
         self.assertEqual(meas_level, MeasLevel.CLASSIFIED)
         self.assertTrue(abs(result.value.n - backend.ideal_beta) < self.test_tol)

--- a/test/curve_analysis/test_curve_fit.py
+++ b/test/curve_analysis/test_curve_fit.py
@@ -52,7 +52,7 @@ def simulate_output_data(func, xvals, param_dict, **metadata):
     for datum in data:
         expdata.add_data(datum)
 
-    expdata.metadata["job_metadata"] = [{"run_options": {"meas_level": MeasLevel.CLASSIFIED}}]
+    expdata.metadata["meas_level"] = MeasLevel.CLASSIFIED
 
     return expdata
 

--- a/test/test_t1.py
+++ b/test/test_t1.py
@@ -121,13 +121,7 @@ class TestT1(QiskitExperimentsTestCase):
         """
 
         data = ExperimentData()
-        data._metadata = {
-            "job_metadata": [
-                {
-                    "run_options": {"meas_level": 2},
-                },
-            ]
-        }
+        data._metadata = {"meas_level": 2}
 
         numbers = [750, 1800, 2750, 3550, 4250, 4850, 5450, 5900, 6400, 6800, 7000, 7350, 7700]
 
@@ -178,13 +172,7 @@ class TestT1(QiskitExperimentsTestCase):
         """
 
         data = ExperimentData()
-        data._metadata = {
-            "job_metadata": [
-                {
-                    "run_options": {"meas_level": 2},
-                },
-            ]
-        }
+        data._metadata = {"meas_level": 2}
 
         for i in range(10):
             data.add_data(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR reduces the default metadata stored in BaseExperiment to just the physical qubits, and meas level and meas return (if they have been set as run options).

### Details and comments
