### PR TITLE
Fix tomography analysis for asymmetric QPT

### DIFF
--- a/qiskit_experiments/library/tomography/qpt_experiment.py
+++ b/qiskit_experiments/library/tomography/qpt_experiment.py
@@ -17,7 +17,7 @@ from typing import Union, Optional, Iterable, List, Tuple, Sequence
 import numpy as np
 from qiskit.circuit import QuantumCircuit, Instruction
 from qiskit.quantum_info.operators.base_operator import BaseOperator
-from qiskit.quantum_info import Choi, Operator, Statevector, partial_trace
+from qiskit.quantum_info import Choi, Operator, Statevector, DensityMatrix, partial_trace
 from qiskit_experiments.exceptions import QiskitError
 from .tomography_experiment import TomographyExperiment
 from .qpt_analysis import ProcessTomographyAnalysis
@@ -104,37 +104,44 @@ class ProcessTomography(TomographyExperiment):
         circuit_ops = self._circuit.count_ops()
         if "measure" in circuit_ops:
             return None
-        perm_circ = self._permute_circuit()
+
         try:
+            circuit = self._permute_circuit()
             if "reset" in circuit_ops or "kraus" in circuit_ops or "superop" in circuit_ops:
-                channel = Choi(perm_circ)
+                channel = Choi(circuit)
             else:
-                channel = Operator(perm_circ)
+                channel = Operator(circuit)
         except QiskitError:
             # Circuit couldn't be simulated
             return None
 
         total_qubits = self._circuit.num_qubits
-        if self._meas_qubits:
-            num_meas = len(self._meas_qubits)
-        else:
-            num_meas = total_qubits
-        if self._prep_qubits:
-            num_prep = len(self._prep_qubits)
-        else:
-            num_prep = total_qubits
+        num_meas = total_qubits if self._meas_qubits is None else len(self._meas_qubits)
+        num_prep = total_qubits if self._prep_qubits is None else len(self._prep_qubits)
 
-        if num_prep == total_qubits and num_meas == total_qubits:
+        # If all qubits are prepared or measurement we are done
+        if num_meas == total_qubits and num_prep == total_qubits:
             return channel
 
-        # Trace out non-measurement subsystems
-        tr_qargs = []
-        if self._prep_qubits:
-            tr_qargs += list(range(num_prep, total_qubits))
-        if self._meas_qubits:
-            tr_qargs += list(range(total_qubits + num_meas, 2 * total_qubits))
+        # Convert channel to a state to project and trace out non-tomography
+        # input and output qubits
+        if isinstance(channel, Operator):
+            chan_state = Statevector(np.ravel(channel, order="F"))
+        else:
+            chan_state = DensityMatrix(channel.data)
 
-        chan_state = Statevector(np.ravel(channel, order="F"))
-        chan_state = partial_trace(chan_state, tr_qargs) / 2 ** (total_qubits - num_meas)
+        # Get qargs for non measured and prepared subsystems
+        non_meas_qargs = list(range(num_meas, total_qubits))
+        non_prep_qargs = list(range(total_qubits + num_prep, 2 * total_qubits))
+
+        # Project non-prepared subsystems on to the zero state
+        if non_prep_qargs:
+            proj0 = Operator([[1, 0], [0, 0]])
+            for qarg in non_prep_qargs:
+                chan_state = chan_state.evolve(proj0, [qarg])
+
+        # Trace out indices to remove
+        tr_qargs = non_meas_qargs + non_prep_qargs
+        chan_state = partial_trace(chan_state, tr_qargs)
         channel = Choi(chan_state.data, input_dims=[2] * num_prep, output_dims=[2] * num_meas)
         return channel

--- a/qiskit_experiments/library/tomography/tomography_analysis.py
+++ b/qiskit_experiments/library/tomography/tomography_analysis.py
@@ -114,7 +114,7 @@ class TomographyAnalysis(BaseAnalysis):
 
         # Check for both preparation and measurement data to determine if we are
         # fitting a channel via QPT or a density matrix via QST
-        qpt = preparation_data.shape[0] and measurement_data.shape[0]
+        qpt = preparation_data.shape[0]
 
         # Compute the preparation dimension if we are performing QPT
         if qpt:
@@ -335,7 +335,7 @@ class TomographyAnalysis(BaseAnalysis):
             fit: the fitted state matrix.
 
         Returns:
-            A pair of eigenvectors, eigenvalues.
+            A pair of (eigenvalues, eigenvectors).
         """
         evals, evecs = la.eigh(fit)
         # Truncate eigenvalues to real part

--- a/qiskit_experiments/library/tomography/tomography_analysis.py
+++ b/qiskit_experiments/library/tomography/tomography_analysis.py
@@ -14,7 +14,7 @@ Quantum process tomography analysis
 """
 
 
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Union, Optional, Callable
 import time
 import numpy as np
 import scipy.linalg as la
@@ -92,7 +92,7 @@ class TomographyAnalysis(BaseAnalysis):
         return options
 
     @classmethod
-    def _get_fitter(cls, fitter):
+    def _get_fitter(cls, fitter: Union[str, Callable]) -> Callable:
         """Return fitter function for named builtin fitters"""
         if fitter is None:
             raise AnalysisError("No tomography fitter given")
@@ -112,6 +112,20 @@ class TomographyAnalysis(BaseAnalysis):
         fitter = self._get_fitter(self.options.fitter)
         fitter_opts = self.options.fitter_options
 
+        # Check for both preparation and measurement data to determine if we are
+        # fitting a channel via QPT or a density matrix via QST
+        qpt = preparation_data.shape[0] and measurement_data.shape[0]
+
+        # Compute the preparation dimension if we are performing QPT
+        if qpt:
+            preparation_dim = 2 ** preparation_data.shape[1]
+        else:
+            preparation_dim = 1
+
+        # Use preparation dim to set the expected trace of the fitted state.
+        # For QPT this is the input dimension, for QST this will always be 1.
+        trace = preparation_dim if self.options.rescale_trace else None
+
         # Work around to set proper trace and trace preserving constraints for
         # cvxpy fitter
         if fitter in (cvxpy_linear_lstsq, cvxpy_gaussian_lstsq):
@@ -119,18 +133,16 @@ class TomographyAnalysis(BaseAnalysis):
 
             # Add default value for CVXPY trace constraint if no user value is provided
             if "trace" not in fitter_opts:
-                if self.options.preparation_basis:
-                    fitter_opts["trace"] = 2 ** len(preparation_data[0])
-                else:
-                    fitter_opts["trace"] = 1
+                fitter_opts["trace"] = trace
 
             # By default add trace preserving constraint to cvxpy QPT fit
-            if "trace_preserving" not in fitter_opts and self.options.preparation_basis:
+            if qpt and "trace_preserving" not in fitter_opts:
                 fitter_opts["trace_preserving"] = True
 
+        # Run tomography fitter
+        t_fitter_start = time.time()
         try:
-            t_fitter_start = time.time()
-            state, fitter_metadata = fitter(
+            fit, fitter_metadata = fitter(
                 outcome_data,
                 shot_data,
                 measurement_data,
@@ -139,72 +151,47 @@ class TomographyAnalysis(BaseAnalysis):
                 preparation_basis=self.options.preparation_basis,
                 **self.options.fitter_options,
             )
-            t_fitter_stop = time.time()
-            if fitter_metadata is None:
-                fitter_metadata = {}
-            state = Choi(state) if self.options.preparation_basis else DensityMatrix(state)
-
-            fitter_metadata["fitter"] = fitter.__name__
-            fitter_metadata["fitter_time"] = t_fitter_stop - t_fitter_start
-
-            analysis_results = self._postprocess_fit(
-                state,
-                metadata=fitter_metadata,
-                target_state=self.options.target,
-                rescale_positive=self.options.rescale_positive,
-                rescale_trace=self.options.rescale_trace,
-                qpt=bool(self.options.preparation_basis),
-            )
-
         except AnalysisError as ex:
             raise AnalysisError(f"Tomography fitter failed with error: {str(ex)}") from ex
+        t_fitter_stop = time.time()
 
+        # Add fitter metadata
+        if fitter_metadata is None:
+            fitter_metadata = {}
+        fitter_metadata["fitter"] = fitter.__name__
+        fitter_metadata["fitter_time"] = t_fitter_stop - t_fitter_start
+
+        # Post process fit
+        analysis_results = self._postprocess_fit(
+            fit,
+            fitter_metadata=fitter_metadata,
+            trace=trace,
+            make_positive=self.options.rescale_positive,
+            preparation_dim=preparation_dim,
+            target_state=self.options.target,
+        )
         return analysis_results, []
 
     @classmethod
     def _postprocess_fit(
         cls,
-        state,
-        metadata=None,
-        target_state=None,
-        rescale_positive=False,
-        rescale_trace=False,
-        qpt=False,
+        fit: np.ndarray,
+        fitter_metadata: Optional[Dict] = None,
+        trace: Optional[float] = None,
+        make_positive: bool = False,
+        preparation_dim: int = 1,
+        target_state: Optional[Union[Choi, DensityMatrix]] = None,
     ):
-        """Post-process fitter data"""
-        # Get eigensystem of state
-        state_cls = type(state)
-        evals, evecs = cls._state_eigensystem(state)
+        """Post-process raw fitter data"""
+        # Convert fitter matrix to state data for post-processing
+        qpt = preparation_dim > 1
+        state_result = cls._state_result(
+            fit, make_positive=make_positive, trace=trace, preparation_dim=preparation_dim
+        )
 
-        # Rescale eigenvalues to be PSD
-        rescaled_psd = False
-        if rescale_positive and np.any(evals < 0):
-            scaled_evals = cls._make_positive(evals)
-            rescaled_psd = True
-        else:
-            scaled_evals = evals
-
-        # Rescale trace
-        trace = np.sqrt(len(scaled_evals)) if qpt else 1
-        sum_evals = np.sum(scaled_evals)
-        rescaled_trace = False
-        if rescale_trace and not np.isclose(sum_evals - trace, 0, atol=1e-12):
-            scaled_evals = trace * scaled_evals / sum_evals
-            rescaled_trace = True
-
-        # Compute state with rescaled eigenvalues
-        state_result = AnalysisResultData("state", state, extra=metadata)
-        state_result.extra["eigvals"] = scaled_evals
-        if rescaled_psd or rescaled_trace:
-            state = state_cls(evecs @ (scaled_evals * evecs).T.conj())
-            state_result.value = state
-            state_result.extra["raw_eigvals"] = evals
-
-        if rescaled_trace:
-            state_result.extra["trace"] = np.sum(scaled_evals)
-            state_result.extra["raw_trace"] = sum_evals
-        else:
-            state_result.extra["trace"] = sum_evals
+        # Add fitter metadata
+        if fitter_metadata:
+            state_result.extra["fitter_metadata"] = fitter_metadata
 
         # Results list
         analysis_results = [state_result]
@@ -212,21 +199,145 @@ class TomographyAnalysis(BaseAnalysis):
         # Compute fidelity with target
         if target_state is not None:
             analysis_results.append(
-                cls._fidelity_result(scaled_evals, evecs, target_state, qpt=qpt)
+                cls._fidelity_result(state_result, target_state, preparation_dim=preparation_dim)
             )
 
         # Check positive
-        analysis_results.append(cls._positivity_result(scaled_evals, qpt=qpt))
+        analysis_results.append(cls._positivity_result(state_result, qpt=qpt))
 
         # Check trace preserving
         if qpt:
-            analysis_results.append(cls._tp_result(scaled_evals, evecs))
+            analysis_results.append(cls._tp_result(state_result, preparation_dim=preparation_dim))
+
+        # Finally format state result metadata to remove eigenvectors
+        # which are no longer needed to reduce size
+        state_result.extra.pop("eigvecs")
 
         return analysis_results
 
+    @classmethod
+    def _state_result(
+        cls,
+        fit: np.ndarray,
+        make_positive: bool = False,
+        trace: Optional[float] = None,
+        preparation_dim: int = 1,
+    ) -> AnalysisResultData:
+        """Convert fit data to state result data"""
+        # Get eigensystem of state fit
+        raw_eigvals, eigvecs = cls._state_eigensystem(fit)
+
+        # Optionally rescale eigenvalues to be non-negative
+        if make_positive and np.any(raw_eigvals < 0):
+            eigvals = cls._make_positive(raw_eigvals)
+            fit = eigvecs @ (eigvals * eigvecs).T.conj()
+            rescaled_psd = True
+        else:
+            eigvals = raw_eigvals
+            rescaled_psd = False
+
+        # Optionally rescale fit trace
+        fit_trace = np.sum(eigvals)
+        if trace is not None and not np.isclose(fit_trace - trace, 0, atol=1e-12):
+            scale = trace / fit_trace
+            fit = fit * scale
+            eigvals = eigvals * scale
+        else:
+            trace = fit_trace
+
+        # Convert class of value
+        if preparation_dim > 1:
+            value = Choi(fit, input_dims=preparation_dim)
+        else:
+            value = DensityMatrix(fit)
+
+        # Construct state result extra metadata
+        extra = {
+            "trace": trace,
+            "eigvals": eigvals,
+            "raw_eigvals": raw_eigvals,
+            "rescaled_psd": rescaled_psd,
+            "eigvecs": eigvecs,
+        }
+        return AnalysisResultData("state", value, extra=extra)
+
     @staticmethod
-    def _state_eigensystem(state):
-        evals, evecs = la.eigh(state)
+    def _positivity_result(
+        state_result: AnalysisResultData, qpt: bool = False
+    ) -> AnalysisResultData:
+        """Check if eigenvalues are positive"""
+        evals = state_result.extra["eigvals"]
+        cond = np.sum(np.abs(evals[evals < 0]))
+        is_pos = bool(np.isclose(cond, 0))
+        name = "completely_positive" if qpt else "positive"
+        result = AnalysisResultData(name, is_pos)
+        if not is_pos:
+            result.extra = {"delta": cond}
+        return result
+
+    @staticmethod
+    def _tp_result(
+        state_result: AnalysisResultData, preparation_dim: int = 1
+    ) -> AnalysisResultData:
+        """Check if QPT channel is trace preserving"""
+        evals = state_result.extra["eigvals"]
+        evecs = state_result.extra["eigvecs"]
+        size = len(evals)
+        measurement_dim = size // preparation_dim
+        mats = np.reshape(evecs.T, (size, measurement_dim, preparation_dim), order="F")
+        kraus_cond = np.einsum("i,ija,ijb->ab", evals, mats.conj(), mats)
+        cond = np.sum(np.abs(la.eigvalsh(kraus_cond - np.eye(preparation_dim))))
+        is_tp = bool(np.isclose(cond, 0))
+        result = AnalysisResultData("trace_preserving", is_tp)
+        if not is_tp:
+            result.extra = {"delta": cond}
+        return result
+
+    @staticmethod
+    def _fidelity_result(
+        state_result: AnalysisResultData,
+        target: Union[Choi, DensityMatrix],
+        preparation_dim: int = 1,
+    ):
+        """Faster computation of fidelity from eigen decomposition"""
+        evals = state_result.extra["eigvals"]
+        evecs = state_result.extra["eigvecs"]
+
+        # Format target to statevector or densitymatrix array
+        name = "process_fidelity" if preparation_dim > 1 else "state_fidelity"
+        if target is None:
+            raise AnalysisError("No target state provided")
+        if isinstance(target, QuantumChannel):
+            target_state = Choi(target).data / preparation_dim
+        elif isinstance(target, BaseOperator):
+            target_state = np.ravel(Operator(target), order="F") / np.sqrt(preparation_dim)
+        else:
+            # Statevector or density matrix
+            target_state = np.array(target)
+
+        if target_state.ndim == 1:
+            rho = evecs @ (evals / preparation_dim * evecs).T.conj()
+            fidelity = np.real(target_state.conj() @ rho @ target_state)
+        else:
+            sqrt_rho = evecs @ (np.sqrt(evals / preparation_dim) * evecs).T.conj()
+            eig = la.eigvalsh(sqrt_rho @ target_state @ sqrt_rho)
+            fidelity = np.sum(np.sqrt(np.maximum(eig, 0))) ** 2
+        return AnalysisResultData(name, fidelity)
+
+    @staticmethod
+    def _state_eigensystem(fit: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """Compute the eigensystem of the fitted state.
+
+        The eigenvalues are returned as a real array ordered from
+        smallest to largest eigenvalues.
+
+        Args:
+            fit: the fitted state matrix.
+
+        Returns:
+            A pair of eigenvectors, eigenvalues.
+        """
+        evals, evecs = la.eigh(fit)
         # Truncate eigenvalues to real part
         evals = np.real(evals)
         # Sort eigensystem from largest to smallest eigenvalues
@@ -234,7 +345,13 @@ class TomographyAnalysis(BaseAnalysis):
         return evals[sort_inds], evecs[:, sort_inds]
 
     @staticmethod
-    def _make_positive(evals, epsilon=0):
+    def _make_positive(evals: np.ndarray, epsilon: float = 0) -> np.ndarray:
+        """Rescale a real vector to be non-negative.
+
+        This truncates any negative values to zero and rescales
+        the remaining eigenvectors such that the sum of the vector
+        is preserved.
+        """
         if epsilon < 0:
             raise AnalysisError("epsilon must be non-negative.")
         ret = evals.copy()
@@ -252,55 +369,6 @@ class TomographyAnalysis(BaseAnalysis):
                     ret[j] = evals[j] + shift
                 break
         return ret
-
-    @staticmethod
-    def _positivity_result(evals, qpt=False):
-        """Check if eigenvalues are positive"""
-        cond = np.sum(np.abs(evals[evals < 0]))
-        is_pos = bool(np.isclose(cond, 0))
-        name = "completely_positive" if qpt else "positive"
-        result = AnalysisResultData(name, is_pos)
-        if not is_pos:
-            result.extra = {"delta": cond}
-        return result
-
-    @staticmethod
-    def _tp_result(evals, evecs):
-        """Check if QPT channel is trace preserving"""
-        size = len(evals)
-        dim = int(np.sqrt(size))
-        mats = np.reshape(evecs.T, (size, dim, dim), order="F")
-        kraus_cond = np.einsum("i,ija,ijb->ab", evals, mats.conj(), mats)
-        cond = np.sum(np.abs(la.eigvalsh(kraus_cond - np.eye(dim))))
-        is_tp = bool(np.isclose(cond, 0))
-        result = AnalysisResultData("trace_preserving", is_tp)
-        if not is_tp:
-            result.extra = {"delta": cond}
-        return result
-
-    @staticmethod
-    def _fidelity_result(evals, evecs, target, qpt=False):
-        """Faster computation of fidelity from eigen decomposition"""
-        # Format target to statevector or densitymatrix array
-        trace = np.sqrt(len(evals)) if qpt else 1
-        name = "process_fidelity" if qpt else "state_fidelity"
-        if target is None:
-            raise AnalysisError("No target state provided")
-        if isinstance(target, QuantumChannel):
-            target_state = Choi(target).data / trace
-        elif isinstance(target, BaseOperator):
-            target_state = np.ravel(Operator(target), order="F") / np.sqrt(trace)
-        else:
-            target_state = np.array(target)
-
-        if target_state.ndim == 1:
-            rho = evecs @ (evals / trace * evecs).T.conj()
-            fidelity = np.real(target_state.conj() @ rho @ target_state)
-        else:
-            sqrt_rho = evecs @ (np.sqrt(evals / trace) * evecs).T.conj()
-            eig = la.eigvalsh(sqrt_rho @ target_state @ sqrt_rho)
-            fidelity = np.sum(np.sqrt(np.maximum(eig, 0))) ** 2
-        return AnalysisResultData(name, fidelity)
 
     @staticmethod
     def _fitter_data(

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -210,8 +210,8 @@ class TomographyExperiment(BaseExperiment):
         """Permute circuit qubits.
 
         This permutes the circuit so that the specified preparation and measurement
-        qubits correspond to input and output qubits [0, ..., N-1] respectively
-        for the returned circuit.
+        qubits correspond to input and output qubits [0, ..., N-1] and [0, ..., M-1]
+        respectively for the returned circuit.
         """
         if self._meas_qubits is None and self._prep_qubits is None:
             return self._circuit

--- a/releasenotes/notes/fix-asymmetric-qpt-3107ef95e8c117c6.yaml
+++ b/releasenotes/notes/fix-asymmetric-qpt-3107ef95e8c117c6.yaml
@@ -1,0 +1,17 @@
+---
+fixes:
+  - |
+    Fixes a bug with the :class:`.ProcessTomography` where the default target
+    channel analysis option was computed incorrectly if not all qubits were
+    prepared and measured, and the preparations and measurements were applied
+    to different subsets of qubits.
+
+    See `Issue 758 <https://github.com/Qiskit/qiskit-experiments/issues/758>`_
+    for details.
+  - |
+    Fixes a bug with the :class:`.ProcessTomographyAnalysis` where analysis
+    would raise an exception if the number of prepared and measurement qubits
+    are not equal.
+
+    See `Issue 757 <https://github.com/Qiskit/qiskit-experiments/issues/757>`_
+    for details.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #757
Fixes #758 

This fixes a bug with process tomography performed on a different number of input and output qubits where the target channel and TP condition was not calculated correctly when the dimensions of the input and output fitted channel are different.

Also cleans up some TomographyAnalysis helper functions for postprocessing fitter data.

### Details and comments

See issues #757, #758 for details.

