### PR TITLE
Fix tomography fitter data

### DIFF
--- a/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
@@ -13,7 +13,7 @@
 Contrained convex least-squares tomography fitter.
 """
 
-from typing import Optional, Dict, List, Tuple
+from typing import Optional, Dict, Tuple
 import numpy as np
 
 from qiskit_experiments.library.tomography.basis import (
@@ -27,7 +27,7 @@ from . import fitter_utils
 
 @cvxpy_utils.requires_cvxpy
 def cvxpy_linear_lstsq(
-    outcome_data: List[np.ndarray],
+    outcome_data: np.ndarray,
     shot_data: np.ndarray,
     measurement_data: np.ndarray,
     preparation_data: np.ndarray,
@@ -92,7 +92,7 @@ def cvxpy_linear_lstsq(
         fitter function.
 
     Args:
-        outcome_data: list of outcome frequency data.
+        outcome_data: measurement outcome frequency data.
         shot_data: basis measurement total shot data.
         measurement_data: measurement basis indice data.
         preparation_data: preparation basis indice data.
@@ -124,6 +124,7 @@ def cvxpy_linear_lstsq(
     )
 
     if weights is not None:
+        weights = weights / np.sqrt(np.sum(weights**2))
         basis_matrix = weights[:, None] * basis_matrix
         probability_data = weights * probability_data
 
@@ -174,7 +175,7 @@ def cvxpy_linear_lstsq(
 
 @cvxpy_utils.requires_cvxpy
 def cvxpy_gaussian_lstsq(
-    outcome_data: List[np.ndarray],
+    outcome_data: np.ndarray,
     shot_data: np.ndarray,
     measurement_data: np.ndarray,
     preparation_data: np.ndarray,
@@ -219,7 +220,7 @@ def cvxpy_gaussian_lstsq(
         :math:`K=2^m` the number of measurement outcomes for each basis measurement.
 
     Args:
-        outcome_data: list of outcome frequency data.
+        outcome_data: measurement outcome frequency data.
         shot_data: basis measurement total shot data.
         measurement_data: measurement basis indice data.
         preparation_data: preparation basis indice data.
@@ -250,7 +251,7 @@ def cvxpy_gaussian_lstsq(
         shot_data,
         measurement_data,
         preparation_data,
-        measurement_basis,
+        measurement_basis=measurement_basis,
         preparation_basis=preparation_basis,
         psd=psd,
         trace=trace,

--- a/qiskit_experiments/library/tomography/fitters/lininv.py
+++ b/qiskit_experiments/library/tomography/fitters/lininv.py
@@ -13,7 +13,7 @@
 Linear inversion MLEtomography fitter.
 """
 
