### PR TITLE
[WIP] Chained experiment

### DIFF
--- a/qiskit_experiments/framework/composite/chained_experiment.py
+++ b/qiskit_experiments/framework/composite/chained_experiment.py
@@ -64,7 +64,7 @@ class GoodExperimentTransition(BaseTransitionCallable):
 
 
 class ChainedExperiment(CompositeExperiment):
-    """An experiment that is made of several experiments that are run one after another.
+    """An experiment made of several sub-experiments ran one after another.
 
     The chained experiment works using analysis callback functions and an index to the experiment
     in the chain of experiments that needs to be run. Each time an experiment is run there are

--- a/qiskit_experiments/framework/composite/chained_experiment.py
+++ b/qiskit_experiments/framework/composite/chained_experiment.py
@@ -1,0 +1,113 @@
+
+from abc import ABC, abstractmethod
+from typing import List, Optional, Union
+
+from qiskit.providers import Backend
+from qiskit_experiments.framework.base_experiment import BaseExperiment, ExperimentData, BaseAnalysis
+from qiskit_experiments.framework.composite.composite_experiment import CompositeExperiment
+from qiskit.providers.options import Options
+from qiskit import QuantumCircuit
+
+
+class BaseTransitionCallable(ABC):
+    """A method to determine how to transition between experiments."""
+
+    @abstractmethod
+    def __call__(
+        self,
+        experiment_data: ExperimentData,
+        **kwargs,
+    ) -> int:
+        """The call method determines if the ChainedExperiment can transition to the next experiment.
+
+        Args:
+            current_exp_idx: The index of the experiment that just run.
+            experiment_data: The experiment data. Typically, the children will contain the
+                experiment data of the sub-experiments.
+            args: Additional arguments.
+            kwargs: Additional keyword arguments.
+        """
+
+
+class GoodExperimentTransition(BaseTransitionCallable):
+    """A simple experiment transition callable."""
+
+    def __call__(
+        self,
+        experiment_data: ExperimentData,
+        **kwargs
+    ) -> int:
+        """A simple experiment transition callback based on the quality of the result."""
+
+        if experiment_data.child_data(-1).analysis_results(0).quality == "good":
+            return 1
+        else:
+            return 0
+
+
+class ChainedExperiment(CompositeExperiment):
+    """An experiment that is made of several experiments that are run one after another."""
+
+    def __init__(self, experiments: List[BaseExperiment], transition_callback: BaseTransitionCallable):
+        """
+
+        Args:
+            experiments: The list of experiments to run.
+            transition_callback: The method that determines which experiment to run next.
+        """
+        qubits = tuple()  # TODO
+        super().__init__(experiments, qubits)
+
+        self._current_index = 0
+        self._transition_callback = transition_callback
+        self._transition_options = self._default_transition_options()
+
+    def current_index(self) -> int:
+        """Returns the index of the experiment that is currently being run in the chain."""
+        return self._current_index
+
+    @classmethod
+    def _default_transition_options(cls) -> Options:
+        """Default options to control how transitions between experiments occur."""
+        return Options()
+
+    @property
+    def transition_options(self) -> Options:
+        """Options that can be given to the transition callback."""
+        return self._transition_options
+
+    def run(
+        self,
+        backend: Optional[Backend] = None,
+        analysis: Optional[Union[BaseAnalysis, None]] = "default",
+        timeout: Optional[float] = None,
+        **run_options,
+    ) -> ExperimentData:
+        """Run the chained experiment by transitioning between the sub-experiments using a counter."""
+        experiment_data = super().run(backend=backend, analysis=analysis, timeout=timeout, **run_options)
+        return self._run_index(experiment_data)
+
+    def _run_jobs(self, circuits: List[QuantumCircuit], **run_options) -> List[BaseJob]:
+        """Do not run anything yet."""
+        return []
+
+    def _run_index(self, experiment_data):
+        if self._current_index >= self.num_experiments:
+            return experiment_data
+
+        exp_data = self.component_experiment(self._current_index).run()
+        experiment_data.add_child_data(exp_data)
+
+        # transition callback thingy
+        experiment_data.add_analysis_callback(self._transition_callback)
+
+        # recursion
+        experiment_data.add_analysis_callback(self._run_index)
+
+    def _transition_callack(self, experiment_data, **kwargs):
+        """Define how the index is updated."""
+        self._current_index += self.experiment_options.callback(experiment_data, **kwargs)
+
+    def circuits(self) -> List[QuantumCircuit]:
+        """Returns the circuits of the current experiment."""
+        return self.component_experiment(self._current_index).circuits()

--- a/test/test_chained_experiment.py
+++ b/test/test_chained_experiment.py
@@ -12,7 +12,9 @@
 
 """Class to test chained experiments."""
 
