### PR TITLE
Replace `__fixed_parameters__` with analysis option

### DIFF
--- a/qiskit_experiments/curve_analysis/curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis.py
@@ -241,7 +241,9 @@ class CurveAnalysis(BaseAnalysis, ABC):
         if hasattr(self, "__fixed_parameters__"):
             warnings.warn(
                 "The class attribute __fixed_parameters__ has been deprecated and will be removed. "
-                "Now this attribute is absorbed in analysis options as fixed_parameters.",
+                "Now this attribute is absorbed in analysis options as fixed_parameters. "
+                "This warning will be dropped in v0.4 along with "
+                "the support for the deprecated attribute.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -967,6 +969,8 @@ class CurveAnalysis(BaseAnalysis, ABC):
 
     @classmethod
     def from_config(cls, config: Union[AnalysisConfig, Dict]) -> "CurveAnalysis":
+        # For backward compatibility. This will be removed in v0.4.
+
         instance = super().from_config(config)
 
         # When fixed param value is hard-coded as options. This is deprecated data structure.
@@ -980,7 +984,9 @@ class CurveAnalysis(BaseAnalysis, ABC):
             warnings.warn(
                 "Fixed parameter value should be defined in options.fixed_parameters as "
                 "a dictionary values, rather than a standalone analysis option. "
-                "Please re-save this experiment to be loaded after deprecation period.",
+                "Please re-save this experiment to be loaded after deprecation period. "
+                "This warning will be dropped in v0.4 along with "
+                "the support for the deprecated fixed parameter options.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/qiskit_experiments/curve_analysis/curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis.py
@@ -47,6 +47,7 @@ from qiskit_experiments.framework import (
     ExperimentData,
     AnalysisResultData,
     Options,
+    AnalysisConfig,
 )
 
 PARAMS_ENTRY_PREFIX = "@Parameters_"
@@ -233,12 +234,21 @@ class CurveAnalysis(BaseAnalysis, ABC):
     #: List[SeriesDef]: List of mapping representing a data series
     __series__ = list()
 
-    #: List[str]: Fixed parameter in fit function. Value should be set to the analysis options.
-    __fixed_parameters__ = list()
-
     def __init__(self):
         """Initialize data fields that are privately accessed by methods."""
         super().__init__()
+
+        if hasattr(self, "__fixed_parameters__"):
+            warnings.warn(
+                "The class attribute __fixed_parameters__ has been deprecated and will be removed. "
+                "Now this attribute is absorbed in analysis options as fixed_parameters.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            # pylint: disable=no-member
+            self._options.fixed_parameters = {
+                p: self.options.get(p, None) for p in self.__fixed_parameters__
+            }
 
         #: Dict[str, Any]: Experiment metadata
         self.__experiment_metadata = None
@@ -271,21 +281,12 @@ class CurveAnalysis(BaseAnalysis, ABC):
             )
 
         # remove the first function argument. this is usually x, i.e. not a fit parameter.
-        fit_params = list(list(fsigs)[0].parameters.keys())[1:]
+        return list(list(fsigs)[0].parameters.keys())[1:]
 
-        # remove fixed parameters
-        if cls.__fixed_parameters__ is not None:
-            for fixed_param in cls.__fixed_parameters__:
-                try:
-                    fit_params.remove(fixed_param)
-                except ValueError as ex:
-                    raise AnalysisError(
-                        f"Defined fixed parameter {fixed_param} is not a fit function argument."
-                        "Update series definition to ensure the parameter name is defined with "
-                        f"fit functions. Currently available parameters are {fit_params}."
-                    ) from ex
-
-        return fit_params
+    @property
+    def parameters(self) -> List[str]:
+        """Return parameters of this curve analysis."""
+        return [s for s in self._fit_params() if s not in self.options.fixed_parameters]
 
     @classmethod
     def _default_options(cls) -> Options:
@@ -339,6 +340,9 @@ class CurveAnalysis(BaseAnalysis, ABC):
                 as extra information.
             curve_fitter_options (Dict[str, Any]) Options that are passed to the
                 specified curve fitting function.
+            fixed_parameters (Dict[str, Any]): Fitting model parameters that are fixed
+                during the curve fitting. This should be provided with default value
+                keyed on one of the parameter names in the series definition.
         """
         options = super()._default_options()
 
@@ -360,11 +364,9 @@ class CurveAnalysis(BaseAnalysis, ABC):
         options.style = PlotterStyle()
         options.extra = dict()
         options.curve_fitter_options = dict()
-
-        # automatically populate initial guess and boundary
-        fit_params = cls._fit_params()
-        options.p0 = {par_name: None for par_name in fit_params}
-        options.bounds = {par_name: None for par_name in fit_params}
+        options.p0 = {}
+        options.bounds = {}
+        options.fixed_parameters = {}
 
         return options
 
@@ -754,16 +756,15 @@ class CurveAnalysis(BaseAnalysis, ABC):
         #
 
         # Update all fit functions in the series definitions if fixed parameter is defined.
-        # Fixed parameters should be provided by the analysis options.
-        if self.__fixed_parameters__:
-            assigned_params = {k: self.options.get(k, None) for k in self.__fixed_parameters__}
+        assigned_params = self.options.fixed_parameters
 
+        if assigned_params:
             # Check if all parameters are assigned.
             if any(v is None for v in assigned_params.values()):
                 raise AnalysisError(
                     f"Unassigned fixed-value parameters for the fit "
                     f"function {self.__class__.__name__}."
-                    f"All values of fixed-parameters, i.e. {self.__fixed_parameters__}, "
+                    f"All values of fixed-parameters, i.e. {assigned_params}, "
                     "must be provided by the analysis options to run this analysis."
                 )
 
@@ -815,7 +816,7 @@ class CurveAnalysis(BaseAnalysis, ABC):
 
         # Generate algorithmic initial guesses and boundaries
         default_fit_opt = FitOptions(
-            parameters=self._fit_params(),
+            parameters=self.parameters,
             default_p0=self.options.p0,
             default_bounds=self.options.bounds,
             **self.options.curve_fitter_options,
@@ -963,6 +964,31 @@ class CurveAnalysis(BaseAnalysis, ABC):
             figures = []
 
         return analysis_results, figures
+
+    @classmethod
+    def from_config(cls, config: Union[AnalysisConfig, Dict]) -> "CurveAnalysis":
+        instance = super().from_config(config)
+
+        # When fixed param value is hard-coded as options. This is deprecated data structure.
+        loaded_opts = instance.options.__dict__
+
+        # pylint: disable=no-member
+        deprecated_fixed_params = {
+            p: loaded_opts[p] for p in instance.parameters if p in loaded_opts
+        }
+        if any(deprecated_fixed_params):
+            warnings.warn(
+                "Fixed parameter value should be defined in options.fixed_parameters as "
+                "a dictionary values, rather than a standalone analysis option. "
+                "Please re-save this experiment to be loaded after deprecation period.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            new_fixed_params = instance.options.fixed_parameters
+            new_fixed_params.update(deprecated_fixed_params)
+            instance.set_options(fixed_parameters=new_fixed_params)
+
+        return instance
 
 
 def is_error_not_significant(

--- a/qiskit_experiments/curve_analysis/standard_analysis/error_amplification_analysis.py
+++ b/qiskit_experiments/curve_analysis/standard_analysis/error_amplification_analysis.py
@@ -105,12 +105,6 @@ class ErrorAmplificationAnalysis(curve.CurveAnalysis):
         descriptions of analysis options.
 
         Analysis Options:
-            angle_per_gate (float): The ideal angle per repeated gate.
-                The user must set this option as it defaults to None.
-            phase_offset (float): A phase offset for the analysis. This phase offset will be
-                :math:`\pi/2` if the square-root of X gate is added before the repeated gates.
-                This is decided for the user in :meth:`set_schedule` depending on whether the
-                sx gate is included in the experiment.
             max_good_angle_error (float): The maximum angle error for which the fit is
                 considered as good. Defaults to :math:`\pi/2`.
         """
@@ -118,11 +112,8 @@ class ErrorAmplificationAnalysis(curve.CurveAnalysis):
         default_options.result_parameters = ["d_theta"]
         default_options.xlabel = "Number of gates (n)"
         default_options.ylabel = "Population"
-        default_options.angle_per_gate = None
-        default_options.phase_offset = 0.0
-        default_options.max_good_angle_error = np.pi / 2
-        default_options.amp = 1.0
         default_options.ylim = [0, 1.0]
+        default_options.max_good_angle_error = np.pi / 2
 
         return default_options
 
@@ -140,6 +131,8 @@ class ErrorAmplificationAnalysis(curve.CurveAnalysis):
         Raises:
             CalibrationError: When ``angle_per_gate`` is missing.
         """
+        fixed_params = self.options.fixed_parameters
+
         curve_data = self._data()
         max_abs_y, _ = curve.guess.max_height(curve_data.y, absolute=True)
         max_y, min_y = np.max(curve_data.y), np.min(curve_data.y)
@@ -152,16 +145,19 @@ class ErrorAmplificationAnalysis(curve.CurveAnalysis):
         if "amp" in user_opt.p0:
             user_opt.p0.set_if_empty(amp=max_y - min_y)
             user_opt.bounds.set_if_empty(amp=(0, 2 * max_abs_y))
+            amp = user_opt.p0["amp"]
+        else:
+            # Fixed parameter
+            amp = fixed_params.get("amp", 1.0)
 
         # Base the initial guess on the intended angle_per_gate and phase offset.
-        apg = self.options.angle_per_gate
-        phi = self.options.phase_offset
+        apg = user_opt.p0.get("angle_per_gate", fixed_params.get("angle_per_gate", 0.0))
+        phi = user_opt.p0.get("phase_offset", fixed_params.get("phase_offset", 0.0))
 
         # Prepare logical guess for specific condition (often satisfied)
         d_theta_guesses = []
 
         offsets = apg * curve_data.x + phi
-        amp = user_opt.p0.get("amp", self.options.amp)
         for i in range(curve_data.x.size):
             xi = curve_data.x[i]
             yi = curve_data.y[i]

--- a/qiskit_experiments/library/calibration/fine_amplitude.py
+++ b/qiskit_experiments/library/calibration/fine_amplitude.py
@@ -171,9 +171,10 @@ class FineXAmplitudeCal(FineAmplitudeCal):
             auto_update=auto_update,
         )
         self.analysis.set_options(
-            angle_per_gate=np.pi,
-            phase_offset=np.pi / 2,
-            amp=1,
+            fixed_parameters={
+                "angle_per_gate": np.pi,
+                "phase_offset": np.pi / 2,
+            }
         )
 
     @classmethod
@@ -222,8 +223,10 @@ class FineSXAmplitudeCal(FineAmplitudeCal):
             auto_update=auto_update,
         )
         self.analysis.set_options(
-            angle_per_gate=np.pi / 2,
-            phase_offset=np.pi,
+            fixed_parameters={
+                "angle_per_gate": np.pi / 2,
+                "phase_offset": np.pi,
+            }
         )
 
     @classmethod

--- a/qiskit_experiments/library/characterization/analysis/fine_amplitude_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/fine_amplitude_analysis.py
@@ -58,5 +58,3 @@ class FineAmplitudeAnalysis(ErrorAmplificationAnalysis):
             filter_kwargs={"series": 1},
         ),
     ]
-
-    __fixed_parameters__ = ["angle_per_gate", "phase_offset"]

--- a/qiskit_experiments/library/characterization/analysis/fine_drag_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/fine_drag_analysis.py
@@ -12,6 +12,8 @@
 
 """Fine DRAG calibration analysis."""
 
+import warnings
+
 import numpy as np
 from qiskit_experiments.curve_analysis import ErrorAmplificationAnalysis
 from qiskit_experiments.framework import Options
@@ -31,6 +33,16 @@ class FineDragAnalysis(ErrorAmplificationAnalysis):
     """
 
     __fixed_parameters__ = ["angle_per_gate", "phase_offset", "amp"]
+
+    def __init__(self):
+        super().__init__()
+
+        warnings.warn(
+            f"{self.__class__.__name__} has been deprecated. Use ErrorAmplificationAnalysis "
+            "instance with the analysis options involving the fixed_parameters.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     @classmethod
     def _default_options(cls) -> Options:

--- a/qiskit_experiments/library/characterization/analysis/fine_frequency_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/fine_frequency_analysis.py
@@ -12,6 +12,8 @@
 
 """Fine frequency experiment analysis."""
 
+import warnings
+
 import numpy as np
 
 from qiskit_experiments.curve_analysis import ErrorAmplificationAnalysis
@@ -32,6 +34,16 @@ class FineFrequencyAnalysis(ErrorAmplificationAnalysis):
     """
 
     __fixed_parameters__ = ["angle_per_gate", "phase_offset"]
+
+    def __init__(self):
+        super().__init__()
+
+        warnings.warn(
+            f"{self.__class__.__name__} has been deprecated. Use ErrorAmplificationAnalysis "
+            "instance with the analysis options involving the fixed_parameters.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     @classmethod
     def _default_options(cls) -> Options:

--- a/qiskit_experiments/library/characterization/analysis/fine_half_angle_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/fine_half_angle_analysis.py
@@ -12,6 +12,8 @@
 
 """Fine half angle calibration analysis."""
 
+import warnings
+
 import numpy as np
 from qiskit_experiments.framework import Options
 from qiskit_experiments.curve_analysis import ErrorAmplificationAnalysis, ParameterRepr
@@ -30,6 +32,16 @@ class FineHalfAngleAnalysis(ErrorAmplificationAnalysis):
     """
 
     __fixed_parameters__ = ["angle_per_gate", "phase_offset", "amp"]
+
+    def __init__(self):
+        super().__init__()
+
+        warnings.warn(
+            f"{self.__class__.__name__} has been deprecated. Use ErrorAmplificationAnalysis "
+            "instance with the analysis options involving the fixed_parameters.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     @classmethod
     def _default_options(cls) -> Options:

--- a/qiskit_experiments/library/characterization/fine_amplitude.py
+++ b/qiskit_experiments/library/characterization/fine_amplitude.py
@@ -253,9 +253,10 @@ class FineXAmplitude(FineAmplitude):
         super().__init__([qubit], XGate(), backend=backend)
         # Set default analysis options
         self.analysis.set_options(
-            angle_per_gate=np.pi,
-            phase_offset=np.pi / 2,
-            amp=1,
+            fixed_parameters={
+                "angle_per_gate": np.pi,
+                "phase_offset": np.pi / 2,
+            }
         )
 
     @classmethod
@@ -290,8 +291,10 @@ class FineSXAmplitude(FineAmplitude):
         super().__init__([qubit], SXGate(), backend=backend)
         # Set default analysis options
         self.analysis.set_options(
-            angle_per_gate=np.pi / 2,
-            phase_offset=np.pi,
+            fixed_parameters={
+                "angle_per_gate": np.pi / 2,
+                "phase_offset": np.pi,
+            }
         )
 
     @classmethod
@@ -353,9 +356,10 @@ class FineZXAmplitude(FineAmplitude):
         super().__init__(qubits, gate, backend=backend, measurement_qubits=[qubits[1]])
         # Set default analysis options
         self.analysis.set_options(
-            angle_per_gate=np.pi / 2,
-            phase_offset=np.pi,
-            amp=1,
+            fixed_parameters={
+                "angle_per_gate": np.pi / 2,
+                "phase_offset": np.pi,
+            },
             outcome="1",
         )
 

--- a/qiskit_experiments/library/characterization/fine_drag.py
+++ b/qiskit_experiments/library/characterization/fine_drag.py
@@ -20,9 +20,7 @@ from qiskit.circuit import Gate
 from qiskit.circuit.library import XGate, SXGate
 from qiskit.providers.backend import Backend
 from qiskit_experiments.framework import BaseExperiment, Options
-from qiskit_experiments.library.characterization.analysis import (
-    FineDragAnalysis,
-)
+from qiskit_experiments.curve_analysis.standard_analysis import ErrorAmplificationAnalysis
 
 
 class FineDrag(BaseExperiment):
@@ -126,7 +124,7 @@ class FineDrag(BaseExperiment):
         This is the correction formula in the FineDRAG Updater.
 
     # section: analysis_ref
-        :py:class:`FineDragAnalysis`
+        :py:class:`~qiskit_experiments.curve_analysis.ErrorAmplificationAnalysis`
 
     # section: see_also
         qiskit_experiments.library.calibration.drag.DragCal
@@ -161,7 +159,17 @@ class FineDrag(BaseExperiment):
             gate: The gate that will be repeated.
             backend: Optional, the backend to run the experiment on.
         """
-        super().__init__([qubit], analysis=FineDragAnalysis(), backend=backend)
+        analysis = ErrorAmplificationAnalysis()
+        analysis.set_options(
+            normalization=True,
+            fixed_parameters={
+                "angle_per_gate": 0.0,
+                "phase_offset": np.pi / 2,
+                "amp": 1.0,
+            },
+        )
+
+        super().__init__([qubit], analysis=analysis, backend=backend)
         self.set_experiment_options(gate=gate)
 
     @staticmethod

--- a/qiskit_experiments/library/characterization/fine_frequency.py
+++ b/qiskit_experiments/library/characterization/fine_frequency.py
@@ -19,7 +19,7 @@ from qiskit import QuantumCircuit
 from qiskit.providers.backend import Backend
 
 from qiskit_experiments.framework import BaseExperiment, Options
-from qiskit_experiments.library.characterization.analysis import FineFrequencyAnalysis
+from qiskit_experiments.curve_analysis.standard_analysis import ErrorAmplificationAnalysis
 
 
 class FineFrequency(BaseExperiment):
@@ -47,7 +47,7 @@ class FineFrequency(BaseExperiment):
             meas: 1/══════════════════════════════════════════════╩═
                                                                   0
     # section: analysis_ref
-        :py:class:`FineFrequencyAnalysis`
+        :py:class:`~qiskit_experiments.curve_analysis.ErrorAmplificationAnalysis`
     """
 
     def __init__(
@@ -66,7 +66,16 @@ class FineFrequency(BaseExperiment):
             repetitions: The number of repetitions, if not given then the default value
                 from the experiment default options will be used.
         """
-        super().__init__([qubit], analysis=FineFrequencyAnalysis(), backend=backend)
+        analysis = ErrorAmplificationAnalysis()
+        analysis.set_options(
+            normalization=True,
+            fixed_parameters={
+                "angle_per_gate": np.pi / 2,
+                "phase_offset": 0.0,
+            },
+        )
+
+        super().__init__([qubit], analysis=analysis, backend=backend)
 
         if repetitions is not None:
             self.set_experiment_options(repetitions=repetitions)

--- a/qiskit_experiments/library/characterization/half_angle.py
+++ b/qiskit_experiments/library/characterization/half_angle.py
@@ -19,7 +19,8 @@ from qiskit import QuantumCircuit
 from qiskit.providers import Backend
 
 from qiskit_experiments.framework import BaseExperiment, Options
-from qiskit_experiments.library.characterization.analysis import FineHalfAngleAnalysis
+from qiskit_experiments.curve_analysis.standard_analysis import ErrorAmplificationAnalysis
+from qiskit_experiments.curve_analysis import ParameterRepr
 
 
 class HalfAngle(BaseExperiment):
@@ -84,7 +85,23 @@ class HalfAngle(BaseExperiment):
             qubit: The qubit on which to run the fine amplitude calibration experiment.
             backend: Optional, the backend to run the experiment on.
         """
-        super().__init__([qubit], analysis=FineHalfAngleAnalysis(), backend=backend)
+        analysis = ErrorAmplificationAnalysis()
+
+        default_bounds = analysis.options.bounds
+        default_bounds.update({"d_theta": (-np.pi / 2, np.pi / 2)})
+
+        analysis.set_options(
+            fixed_parameters={
+                "angle_per_gate": np.pi,
+                "phase_offset": -np.pi / 2,
+                "amp": 1.0,
+            },
+            result_parameters=[ParameterRepr("d_theta", "d_hac", "rad")],
+            normalization=True,
+            bounds=default_bounds,
+        )
+
+        super().__init__([qubit], analysis=analysis, backend=backend)
 
     @staticmethod
     def _pre_circuit() -> QuantumCircuit:

--- a/releasenotes/notes/curve-analysis-fixed-parameters-5915a29db1e2628b.yaml
+++ b/releasenotes/notes/curve-analysis-fixed-parameters-5915a29db1e2628b.yaml
@@ -1,0 +1,23 @@
+---
+upgrade:
+  - |
+    New default :class:`CurveAnalysis` analysis option ``fixed_parameters``
+    has been added. We can directly exclude parameters from the fit model
+    of the particular analysis instance, rather than defining a new class to define
+    the class attribute :attr:`CurveAnalysis.__fixed_parameters__`.
+deprecations:
+  - |
+    Class attribute :attr:`CurveAnalysis.__fixed_parameters__` has been deprecated
+    and support for the instantiation of the class with this attribute will be dropped soon.
+    In addition, the fixed parameter value defined as a standalone analysis option
+    has been deprecated. Please set `fixed_parameters` option instead.
+    This is a python dictionary of fixed parameter values keyed on the fit parameter names.
+  - |
+    Analysis class :class:`FineDragAnalysis` has been deprecated. Now you can directly
+    set fixed parameters to the :class:`ErrorAmplificationAnalysis` instance as an analysis option.
+  - |
+    Analysis class :class:`FineFrequencyAnalysis` has been deprecated. Now you can directly
+    set fixed parameters to the :class:`ErrorAmplificationAnalysis` instance as an analysis option.
+  - |
+    Analysis class :class:`FineHalfAngleAnalysis` has been deprecated. Now you can directly
+    set fixed parameters to the :class:`ErrorAmplificationAnalysis` instance as an analysis option.

--- a/test/calibration/experiments/test_fine_amplitude.py
+++ b/test/calibration/experiments/test_fine_amplitude.py
@@ -158,8 +158,10 @@ class TestSpecializations(QiskitExperimentsTestCase):
         exp = FineXAmplitude(0)
 
         self.assertTrue(exp.experiment_options.add_cal_circuits)
-        self.assertEqual(exp.analysis.options.angle_per_gate, np.pi)
-        self.assertEqual(exp.analysis.options.phase_offset, np.pi / 2)
+        self.assertDictEqual(
+            exp.analysis.options.fixed_parameters,
+            {"angle_per_gate": np.pi, "phase_offset": np.pi / 2},
+        )
         self.assertEqual(exp.experiment_options.gate, XGate())
 
     def test_fine_sx_amp(self):
@@ -171,8 +173,10 @@ class TestSpecializations(QiskitExperimentsTestCase):
 
         expected = [0, 1, 2, 3, 5, 7, 9, 11, 13, 15, 17, 21, 23, 25]
         self.assertEqual(exp.experiment_options.repetitions, expected)
-        self.assertEqual(exp.analysis.options.angle_per_gate, np.pi / 2)
-        self.assertEqual(exp.analysis.options.phase_offset, np.pi)
+        self.assertDictEqual(
+            exp.analysis.options.fixed_parameters,
+            {"angle_per_gate": np.pi / 2, "phase_offset": np.pi},
+        )
         self.assertEqual(exp.experiment_options.gate, SXGate())
 
     @data((2, 3), (3, 1), (0, 1))

--- a/test/curve_analysis/test_standard_analysis.py
+++ b/test/curve_analysis/test_standard_analysis.py
@@ -50,15 +50,15 @@ class TestErrorAmplificationAnalysis(QiskitExperimentsTestCase):
         class FakeAmpAnalysis(ErrorAmplificationAnalysis):
             """Analysis class for testing."""
 
-            __fixed_parameters__ = ["angle_per_gate", "phase_offset", "amp"]
-
             @classmethod
             def _default_options(cls) -> Options:
                 """Default analysis options."""
                 options = super()._default_options()
-                options.angle_per_gate = np.pi
-                options.phase_offset = np.pi / 2
-                options.amp = 1.0
+                options.fixed_parameters = {
+                    "angle_per_gate": np.pi,
+                    "phase_offset": np.pi / 2,
+                    "amp": 1.0,
+                }
 
                 return options
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR adds new `fixed_parameters` option to the `CurveAnalysis` and remove corresponding class attribute, as proposed in #726 by @eggerdj. This change allows developers/end-users to flexibly set analysis class without defining a new class just to fix parameters in the model.

### Details and comments

The most of logic/documentation will be replaced by #726 thus added code here is just temporary. No careful review or better/smarter logic is needed as long as all unittests pass. The important point of this PR is how API changes.