-from typing import Dict, List, Tuple, Optional, Sequence
+from typing import Dict, Tuple, Optional, Sequence
 from functools import lru_cache
 import numpy as np
 from qiskit_experiments.library.tomography.basis.fitter_basis import (
@@ -23,7 +23,7 @@ from qiskit_experiments.library.tomography.basis.fitter_basis import (
 
 
 def linear_inversion(
-    outcome_data: List[np.ndarray],
+    outcome_data: np.ndarray,
     shot_data: np.ndarray,
     measurement_data: np.ndarray,
     preparation_data: np.ndarray,
@@ -76,7 +76,7 @@ def linear_inversion(
         least-squares optimization.
 
     Args:
-        outcome_data: list of outcome frequency data.
+        outcome_data: measurement outcome frequency data.
         shot_data: basis measurement total shot data.
         measurement_data: measurement basis indice data.
         preparation_data: preparation basis indice data.
@@ -116,7 +116,11 @@ def linear_inversion(
             p_mat = None
 
         # Get probabilities and optional measurement basis component
-        for outcome, freq in outcomes:
+        for outcome, freq in enumerate(outcomes):
+            if freq == 0:
+                # Skip component with zero probability
+                continue
+
             if meas_dual_basis:
                 dual_op = meas_dual_basis.matrix(midx, outcome)
                 if prep_dual_basis:

--- a/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
@@ -13,7 +13,7 @@
 Linear least-square MLE tomography fitter.
 """
 
-from typing import Optional, Dict, List, Tuple
+from typing import Optional, Dict, Tuple
 import numpy as np
 import scipy.linalg as la
 
@@ -26,7 +26,7 @@ from . import fitter_utils
 
 
 def scipy_linear_lstsq(
-    outcome_data: List[np.ndarray],
+    outcome_data: np.ndarray,
     shot_data: np.ndarray,
     measurement_data: np.ndarray,
     preparation_data: np.ndarray,
@@ -67,7 +67,7 @@ def scipy_linear_lstsq(
         fitter function.
 
     Args:
-        outcome_data: list of outcome frequency data.
+        outcome_data: measurement outcome frequency data.
         shot_data: basis measurement total shot data.
         measurement_data: measurement basis indice data.
         preparation_data: preparation basis indice data.
@@ -112,7 +112,7 @@ def scipy_linear_lstsq(
 
 
 def scipy_gaussian_lstsq(
-    outcome_data: List[np.ndarray],
+    outcome_data: np.ndarray,
     shot_data: np.ndarray,
     measurement_data: np.ndarray,
     preparation_data: np.ndarray,
@@ -152,7 +152,7 @@ def scipy_gaussian_lstsq(
         :math:`K=2^m` the number of measurement outcomes for each basis measurement.
 
     Args:
-        outcome_data: list of outcome frequency data.
+        outcome_data: measurement outcome frequency data.
         shot_data: basis measurement total shot data.
         measurement_data: measurement basis indice data.
         preparation_data: preparation basis indice data.

--- a/qiskit_experiments/library/tomography/tomography_analysis.py
+++ b/qiskit_experiments/library/tomography/tomography_analysis.py
@@ -117,14 +117,15 @@ class TomographyAnalysis(BaseAnalysis):
                 shot_data,
                 measurement_data,
                 preparation_data,
-                self.options.measurement_basis,
-                self.options.preparation_basis,
+                measurement_basis=self.options.measurement_basis,
+                preparation_basis=self.options.preparation_basis,
                 **self.options.fitter_options,
             )
             t_fitter_stop = time.time()
             if fitter_metadata is None:
                 fitter_metadata = {}
             state = Choi(state) if self.options.preparation_basis else DensityMatrix(state)
+
             fitter_metadata["fitter"] = fitter.__name__
             fitter_metadata["fitter_time"] = t_fitter_stop - t_fitter_start
 
@@ -314,16 +315,14 @@ class TomographyAnalysis(BaseAnalysis):
         measurement_data = np.zeros((num_basis, meas_size), dtype=int)
         preparation_data = np.zeros((num_basis, prep_size), dtype=int)
         shot_data = np.zeros(num_basis, dtype=int)
-        outcome_data = []
+        outcome_data = np.zeros((num_basis, 2**meas_size), dtype=int)
 
         for i, (basis_key, counts) in enumerate(outcome_dict.items()):
             measurement_data[i] = basis_key[0]
             preparation_data[i] = basis_key[1]
-            outcome_arr = np.zeros((len(counts), 2), dtype=int)
-            for j, (outcome, freq) in enumerate(counts.items()):
-                outcome_arr[j] = [outcome, freq]
+            for outcome, freq in counts.items():
+                outcome_data[i][outcome] = freq
                 shot_data[i] += freq
-            outcome_data.append(outcome_arr)
         return outcome_data, shot_data, measurement_data, preparation_data
 
     @staticmethod

--- a/releasenotes/notes/fix-tomography-fitter-b144c0df24c30d68.yaml
+++ b/releasenotes/notes/fix-tomography-fitter-b144c0df24c30d68.yaml
@@ -1,0 +1,23 @@
+---
+upgrade:
+  - |
+    The signature of the ``outcome_data`` argument of the tomography
+    fitter functions in :mod:`.library.tomography` has been changed from
+    a list of NumPy ndarray vectors of non-zero observed frequencies into a
+    single ndarray matrix containing the observed frequencies of all possible
+    measurement outcomes for the measurement bases.
+fixes:
+  - |
+    Fixes a bug in :class:`.TomographyAnalysis` where the basis elements of
+    unobserved measurement outcomes were not being included in the fitter
+    objective function for least-squares fitters (CVXPY and SciPy).
+    This would lead to lower than expected fit fidelities when fitting data
+    with many zero count outcomes (typically synthetic data from ideal simulation).
+  - |
+    Fixes issue with the CVXPY :class:`.ProcessTomography` analysis fitter
+    functions :func:`.cvxpy_linear_lstsq` and :func:`cvxpy_gaussian_lstsq`
+    where the trace preserving constraint was not being applied to the fit
+    functions by default and required being explicitly passed as a
+    ``solver_option``. Now all CVXPY process tomography experiments will
+    have this option set to True by default unless a user explicitly
+    disables it by setting the solver_option to False.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ arxiv
 ddt~=1.4.2
 qiskit-aer>=0.10.0
 pandas>=1.1.5
+cvxpy>=1.1.15


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #724

### Details and comments

* Fixes a bug in :class:`.TomographyAnalysis` where the basis elements of
    unobserved measurement outcomes were not being included in the fitter
    objective function for least-squares fitters (CVXPY and SciPy).
    This would lead to lower than expected fit fidelities when fitting data
    with many zero count outcomes (typically synthetic data from ideal simulation).
* Fixes issue with the CVXPY :class:`.ProcessTomography` analysis fitter
    functions :func:`.cvxpy_linear_lstsq` and :func:`cvxpy_gaussian_lstsq`
    where the trace preserving constraint was not being applied to the fit
    functions by default and required being explicitly passed as a
    ``solver_option``. Now all CVXPY process tomography experiments will
    have this option set to True by default unless a user explicitly
    disables it by setting the solver_option to False.