+import copy
 from typing import List, Optional, Union
+import numpy as np
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.test.mock import FakeBelem
@@ -28,9 +30,18 @@ from qiskit_experiments.framework.base_experiment import BaseExperiment, Experim
 from qiskit_experiments.framework.base_analysis import BaseAnalysis
 from qiskit_experiments.calibration_management.calibrations import Calibrations
 from qiskit_experiments.calibration_management.basis_gate_library import FixedFrequencyTransmon
-from qiskit_experiments.library.calibration import RoughAmplitudeCal, RoughDragCal
-from qiskit_experiments.test.mock_iq_backend import RabiBackend, DragBackend
+from qiskit_experiments.library.calibration import FineXAmplitudeCal, RoughDragCal
+from qiskit_experiments.test.mock_iq_backend import MockFineAmp, DragBackend
 from qiskit_experiments.exceptions import AnalysisError
+
+
+class FineXAmplitudeCalTest(FineXAmplitudeCal):
+    """A class so that we can access the inst_map that was used."""
+
+    def _transpiled_circuits(self) -> List[QuantumCircuit]:
+        """Wrap the transpile step to save the inst map so we can test it."""
+        self.inst_map = copy.deepcopy(self.calibrations.default_inst_map)
+        return super()._transpiled_circuits()
 
 
 class DefectiveTransitionCallable(BaseTransitionCallable):
@@ -68,24 +79,33 @@ class TestChained(QiskitExperimentsTestCase):
 
         self.cals = Calibrations.from_backend(backend=FakeBelem(), library=FixedFrequencyTransmon())
 
+        self.drag_backend = DragBackend(gate_name="Drag(x)")
+        self.amp_backend = MockFineAmp(0.05 * np.pi, np.pi, "x")
+
     def test_single_experiment(self):
         """Test the chained experiment with a single experiment."""
 
-        rabi = RoughAmplitudeCal(0, self.cals, backend=RabiBackend())
+        drag = RoughDragCal(0, self.cals, backend=self.drag_backend)
 
-        cal_chain = ChainedExperiment([rabi])
+        cal_chain = ChainedExperiment([drag])
+
+        self.assertEqual(len(self.cals.parameters_table(parameters=["β"])["data"]), 2)
 
         exp_data = cal_chain.run()
 
         self.assertEqual(len(exp_data.child_data()), 1)
 
+        self.assertExperimentDone(exp_data)
+        self.assertEqual(len(self.cals.parameters_table(parameters=["β"])["data"]), 3)
+
     def test_watchdog(self):
         """Test that we do not get endless loops on ill-defined transition functions."""
 
-        exp = DummyExperiment((0, ))
+        exp = DummyExperiment((0, ), backend=DragBackend(gate_name="Drag(x)"))
         exp_chain = ChainedExperiment([exp], DefectiveTransitionCallable())
+        exp_chain.analysis = None
 
-        with self.assertRaisesRegex(AnalysisError, msg=""):
+        with self.assertRaisesRegex(AnalysisError, expected_regex=""):
             exp_chain.run()
 
     def test_simple_cal_chain(self):
