### PR TITLE
Add option to flatten results in composite experiments

### DIFF
--- a/docs/tutorials/tphi_characterization.rst
+++ b/docs/tutorials/tphi_characterization.rst
@@ -63,21 +63,21 @@ we compute the results for :math:`T_\varphi.`
 
 .. jupyter-execute::
 
-    print(expdata.child_data(0).analysis_results("T1"))
+    print(expdata.analysis_results("T1"))
 
 .. jupyter-execute::
 
-    display(expdata.child_data(0).figure(0))
-
-
-.. jupyter-execute::
-
-    print(expdata.child_data(1).analysis_results("T2star"))
+    display(expdata.figure(0))
 
 
 .. jupyter-execute::
 
-    display(expdata.child_data(1).figure(0))
+    print(expdata.analysis_results("T2star"))
+
+
+.. jupyter-execute::
+
+    display(expdata.figure(1))
 
 .. jupyter-execute::
 

--- a/qiskit_experiments/database_service/db_analysis_result.py
+++ b/qiskit_experiments/database_service/db_analysis_result.py
@@ -338,6 +338,15 @@ class DbAnalysisResultV1(DbAnalysisResult):
         """
         return self._device_components
 
+    @device_components.setter
+    def device_components(self, components: List[Union[DeviceComponent, str]]):
+        """Set the device components"""
+        self._device_components = []
+        for comp in components:
+            if isinstance(comp, str):
+                comp = to_component(comp)
+            self._device_components.append(comp)
+
     @property
     def result_id(self) -> str:
         """Return analysis result ID.

--- a/qiskit_experiments/framework/base_analysis.py
+++ b/qiskit_experiments/framework/base_analysis.py
@@ -192,6 +192,12 @@ class BaseAnalysis(ABC, StoreInitArgs):
         elif experiment_components:
             device_components = experiment_components
 
+        if isinstance(data, DbAnalysisResultV1):
+            # Update device components and experiment id
+            data.device_components = device_components
+            data._experiment_id = experiment_id
+            return data
+
         return DbAnalysisResultV1(
             name=data.name,
             value=data.value,

--- a/qiskit_experiments/framework/composite/batch_experiment.py
+++ b/qiskit_experiments/framework/composite/batch_experiment.py
@@ -46,6 +46,7 @@ class BatchExperiment(CompositeExperiment):
         self,
         experiments: List[BaseExperiment],
         backend: Optional[Backend] = None,
+        combine_results: bool = False,
         analysis: Optional[CompositeAnalysis] = None,
     ):
         """Initialize a batch experiment.
@@ -53,6 +54,12 @@ class BatchExperiment(CompositeExperiment):
         Args:
             experiments: a list of experiments.
             backend: Optional, the backend to run the experiment on.
+            combine_results: If True flatten all component experiment results
+                             into a single ExperimentData container, including
+                             nested composite experiments. If False save each
+                             component experiment results as a separate child
+                             ExperimentData container. This kwarg is ignored
+                             if the analysis kwarg is used.
             analysis: Optional, the composite analysis class to use. If not
                       provided this will be initialized automatically from the
                       supplied experiments.
@@ -67,7 +74,9 @@ class BatchExperiment(CompositeExperiment):
                     self._qubit_map[physical_qubit] = logical_qubit
                     logical_qubit += 1
         qubits = tuple(self._qubit_map.keys())
-        super().__init__(experiments, qubits, backend=backend, analysis=analysis)
+        super().__init__(
+            experiments, qubits, backend=backend, analysis=analysis, combine_results=combine_results
+        )
 
     def circuits(self):
         return self._batch_circuits(to_transpile=False)

--- a/qiskit_experiments/framework/composite/batch_experiment.py
+++ b/qiskit_experiments/framework/composite/batch_experiment.py
@@ -46,7 +46,7 @@ class BatchExperiment(CompositeExperiment):
         self,
         experiments: List[BaseExperiment],
         backend: Optional[Backend] = None,
-        combine_results: bool = False,
+        flatten_results: bool = False,
         analysis: Optional[CompositeAnalysis] = None,
     ):
         """Initialize a batch experiment.
