### PR TITLE
Make FineZXAmplitude restless compatible

### DIFF
--- a/qiskit_experiments/data_processing/__init__.py
+++ b/qiskit_experiments/data_processing/__init__.py
@@ -59,6 +59,7 @@ Data Processing Nodes
     :toctree: ../stubs/
 
     Probability
+    MarginalizeCounts
     ToImag
     ToReal
     SVD
@@ -69,6 +70,7 @@ Data Processing Nodes
 from .data_action import DataAction, TrainableDataAction
 from .nodes import (
     Probability,
+    MarginalizeCounts,
     ToImag,
     ToReal,
     SVD,

--- a/qiskit_experiments/data_processing/nodes.py
+++ b/qiskit_experiments/data_processing/nodes.py
@@ -16,7 +16,7 @@ from abc import abstractmethod
 from abc import ABC
 from enum import Enum
 from numbers import Number
-from typing import Union, Sequence
+from typing import Union, Sequence, Set
 from collections import defaultdict
 
 import numpy as np
@@ -398,7 +398,99 @@ class ToAbs(IQPart):
         return unp.sqrt(data[..., 0] ** 2 + data[..., 1] ** 2) * self.scale
 
 
-class Probability(DataAction):
+class CountsAction(DataAction):
+    """An abstract DataAction that acts on count dictionaries."""
+
+    @abstractmethod
+    def _process(self, data: np.ndarray) -> np.ndarray:
+        """Defines how the counts are processed."""
+
+    def _format_data(self, data: np.ndarray) -> np.ndarray:
+        """
+        Checks that the given data has a counts format.
+
+        Args:
+            data: A data array to format. This is a single numpy array containing
+                all circuit results input to the data processor.
+                This is usually an object data type containing Python dictionaries of
+                count data keyed on the measured bitstring.
+                A count value is a discrete quantity representing the frequency of an event.
+                Therefore, count values do not have an uncertainty.
+
+        Returns:
+            The ``data`` as given.
+
+        Raises:
+            DataProcessorError: If the data is not a counts dict or a list of counts dicts.
+        """
+        valid_count_type = int, np.integer
+
+        if self._validate:
+            for datum in data:
+                if not isinstance(datum, dict):
+                    raise DataProcessorError(
+                        f"Data entry must be dictionary of counts, received {type(datum)}."
+                    )
+                for bit_str, count in datum.items():
+                    if not isinstance(bit_str, str):
+                        raise DataProcessorError(
+                            f"Key {bit_str} is not a valid count key in {self.__class__.__name__}."
+                        )
+                    if not isinstance(count, valid_count_type):
+                        raise DataProcessorError(
+                            f"Count {bit_str} is not a valid count for {self.__class__.__name__}. "
+                            "The uncertainty of probability is computed based on sampling error, "
+                            "thus the count should be an error-free discrete quantity "
+                            "representing the frequency of event."
+                        )
+
+        return data
+
+
+class MarginalizeCounts(CountsAction):
+    r"""A data action to marginalize count dictionaries.
+
+    This data action takes a count dictionary and returns a new count dictionary that
+    is marginalized over a set of specified qubits. For example, given the count
+    dictionary :code:`{"010": 1, "110": 10, "100": 100}` this node will return the
+    count dictionary :code:`{"10": 11, "00": 100}` when marginalized over qubit 2.
+    """
+
+    def __init__(self, qubits_to_keep: Set[int], validate: bool = True):
+        """Initialize a counts marginalization node.
+
+        Args:
+            qubits_to_keep: A set of qubits to retain during the marginalization process.
+            validate: If set to False the DataAction will not validate its input.
+        """
+        super().__init__(validate)
+        self._qubits_to_keep = sorted(qubits_to_keep, reverse=True)
+
+    def _process(self, data: np.ndarray) -> np.ndarray:
+        """Perform counts marginalization."""
+        marginalized_counts = []
+
+        for datum in data:
+            new_counts = defaultdict(int)
+            for bit_str, count in datum.items():
+                new_counts["".join([bit_str[::-1][idx] for idx in self._qubits_to_keep])] += count
+
+            marginalized_counts.append(new_counts)
+
+        return np.array(marginalized_counts)
+
+    def __repr__(self):
+        """String representation of the node."""
+        options_str = ", ".join(
+            [
+                f"qubits_to_keep={self._qubits_to_keep}",
+                f"validate={self._validate}",
+            ]
+        )
+        return f"{self.__class__.__name__}({options_str})"
+
+
+class Probability(CountsAction):
     r"""Compute the mean probability of a single measurement outcome from counts.
 
     This node returns the mean and standard deviation of a single measurement
@@ -470,47 +562,6 @@ class Probability(DataAction):
             self._alpha_prior = list(alpha_prior)
 
         super().__init__(validate)
-
-    def _format_data(self, data: np.ndarray) -> np.ndarray:
-        """
-        Checks that the given data has a counts format.
-
-        Args:
-            data: A data array to format. This is a single numpy array containing
-                all circuit results input to the data processor.
-                This is usually an object data type containing Python dictionaries of
-                count data keyed on the measured bitstring.
-                A count value is a discrete quantity representing the frequency of an event.
-                Therefore, count values do not have an uncertainty.
-
-        Returns:
-            The ``data`` as given.
-
-        Raises:
-            DataProcessorError: If the data is not a counts dict or a list of counts dicts.
-        """
-        valid_count_type = int, np.integer
-
-        if self._validate:
-            for datum in data:
-                if not isinstance(datum, dict):
-                    raise DataProcessorError(
-                        f"Data entry must be dictionary of counts, received {type(datum)}."
-                    )
-                for bit_str, count in datum.items():
-                    if not isinstance(bit_str, str):
-                        raise DataProcessorError(
-                            f"Key {bit_str} is not a valid count key in {self.__class__.__name__}."
-                        )
-                    if not isinstance(count, valid_count_type):
-                        raise DataProcessorError(
-                            f"Count {bit_str} is not a valid count for {self.__class__.__name__}. "
-                            "The uncertainty of probability is computed based on sampling error, "
-                            "thus the count should be an error-free discrete quantity "
-                            "representing the frequency of event."
-                        )
-
-        return data
 
     def _process(self, data: np.ndarray) -> np.ndarray:
         """Compute mean and standard error from the beta distribution.

--- a/qiskit_experiments/data_processing/nodes.py
+++ b/qiskit_experiments/data_processing/nodes.py
@@ -454,6 +454,12 @@ class MarginalizeCounts(CountsAction):
     is marginalized over a set of specified qubits. For example, given the count
     dictionary :code:`{"010": 1, "110": 10, "100": 100}` this node will return the
     count dictionary :code:`{"10": 11, "00": 100}` when marginalized over qubit 2.
+    
+    .. note::
+        This data action can be used to discard one or more qubits in the counts
+        dictionary. This is, for example, useful when processing two-qubit restless
+        experiments but can be used in a more general context. In composite 
+        experiments the counts marginalization is already done in the data container.
     """
 
     def __init__(self, qubits_to_keep: Set[int], validate: bool = True):

--- a/qiskit_experiments/data_processing/nodes.py
+++ b/qiskit_experiments/data_processing/nodes.py
@@ -454,11 +454,11 @@ class MarginalizeCounts(CountsAction):
     is marginalized over a set of specified qubits. For example, given the count
     dictionary :code:`{"010": 1, "110": 10, "100": 100}` this node will return the
     count dictionary :code:`{"10": 11, "00": 100}` when marginalized over qubit 2.
-    
+
     .. note::
         This data action can be used to discard one or more qubits in the counts
         dictionary. This is, for example, useful when processing two-qubit restless
-        experiments but can be used in a more general context. In composite 
+        experiments but can be used in a more general context. In composite
         experiments the counts marginalization is already done in the data container.
     """
 

--- a/qiskit_experiments/library/characterization/fine_amplitude.py
+++ b/qiskit_experiments/library/characterization/fine_amplitude.py
@@ -19,6 +19,7 @@ from qiskit import QuantumCircuit
 from qiskit.circuit import Gate
 from qiskit.circuit.library import XGate, SXGate
 from qiskit.providers.backend import Backend
+from qiskit_experiments.data_processing import DataProcessor, nodes
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
 from qiskit_experiments.library.characterization.analysis import FineAmplitudeAnalysis
@@ -394,3 +395,27 @@ class FineZXAmplitude(FineAmplitude):
         options.basis_gates = ["szx"]
         options.inst_map = None
         return options
+
+    def enable_restless(
+        self, rep_delay: Optional[float] = None, override_processor_by_restless: bool = True
+    ):
+        """Enable restless measurements.
+
+        We wrap the method of the :class:`RestlessMixin` to readout both qubits. This forces
+        the control qubit to be in either the 0 or 1 state before the next circuit starts
+        since restless measurements do not reset qubits.
+        """
+        self.analysis.set_options(outcome="11")
+        super().enable_restless(rep_delay, override_processor_by_restless)
+        self._measurement_qubits = range(self.num_qubits)
+
+    def _get_restless_processor(self) -> DataProcessor:
+        """Marginalize the counts after the restless shot reordering."""
+        return DataProcessor(
+            "memory",
+            [
+                nodes.RestlessToCounts(self._num_qubits),
+                nodes.MarginalizeCounts({1}),  # keep only the target.
+                nodes.Probability("1"),
+            ],
+        )

--- a/releasenotes/notes/fineZXamp-restless-e0dbed212676957f.yaml
+++ b/releasenotes/notes/fineZXamp-restless-e0dbed212676957f.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    A new data processing node to marginalize qubit counts is introduced. This
+    node is, for instance, used in the data processing of a fine ZX amplitude
+    experiment run with restless measurements.
+fixes:
+  - |
+    The FineZXAmplitude now works properly with restless measurements.

--- a/test/data_processing/test_nodes.py
+++ b/test/data_processing/test_nodes.py
@@ -366,7 +366,7 @@ class TestMarginalize(QiskitExperimentsTestCase):
         processed_data = node(data)
 
         self.assertEqual(processed_data[0], {"10": 11, "00": 100})
-        self.assertEqual(processed_data[0], {"11": 1, "10": 10, "00": 100})
+        self.assertEqual(processed_data[1], {"11": 1, "10": 10, "00": 100})
 
     def test_json(self):
         """Check if the node is serializable."""

--- a/test/data_processing/test_nodes.py
+++ b/test/data_processing/test_nodes.py
@@ -356,15 +356,17 @@ class TestMarginalize(QiskitExperimentsTestCase):
         """Test the counts marginalization."""
         node = MarginalizeCounts(qubits_to_keep={0, 1})
 
-        data = np.array([
-            {"010": 1, "110": 10, "100": 100},
-            {"111": 1, "110": 10, "100": 100},
-        ])
+        data = np.array(
+            [
+                {"010": 1, "110": 10, "100": 100},
+                {"111": 1, "110": 10, "100": 100},
+            ]
+        )
 
         processed_data = node(data)
 
         self.assertEqual(processed_data[0], {"10": 11, "00": 100})
-        self.assertEqual(processed_data[0], {"11": 1,"10": 10, "00": 100})
+        self.assertEqual(processed_data[0], {"11": 1, "10": 10, "00": 100})
 
     def test_json(self):
         """Check if the node is serializable."""

--- a/test/data_processing/test_nodes.py
+++ b/test/data_processing/test_nodes.py
@@ -24,6 +24,7 @@ from qiskit_experiments.data_processing.nodes import (
     AverageData,
     MinMaxNormalize,
     Probability,
+    MarginalizeCounts,
     RestlessToCounts,
 )
 from qiskit_experiments.framework.json import ExperimentDecoder, ExperimentEncoder
@@ -346,6 +347,29 @@ class TestSVD(BaseDataProcessorTest):
 
         loaded_node = json.loads(json.dumps(node, cls=ExperimentEncoder), cls=ExperimentDecoder)
         self.assertTrue(loaded_node.is_trained)
+
+
+class TestMarginalize(QiskitExperimentsTestCase):
+    """Test the marginalization node."""
+
+    def test_marginalize(self):
+        """Test the counts marginalization."""
+        node = MarginalizeCounts(qubits_to_keep={0, 1})
+
+        data = np.array([
+            {"010": 1, "110": 10, "100": 100},
+            {"111": 1, "110": 10, "100": 100},
+        ])
+
+        processed_data = node(data)
+
+        self.assertEqual(processed_data[0], {"10": 11, "00": 100})
+        self.assertEqual(processed_data[0], {"11": 1,"10": 10, "00": 100})
+
+    def test_json(self):
+        """Check if the node is serializable."""
+        node = MarginalizeCounts(qubits_to_keep={0, 1})
+        self.assertRoundTripSerializable(node, check_func=self.json_equiv)
 
 
 class TestProbability(QiskitExperimentsTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `FineZXAmplitude` experiment with restless measurements needs extra care when compared to the single-qubit equivalent.

### Details and comments

This PR 
* redefines the restless data processor for `FineZXAmplitude`.
* adds a counts marginalization node.

#### Restless FineZXAmplitude without this PR

![image](https://user-images.githubusercontent.com/38065505/159725066-27b9cd39-f87f-48d4-8deb-ae9ac33509f2.png)

#### Restless FineZXAmplitude with this PR

![image](https://user-images.githubusercontent.com/38065505/159726145-c6b8bc31-b6b9-48c3-9512-919b250502f6.png)