@@ -93,13 +113,41 @@ class TestChained(QiskitExperimentsTestCase):
 
         The parameters in the Calibrations should be properly updated if the chain is successful.
         """
-        rabi = RoughAmplitudeCal(0, self.cals, backend=RabiBackend())
-        drag = RoughDragCal(0, self.cals, backend=DragBackend())
+        drag = RoughDragCal(0, self.cals, backend=self.drag_backend)
+        fine_amp = FineXAmplitudeCalTest(0, self.cals, backend=self.amp_backend, schedule_name="x")
 
-        cal_chain = ChainedExperiment([rabi, drag])
+        cal_chain = ChainedExperiment([drag, fine_amp])
+
+        # Sanity checks to ensure future checks.
+        old_beta = self.cals.get_parameter_value("β", 0, "x")
+        self.assertAlmostEqual(old_beta, 0.0, places=1)
+        self.assertEqual(len(self.cals.parameters_table(parameters=["β"])["data"]), 2)
+        self.assertEqual(len(self.cals.parameters_table(parameters=["amp"])["data"]), 2)
 
         exp_data = cal_chain.run()
 
+        # We can only start checking the cals once the chain has run.
+        self.assertExperimentDone(exp_data)
+
         self.assertEqual(len(exp_data.child_data()), 2)
 
-        # Run some tests on the cals.
+        # Check the update of the drag experiment.
+        new_beta = self.cals.get_parameter_value("β", 0, "x")
+        self.assertAlmostEqual(new_beta, self.drag_backend.ideal_beta, places=1)
+        self.assertEqual(len(self.cals.parameters_table(parameters=["β"])["data"]), 3)
+
+        # Check that the fine amplitude experiment ran with the updated beta
+        x_sched = fine_amp.inst_map.get("x", qubits=(0, ))
+        self.assertAlmostEqual(x_sched.blocks[0].pulse.beta, new_beta, places=7)
+        self.assertEqual(len(self.cals.parameters_table(parameters=["amp"])["data"]), 3)
+
+        new_amp = self.cals.get_parameter_value("amp", 0, "x")
+        expected_amp = 0.5 * np.pi / (np.pi + exp_data.child_data(1).analysis_results(1).value.n)
+        self.assertAlmostEqual(new_amp, expected_amp, places=7)
+
+        # Check the experiments that were run.
+        for idx, expected in enumerate([RoughDragCal, FineXAmplitudeCalTest]):
+            self.assertEqual(type(exp_data.child_data(idx).experiment), expected)
+
+    def test_transition_callback(self):
+        """Test that we can change the behaviour of the transition callback with options."""

--- a/test/test_chained_experiment.py
+++ b/test/test_chained_experiment.py
@@ -1,0 +1,105 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Class to test chained experiments."""
+
+from typing import List, Optional, Union
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.test.mock import FakeBelem
+from qiskit.providers import Backend
+
+from test.base import QiskitExperimentsTestCase
+
+from qiskit_experiments.framework.composite.chained_experiment import (
+    ChainedExperiment,
+    BaseTransitionCallable,
+)
+from qiskit_experiments.framework.base_experiment import BaseExperiment, ExperimentData
+from qiskit_experiments.framework.base_analysis import BaseAnalysis
+from qiskit_experiments.calibration_management.calibrations import Calibrations
+from qiskit_experiments.calibration_management.basis_gate_library import FixedFrequencyTransmon
+from qiskit_experiments.library.calibration import RoughAmplitudeCal, RoughDragCal
+from qiskit_experiments.test.mock_iq_backend import RabiBackend, DragBackend
+from qiskit_experiments.exceptions import AnalysisError
+
+
+class DefectiveTransitionCallable(BaseTransitionCallable):
+    """A defective callable that does not transition."""
+
+    def __call__(self, *args, **kwargs):
+        """The pointer index is never incremented."""
+        return 0
+
+
+class DummyExperiment(BaseExperiment):
+    """A dummy experiment."""
+
+    def run(
+        self,
+        backend: Optional[Backend] = None,
+        analysis: Optional[Union[BaseAnalysis, None]] = "default",
+        timeout: Optional[float] = None,
+        **run_options,
+    ) -> ExperimentData:
+        """Returns an empty experiment data instance."""
+        return ExperimentData()
+
+    def circuits(self) -> List[QuantumCircuit]:
+        """Return an empty list."""
+        return []
+
+
+class TestChained(QiskitExperimentsTestCase):
+    """Test the chained experiments."""
+
+    def setUp(self):
+        """Setup the test."""
+        super().setUp()
+
+        self.cals = Calibrations.from_backend(backend=FakeBelem(), library=FixedFrequencyTransmon())
+
+    def test_single_experiment(self):
+        """Test the chained experiment with a single experiment."""
+
+        rabi = RoughAmplitudeCal(0, self.cals, backend=RabiBackend())
+
+        cal_chain = ChainedExperiment([rabi])
+
+        exp_data = cal_chain.run()
+
+        self.assertEqual(len(exp_data.child_data()), 1)
+
+    def test_watchdog(self):
+        """Test that we do not get endless loops on ill-defined transition functions."""
+
+        exp = DummyExperiment((0, ))
+        exp_chain = ChainedExperiment([exp], DefectiveTransitionCallable())
+
+        with self.assertRaisesRegex(AnalysisError, msg=""):
+            exp_chain.run()
+
+    def test_simple_cal_chain(self):
+        """Test a simple calibration chain made of a Rabi and Drag.
+
+        The parameters in the Calibrations should be properly updated if the chain is successful.
+        """
+        rabi = RoughAmplitudeCal(0, self.cals, backend=RabiBackend())
+        drag = RoughDragCal(0, self.cals, backend=DragBackend())
+
+        cal_chain = ChainedExperiment([rabi, drag])
+
+        exp_data = cal_chain.run()
+
+        self.assertEqual(len(exp_data.child_data()), 2)
+
+        # Run some tests on the cals.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR introduces a new type of composite experiment that runs a chain of sub-experiments.

### Details and comments

The chained experiment can be initialized as follows
```python
drag = RoughDragCal(0, cals, backend=backend)
fine_amp = FineXAmplitudeCalTest(0, cals, backend=backend, schedule_name="x")

cal_chain = ChainedExperiment([drag, fine_amp])
```
The transition from one experiment to the next is done using a transition callback that changes an index pointing to which experiment should be run.

TODO:
- [ ] Run on hardware.