@@ -54,7 +54,7 @@ class BatchExperiment(CompositeExperiment):
         Args:
             experiments: a list of experiments.
             backend: Optional, the backend to run the experiment on.
-            combine_results: If True flatten all component experiment results
+            flatten_results: If True flatten all component experiment results
                              into a single ExperimentData container, including
                              nested composite experiments. If False save each
                              component experiment results as a separate child
@@ -75,7 +75,7 @@ class BatchExperiment(CompositeExperiment):
                     logical_qubit += 1
         qubits = tuple(self._qubit_map.keys())
         super().__init__(
-            experiments, qubits, backend=backend, analysis=analysis, combine_results=combine_results
+            experiments, qubits, backend=backend, analysis=analysis, flatten_results=flatten_results
         )
 
     def circuits(self):

--- a/qiskit_experiments/framework/composite/composite_analysis.py
+++ b/qiskit_experiments/framework/composite/composite_analysis.py
@@ -88,7 +88,7 @@ class CompositeAnalysis(BaseAnalysis):
         if fields.get("combine_results", False):
             for analysis in self._analyses:
                 if isinstance(analysis, CompositeAnalysis):
-                    analysis.options.combine_results = True
+                    analysis.set_options(combine_results=True)
 
     def component_analysis(
         self, index: Optional[int] = None
@@ -148,7 +148,6 @@ class CompositeAnalysis(BaseAnalysis):
         # the parent experiment analysis results
         for sub_expdata in component_expdata:
             sub_expdata.block_for_results()
-
         # Optionally combine results from all component experiments
         # for adding to the main experiment data container
         if self.options.combine_results:
@@ -325,17 +324,15 @@ class CompositeAnalysis(BaseAnalysis):
         """
         analysis_results = []
         figures = []
-        if self.options.combine_results:
-            # Optionally combine results into main container
-            for i, sub_expdata in enumerate(component_experiment_data):
-                figures += sub_expdata._figures.values()
-                for result in sub_expdata.analysis_results():
-                    # Add metadata to distinguish the component experiment
-                    # the result was generated from
-                    result.extra["component_experiment"] = {
-                        "experiment_type": sub_expdata.experiment_type,
-                        "component_index": i,
-                    }
-                    analysis_results.append(result)
+        for i, sub_expdata in enumerate(component_experiment_data):
+            figures += sub_expdata._figures.values()
+            for result in sub_expdata.analysis_results():
+                # Add metadata to distinguish the component experiment
+                # the result was generated from
+                result.extra["component_experiment"] = {
+                    "experiment_type": sub_expdata.experiment_type,
+                    "component_index": i,
+                }
+                analysis_results.append(result)
 
         return analysis_results, figures

--- a/qiskit_experiments/framework/composite/composite_analysis.py
+++ b/qiskit_experiments/framework/composite/composite_analysis.py
@@ -286,16 +286,25 @@ class CompositeAnalysis(BaseAnalysis):
         experiment_types = metadata.get("component_types", [None] * num_components)
         component_metadata = metadata.get("component_metadata", [{}] * num_components)
 
-        # Create component experiments and copy backend, tags, share level
-        # and auto save from the parent experiment data
+        # Create component experiments and set the backend and
+        # metadata for the components
         component_expdata = []
         for i, _ in enumerate(self._analyses):
             subdata = ExperimentData(backend=experiment_data.backend)
             subdata._type = experiment_types[i]
             subdata.metadata.update(component_metadata[i])
-            subdata.tags = experiment_data.tags
-            subdata.share_level = experiment_data.share_level
-            subdata.auto_save = experiment_data.auto_save
+
+            if self.options.combine_results:
+                # Explicitly set auto_save to false so the temporary
+                # data can't accidentally be saved
+                subdata.auto_save = False
+            else:
+                # Copy tags, share_level and auto_save from the parent
+                # experiment data if results are not being combined.
+                subdata.tags = experiment_data.tags
+                subdata.share_level = experiment_data.share_level
+                subdata.auto_save = experiment_data.auto_save
+
             component_expdata.append(subdata)
 
         return component_expdata

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -16,7 +16,6 @@ Composite Experiment abstract base class.
 from typing import List, Sequence, Optional, Union
 from abc import abstractmethod
 import warnings
-from qiskit import QiskitError
 from qiskit.providers.backend import Backend
 from qiskit_experiments.framework import BaseExperiment
 from qiskit_experiments.framework.base_analysis import BaseAnalysis
@@ -32,6 +31,7 @@ class CompositeExperiment(BaseExperiment):
         qubits: Sequence[int],
         backend: Optional[Backend] = None,
         experiment_type: Optional[str] = None,
+        combine_results: bool = False,
         analysis: Optional[CompositeAnalysis] = None,
     ):
         """Initialize the composite experiment object.
@@ -41,6 +41,12 @@ class CompositeExperiment(BaseExperiment):
             qubits: list of physical qubits for the experiment.
             backend: Optional, the backend to run the experiment on.
             experiment_type: Optional, composite experiment subclass name.
+            combine_results: If True flatten all component experiment results
+                             into a single ExperimentData container, including
+                             nested composite experiments. If False save each
+                             component experiment results as a separate child
+                             ExperimentData container. This kwarg is ignored
+                             if the analysis kwarg is used.
             analysis: Optional, the composite analysis class to use. If not
                       provided this will be initialized automatically from the
                       supplied experiments.
@@ -52,11 +58,8 @@ class CompositeExperiment(BaseExperiment):
         self._experiments = experiments
         self._num_experiments = len(experiments)
         if analysis is None:
-            analysis = CompositeAnalysis([exp.analysis for exp in self._experiments])
-        elif not isinstance(analysis, CompositeAnalysis):
-            raise QiskitError(
-                f"{type(analysis)} is not a CompositeAnalysis instance. CompositeExperiments"
-                " require a CompositeAnalysis class or subclass for analysis."
+            analysis = CompositeAnalysis(
+                [exp.analysis for exp in self._experiments], combine_results=combine_results
             )
         super().__init__(
             qubits,
@@ -96,6 +99,18 @@ class CompositeExperiment(BaseExperiment):
             stacklevel=2,
         )
         return self.analysis.component_analysis(index)
+
+    @property
+    def analysis(self) -> Union[CompositeAnalysis, None]:
+        """Return the analysis instance for the experiment"""
+        return self._analysis
+
+    @analysis.setter
+    def analysis(self, analysis: Union[CompositeAnalysis, None]) -> None:
+        """Set the analysis instance for the experiment"""
+        if analysis is not None and not isinstance(analysis, CompositeAnalysis):
+            raise TypeError("Input is not a None or a CompositeAnalysis subclass.")
+        self._analysis = analysis
 
     def copy(self) -> "BaseExperiment":
         """Return a copy of the experiment"""

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -31,7 +31,7 @@ class CompositeExperiment(BaseExperiment):
         qubits: Sequence[int],
         backend: Optional[Backend] = None,
         experiment_type: Optional[str] = None,
-        combine_results: bool = False,
+        flatten_results: bool = False,
         analysis: Optional[CompositeAnalysis] = None,
     ):
         """Initialize the composite experiment object.
@@ -41,7 +41,7 @@ class CompositeExperiment(BaseExperiment):
             qubits: list of physical qubits for the experiment.
             backend: Optional, the backend to run the experiment on.
             experiment_type: Optional, composite experiment subclass name.
-            combine_results: If True flatten all component experiment results
+            flatten_results: If True flatten all component experiment results
                              into a single ExperimentData container, including
                              nested composite experiments. If False save each
                              component experiment results as a separate child
@@ -59,7 +59,7 @@ class CompositeExperiment(BaseExperiment):
         self._num_experiments = len(experiments)
         if analysis is None:
             analysis = CompositeAnalysis(
-                [exp.analysis for exp in self._experiments], combine_results=combine_results
+                [exp.analysis for exp in self._experiments], flatten_results=flatten_results
             )
         super().__init__(
             qubits,

--- a/qiskit_experiments/framework/composite/parallel_experiment.py
+++ b/qiskit_experiments/framework/composite/parallel_experiment.py
@@ -43,7 +43,7 @@ class ParallelExperiment(CompositeExperiment):
         self,
         experiments: List[BaseExperiment],
         backend: Optional[Backend] = None,
-        combine_results: bool = False,
+        flatten_results: bool = False,
         analysis: Optional[CompositeAnalysis] = None,
     ):
         """Initialize the analysis object.
@@ -51,7 +51,7 @@ class ParallelExperiment(CompositeExperiment):
         Args:
             experiments: a list of experiments.
             backend: Optional, the backend to run the experiment on.
-            combine_results: If True flatten all component experiment results
+            flatten_results: If True flatten all component experiment results
                              into a single ExperimentData container, including
                              nested composite experiments. If False save each
                              component experiment results as a separate child
@@ -65,7 +65,7 @@ class ParallelExperiment(CompositeExperiment):
         for exp in experiments:
             qubits += exp.physical_qubits
         super().__init__(
-            experiments, qubits, backend=backend, analysis=analysis, combine_results=combine_results
+            experiments, qubits, backend=backend, analysis=analysis, flatten_results=flatten_results
         )
 
     def circuits(self):

--- a/qiskit_experiments/framework/composite/parallel_experiment.py
+++ b/qiskit_experiments/framework/composite/parallel_experiment.py
@@ -43,6 +43,7 @@ class ParallelExperiment(CompositeExperiment):
         self,
         experiments: List[BaseExperiment],
         backend: Optional[Backend] = None,
+        combine_results: bool = False,
         analysis: Optional[CompositeAnalysis] = None,
     ):
         """Initialize the analysis object.
@@ -50,6 +51,12 @@ class ParallelExperiment(CompositeExperiment):
         Args:
             experiments: a list of experiments.
             backend: Optional, the backend to run the experiment on.
+            combine_results: If True flatten all component experiment results
+                             into a single ExperimentData container, including
+                             nested composite experiments. If False save each
+                             component experiment results as a separate child
+                             ExperimentData container. This kwarg is ignored
+                             if the analysis kwarg is used.
             analysis: Optional, the composite analysis class to use. If not
                       provided this will be initialized automatically from the
                       supplied experiments.
@@ -57,7 +64,9 @@ class ParallelExperiment(CompositeExperiment):
         qubits = []
         for exp in experiments:
             qubits += exp.physical_qubits
-        super().__init__(experiments, qubits, backend=backend, analysis=analysis)
+        super().__init__(
+            experiments, qubits, backend=backend, analysis=analysis, combine_results=combine_results
+        )
 
     def circuits(self):
 

--- a/qiskit_experiments/library/characterization/analysis/tphi_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/tphi_analysis.py
@@ -43,7 +43,7 @@ class TphiAnalysis(CompositeAnalysis):
                 "Invlaid component analyses for T2phi, analyses must be a pair of "
                 "T1Analysis and T2RamseyAnalysis instances."
             )
-        super().__init__(analyses, combine_results=True)
+        super().__init__(analyses, flatten_results=True)
 
     def _run_analysis(
         self, experiment_data: ExperimentData

--- a/qiskit_experiments/library/characterization/analysis/tphi_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/tphi_analysis.py
@@ -17,6 +17,9 @@ from typing import List, Tuple
 
 from qiskit_experiments.framework import ExperimentData, AnalysisResultData
 from qiskit_experiments.framework.composite.composite_analysis import CompositeAnalysis
+from qiskit_experiments.library.characterization.analysis.t1_analysis import T1Analysis
+from qiskit_experiments.library.characterization.analysis.t2ramsey_analysis import T2RamseyAnalysis
+from qiskit_experiments.exceptions import QiskitError
 
 
 class TphiAnalysis(CompositeAnalysis):
@@ -26,6 +29,22 @@ class TphiAnalysis(CompositeAnalysis):
     A class to analyze :math:`T_\phi` experiments.
     """
 
