### PR TITLE
Fix float serialization

### DIFF
--- a/qiskit_experiments/framework/json.py
+++ b/qiskit_experiments/framework/json.py
@@ -466,8 +466,8 @@ class ExperimentEncoder(json.JSONEncoder):
             # during serialization. Then both can be serialized as Variable.
             # Note that UFloat doesn't have a tag.
             settings = {
-                "value": obj.nominal_value,
-                "std_dev": obj.std_dev,
+                "value": _serialize_safe_float(obj.nominal_value),
+                "std_dev": _serialize_safe_float(obj.std_dev),
                 "tag": getattr(obj, "tag", None),
             }
             cls = uncertainties.core.Variable

--- a/test/database_service/test_db_analysis_result.py
+++ b/test/database_service/test_db_analysis_result.py
@@ -19,6 +19,7 @@ import json
 
 import math
 import numpy as np
+import uncertainties
 
 
 from qiskit_experiments.database_service import DbAnalysisResultV1 as DbAnalysisResult
@@ -135,6 +136,26 @@ class TestDbAnalysisResult(QiskitExperimentsTestCase):
         self.assertEqual(DbAnalysisResult._display_format(math.inf), "Infinity")
         self.assertEqual(DbAnalysisResult._display_format(-math.inf), "-Infinity")
         self.assertEqual(DbAnalysisResult._display_format(math.nan), "NaN")
+        self.assertEqual(
+            DbAnalysisResult._display_format(
+                uncertainties.ufloat(math.nan, math.nan).nominal_value
+            ),
+            "NaN",
+        )
+        self.assertEqual(
+            DbAnalysisResult._display_format(uncertainties.ufloat(math.nan, math.nan).std_dev),
+            "NaN",
+        )
+        self.assertEqual(
+            DbAnalysisResult._display_format(
+                uncertainties.ufloat(math.inf, -math.inf).nominal_value
+            ),
+            "Infinity",
+        )
+        self.assertEqual(
+            DbAnalysisResult._display_format(uncertainties.ufloat(math.inf, -math.inf).std_dev),
+            "-Infinity",
+        )
 
     def test_display_format_complex(self):
         """Test conversion of db displays"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes bug reported by Haggai where uncertainty class floats with NaN values were not being serialized properly.