+    def __init__(self, analyses=None):
+        if analyses is None:
+            analyses = [T1Analysis(), T2RamseyAnalysis()]
+
+        # Validate analyses kwarg
+        if (
+            len(analyses) != 2
+            or not isinstance(analyses[0], T1Analysis)
+            or not isinstance(analyses[1], T2RamseyAnalysis)
+        ):
+            raise QiskitError(
+                "Invlaid component analyses for T2phi, analyses must be a pair of "
+                "T1Analysis and T2RamseyAnalysis instances."
+            )
+        super().__init__(analyses, combine_results=True)
+
     def _run_analysis(
         self, experiment_data: ExperimentData
     ) -> Tuple[List[AnalysisResultData], List["matplotlib.figure.Figure"]]:
@@ -34,23 +53,24 @@ class TphiAnalysis(CompositeAnalysis):
         _run_analysis for the two sub-experiments.
         Based on the results, it computes the result for :math:`T_phi`.
         """
-        super()._run_analysis(experiment_data)
+        # Run composite analysis and extract T1 and T2star results
+        analysis_results, figures = super()._run_analysis(experiment_data)
+        t1_result = next(filter(lambda res: res.name == "T1", analysis_results))
+        t2star_result = next(filter(lambda res: res.name == "T2star", analysis_results))
 
-        t1_result = experiment_data.child_data(0).analysis_results("T1")
-        t2star_result = experiment_data.child_data(1).analysis_results("T2star")
+        # Calculate Tphi from T1 and T2star
         tphi = 1 / (1 / t2star_result.value - 1 / (2 * t1_result.value))
-
         quality_tphi = (
             "good" if (t1_result.quality == "good" and t2star_result.quality == "good") else "bad"
         )
+        tphi_result = AnalysisResultData(
+            name="T_phi",
+            value=tphi,
+            chisq=None,
+            quality=quality_tphi,
+            extra={"unit": "s"},
+        )
 
-        analysis_results = [
-            AnalysisResultData(
-                name="T_phi",
-                value=tphi,
-                chisq=None,
-                quality=quality_tphi,
-                extra={"unit": "s"},
-            )
-        ]
-        return analysis_results, []
+        # Return combined results
+        analysis_results = [tphi_result] + analysis_results
+        return analysis_results, figures

--- a/qiskit_experiments/library/characterization/tphi.py
+++ b/qiskit_experiments/library/characterization/tphi.py
@@ -23,8 +23,6 @@ from qiskit_experiments.library.characterization import (
     T1,
     T2Ramsey,
     TphiAnalysis,
-    T1Analysis,
-    T2RamseyAnalysis,
 )
 
 
@@ -97,11 +95,8 @@ class Tphi(BatchExperiment):
             backend=backend,
             osc_freq=osc_freq,
         )
-        self.exps = [exp_t1, exp_t2]
+        analysis = TphiAnalysis([exp_t1.analysis, exp_t2.analysis])
 
         # Create batch experiment
-        super().__init__(experiments=self.exps, backend=backend)
-
+        super().__init__([exp_t1, exp_t2], backend=backend, analysis=analysis)
         self.set_experiment_options(delays_t1=delays_t1, delays_t2=delays_t2)
-        # CompositeAnalysis accept the component analysis classes in its constructor
-        self.analysis = TphiAnalysis(analyses=[T1Analysis(), T2RamseyAnalysis()])

--- a/releasenotes/notes/composite-combine-results-7c07820d99bd1b72.yaml
+++ b/releasenotes/notes/composite-combine-results-7c07820d99bd1b72.yaml
@@ -1,16 +1,17 @@
 ---
 features:
   - |
-    Adds a ``combine_results`` analysis option to :class:`.CompositeAnalysis`
-    that if set to ``True`` combines all analysis results and figures from
-    component experiment analysis into a single :class:`.ExperimentData`
-    container. This can be used to flatten results from :class:`.ParallelExperiment`
-    and :class:`.BatchExperiment` into a single :class:`.ExperimentData` container.
-    
-    If set to ``False`` (the default value) the results of each component
-    experiment will be saved as separate :meth:`~.ExperimentData.child_data`
-    as was previously done.
+    Adds a ``combine_results`` init kwarg to :class:`.CompositeAnalysis`,
+    :class:`.CompositeExperiment`, :class:`.ParallelExperiment`, and
+    :class:`.BatchExperiment` that if set to ``True`` combines all analysis
+    results and figures from component experiment analysis into a single
+    :class:`.ExperimentData` container. 
 
     Note that for nested composite experiments setting ``combine_results=True``
     will recursively set the same value for all component experiments that
     are also composite experiments.
+upgrade:
+  - |
+    Changed the :class:`.Tphi` experiment and :class:`.TphiAnalysis` to combine
+    the component analysis results so that it runs as a single experiment
+    returning :math:`T_\phi`, :math:`T_1`, and :math:`T_2^\ast` analysis results.

--- a/releasenotes/notes/composite-combine-results-7c07820d99bd1b72.yaml
+++ b/releasenotes/notes/composite-combine-results-7c07820d99bd1b72.yaml
@@ -1,13 +1,14 @@
 ---
 features:
   - |
-    Adds a ``combine_results`` init kwarg to :class:`.CompositeAnalysis`,
+    Adds a ``flatten_results`` init kwarg to :class:`.CompositeAnalysis`,
     :class:`.CompositeExperiment`, :class:`.ParallelExperiment`, and
-    :class:`.BatchExperiment` that if set to ``True`` combines all analysis
-    results and figures from component experiment analysis into a single
-    :class:`.ExperimentData` container. 
+    :class:`.BatchExperiment` that if set to ``True`` flattens all analysis
+    results and figures from component experiment analysis into the main
+    :class:`.ExperimentData` container, and does not save the individual
+    child data components.
 
-    Note that for nested composite experiments setting ``combine_results=True``
+    Note that for nested composite experiments setting ``flatten_results=True``
     will recursively set the same value for all component experiments that
     are also composite experiments.
 upgrade:

--- a/releasenotes/notes/composite-combine-results-7c07820d99bd1b72.yaml
+++ b/releasenotes/notes/composite-combine-results-7c07820d99bd1b72.yaml
@@ -1,0 +1,16 @@
+---
+features:
+  - |
+    Adds a ``combine_results`` analysis option to :class:`.CompositeAnalysis`
+    that if set to ``True`` combines all analysis results and figures from
+    component experiment analysis into a single :class:`.ExperimentData`
+    container. This can be used to flatten results from :class:`.ParallelExperiment`
+    and :class:`.BatchExperiment` into a single :class:`.ExperimentData` container.
+    
+    If set to ``False`` (the default value) the results of each component
+    experiment will be saved as separate :meth:`~.ExperimentData.child_data`
+    as was previously done.
+
+    Note that for nested composite experiments setting ``combine_results=True``
+    will recursively set the same value for all component experiments that
+    are also composite experiments.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ black~=22.0
 stestr
 astroid==2.5
 pylint==2.7.1
+jinja2==3.0.3
 Sphinx>=1.8.3
 qiskit-sphinx-theme>=1.6
 sphinx-autodoc-typehints

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -73,10 +73,12 @@ class TestComposite(QiskitExperimentsTestCase):
         exp1 = FakeExperiment([1])
         exp2 = FakeExperiment([2])
         exp3 = FakeExperiment([3])
-        comp_exp = ParallelExperiment([
-            BatchExperiment(2 * [ParallelExperiment([exp0, exp1])]),
-            BatchExperiment(3 * [ParallelExperiment([exp2, exp3])])
-        ])
+        comp_exp = ParallelExperiment(
+            [
+                BatchExperiment(2 * [ParallelExperiment([exp0, exp1])]),
+                BatchExperiment(3 * [ParallelExperiment([exp2, exp3])]),
+            ]
+        )
         comp_exp.analysis.set_options(combine_results=True)
         expdata = comp_exp.run(FakeBackend())
         self.assertExperimentDone(expdata)

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -67,6 +67,24 @@ class TestComposite(QiskitExperimentsTestCase):
             expdata = par_exp.run(FakeBackend())
         self.assertExperimentDone(expdata)
 
+    def test_combine_results(self):
+        """Test combining results."""
+        exp0 = FakeExperiment([0])
+        exp1 = FakeExperiment([1])
+        exp2 = FakeExperiment([2])
+        exp3 = FakeExperiment([3])
+        comp_exp = ParallelExperiment([
+            BatchExperiment(2 * [ParallelExperiment([exp0, exp1])]),
+            BatchExperiment(3 * [ParallelExperiment([exp2, exp3])])
+        ])
+        comp_exp.analysis.set_options(combine_results=True)
+        expdata = comp_exp.run(FakeBackend())
+        self.assertExperimentDone(expdata)
+        # Check no child data was saved
+        self.assertEqual(len(expdata.child_data()), 0)
+        # Check right number of analysis results is returned
+        self.assertEqual(len(expdata.analysis_results()), 30)
+
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp1 = FakeExperiment([0])

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -67,7 +67,7 @@ class TestComposite(QiskitExperimentsTestCase):
             expdata = par_exp.run(FakeBackend())
         self.assertExperimentDone(expdata)
 
-    def test_combine_results_nested(self):
+    def test_flatten_results_nested(self):
         """Test combining results."""
         exp0 = FakeExperiment([0])
         exp1 = FakeExperiment([1])
@@ -78,7 +78,7 @@ class TestComposite(QiskitExperimentsTestCase):
                 BatchExperiment(2 * [ParallelExperiment([exp0, exp1])]),
                 BatchExperiment(3 * [ParallelExperiment([exp2, exp3])]),
             ],
-            combine_results=True,
+            flatten_results=True,
         )
         expdata = comp_exp.run(FakeBackend())
         self.assertExperimentDone(expdata)
@@ -87,16 +87,16 @@ class TestComposite(QiskitExperimentsTestCase):
         # Check right number of analysis results is returned
         self.assertEqual(len(expdata.analysis_results()), 30)
 
-    def test_combine_results_partial(self):
-        """Test combining results."""
+    def test_flatten_results_partial(self):
+        """Test flattening results."""
         exp0 = FakeExperiment([0])
         exp1 = FakeExperiment([1])
         exp2 = FakeExperiment([2])
         exp3 = FakeExperiment([3])
         comp_exp = BatchExperiment(
             [
-                ParallelExperiment([exp0, exp1, exp2], combine_results=True),
-                ParallelExperiment([exp2, exp3], combine_results=True),
+                ParallelExperiment([exp0, exp1, exp2], flatten_results=True),
+                ParallelExperiment([exp2, exp3], flatten_results=True),
             ],
         )
         expdata = comp_exp.run(FakeBackend())

--- a/test/test_tphi.py
+++ b/test/test_tphi.py
@@ -62,8 +62,7 @@ class TestTphi(QiskitExperimentsTestCase):
         backend = TphiBackend(t1=t1, t2ramsey=t2ramsey, freq=0.1)
         expdata = exp.run(backend=backend)
         self.assertExperimentDone(expdata)
-        for r in expdata.analysis_results():
-            print(r)
+
         # Extract x values from metadata
         x_values_t1 = []
         x_values_t2 = []

--- a/test/test_tphi.py
+++ b/test/test_tphi.py
@@ -16,8 +16,6 @@ Test T2Ramsey experiment
 from test.base import QiskitExperimentsTestCase
 from qiskit_experiments.library import Tphi
 from qiskit_experiments.test.tphi_backend import TphiBackend
-from qiskit_experiments.library.characterization.analysis.t1_analysis import T1Analysis
-from qiskit_experiments.library.characterization.analysis.t2ramsey_analysis import T2RamseyAnalysis
 from qiskit_experiments.library.characterization.analysis.tphi_analysis import TphiAnalysis
 
 
@@ -37,8 +35,7 @@ class TestTphi(QiskitExperimentsTestCase):
         t1 = 20
         t2ramsey = 25
         backend = TphiBackend(t1=t1, t2ramsey=t2ramsey, freq=0.1)
-        analysis = TphiAnalysis([T1Analysis(), T2RamseyAnalysis()])
-        expdata = exp.run(backend=backend, analysis=analysis)
+        expdata = exp.run(backend=backend)
         self.assertExperimentDone(expdata)
         self.assertRoundTripSerializable(expdata, check_func=self.experiment_data_equiv)
         self.assertRoundTripPickle(expdata, check_func=self.experiment_data_equiv)
@@ -63,14 +60,19 @@ class TestTphi(QiskitExperimentsTestCase):
         t1 = 20
         t2ramsey = 25
         backend = TphiBackend(t1=t1, t2ramsey=t2ramsey, freq=0.1)
-        analysis = TphiAnalysis([T1Analysis(), T2RamseyAnalysis()])
-        expdata = exp.run(backend=backend, analysis=analysis)
+        expdata = exp.run(backend=backend)
         self.assertExperimentDone(expdata)
-
-        data_t1 = expdata.child_data(0).data()
-        x_values_t1 = [datum["metadata"]["xval"] for datum in data_t1]
-        data_t2 = expdata.child_data(1).data()
-        x_values_t2 = [datum["metadata"]["xval"] for datum in data_t2]
+        for r in expdata.analysis_results():
+            print(r)
+        # Extract x values from metadata
+        x_values_t1 = []
+        x_values_t2 = []
+        for datum in expdata.data():
+            comp_meta = datum["metadata"]["composite_metadata"][0]
+            if comp_meta["experiment_type"] == "T1":
+                x_values_t1.append(comp_meta["xval"])
+            else:
+                x_values_t2.append(comp_meta["xval"])
         self.assertListEqual(x_values_t1, delays_t1, "Incorrect delays_t1")
         self.assertListEqual(x_values_t2, delays_t2, "Incorrect delays_t2")
 
@@ -81,16 +83,23 @@ class TestTphi(QiskitExperimentsTestCase):
         exp.set_experiment_options(
             delays_t1=new_delays_t1, delays_t2=new_delays_t2, osc_freq=new_osc_freq
         )
-        expdata = exp.run(backend=backend, analysis=analysis)
+        expdata = exp.run(backend=backend)
         self.assertExperimentDone(expdata)
 
-        data_t1 = expdata.child_data(0).data()
-        x_values_t1 = [datum["metadata"]["xval"] for datum in data_t1]
-        data_t2 = expdata.child_data(1).data()
-        x_values_t2 = [datum["metadata"]["xval"] for datum in data_t2]
-        self.assertListEqual(x_values_t1, new_delays_t1, "Option delays_t1 not set correctly")
-        self.assertListEqual(x_values_t2, new_delays_t2, "Option delays_t2 not set correctly")
-        new_freq_t2 = data_t2[0]["metadata"]["osc_freq"]
+        # Extract x values from metadata
+        x_values_t1 = []
+        x_values_t2 = []
+        new_freq_t2 = None
+        for datum in expdata.data():
+            comp_meta = datum["metadata"]["composite_metadata"][0]
+            if comp_meta["experiment_type"] == "T1":
+                x_values_t1.append(comp_meta["xval"])
+            else:
+                x_values_t2.append(comp_meta["xval"])
+                if new_freq_t2 is None:
+                    new_freq_t2 = comp_meta["osc_freq"]
+        self.assertListEqual(x_values_t1, new_delays_t1, "Incorrect delays_t1")
+        self.assertListEqual(x_values_t2, new_delays_t2, "Incorrect delays_t2")
         self.assertEqual(new_freq_t2, new_osc_freq, "Option osc_freq not set correctly")
 
     def test_roundtrip_serializable(self):
@@ -100,7 +109,7 @@ class TestTphi(QiskitExperimentsTestCase):
 
     def test_analysis_config(self):
         """Test converting analysis to and from config works"""
-        analysis = TphiAnalysis([T1Analysis(), T2RamseyAnalysis()])
+        analysis = TphiAnalysis()
         loaded_analysis = analysis.from_config(analysis.config())
         self.assertNotEqual(analysis, loaded_analysis)
         self.assertEqual(analysis.config(), loaded_analysis.config())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This adds a `flatten_results` option to CompositeAnalysis to flatten the results of any nested component experiments into a single ExperimentData container.

### Details and comments

~Depends on #720~

Still to do:
- [x] Release note
- [x] Unit tests
