### PR TITLE
Rough amplitude calibration fix

### DIFF
--- a/qiskit_experiments/library/calibration/rough_amplitude_cal.py
+++ b/qiskit_experiments/library/calibration/rough_amplitude_cal.py
@@ -173,11 +173,7 @@ class RoughAmplitudeCal(BaseCalibrationExperiment, Rabi):
         result_index = self.experiment_options.result_index
         group = experiment_data.metadata["cal_group"]
 
-        rate = (
-            2
-            * np.pi
-            * BaseUpdater.get_value(experiment_data, self.__outcome__, result_index)
-        )
+        rate = 2 * np.pi * BaseUpdater.get_value(experiment_data, self.__outcome__, result_index)
 
         for angle, param, schedule, prev_amp in experiment_data.metadata["angles_schedules"]:
 

--- a/qiskit_experiments/library/calibration/rough_amplitude_cal.py
+++ b/qiskit_experiments/library/calibration/rough_amplitude_cal.py
@@ -83,9 +83,6 @@ class RoughAmplitudeCal(BaseCalibrationExperiment, Rabi):
             auto_update=auto_update,
         )
 
-        # Needed for subclasses that will drive other transitions than the 0<->1 transition.
-        self._analysis_param_name = self.__outcome__
-
         # Set the pulses to update.
         prev_amp = calibrations.get_parameter_value(cal_parameter_name, qubit, schedule_name)
         self.experiment_options.group = group
@@ -179,7 +176,7 @@ class RoughAmplitudeCal(BaseCalibrationExperiment, Rabi):
         rate = (
             2
             * np.pi
-            * BaseUpdater.get_value(experiment_data, self._analysis_param_name, result_index)
+            * BaseUpdater.get_value(experiment_data, self.__outcome__, result_index)
         )
 
         for angle, param, schedule, prev_amp in experiment_data.metadata["angles_schedules"]:
@@ -262,7 +259,6 @@ class EFRoughXSXAmplitudeCal(RoughAmplitudeCal):
             target_angle=np.pi,
         )
 
-        self._analysis_param_name = self.__outcome__
         self.experiment_options.angles_schedules = [
             AnglesSchedules(
                 target_angle=np.pi,

--- a/qiskit_experiments/library/calibration/rough_amplitude_cal.py
+++ b/qiskit_experiments/library/calibration/rough_amplitude_cal.py
@@ -37,8 +37,6 @@ class RoughAmplitudeCal(BaseCalibrationExperiment, Rabi):
         qiskit_experiments.library.characterization.rabi.Rabi
     """
 
-    __outcome__ = "freq"
-
     def __init__(
         self,
         qubit: int,
@@ -86,7 +84,7 @@ class RoughAmplitudeCal(BaseCalibrationExperiment, Rabi):
         )
 
         # Needed for subclasses that will drive other transitions than the 0<->1 transition.
-        self._analysis_param_name = "rabi_rate"
+        self._analysis_param_name = self.__outcome__
 
         # Set the pulses to update.
         prev_amp = calibrations.get_parameter_value(cal_parameter_name, qubit, schedule_name)
@@ -200,8 +198,6 @@ class RoughXSXAmplitudeCal(RoughAmplitudeCal):
         qiskit_experiments.library.characterization.rabi.Rabi
     """
 
-    __outcome__ = "rabi_rate"
-
     def __init__(
         self,
         qubit: int,
@@ -266,7 +262,7 @@ class EFRoughXSXAmplitudeCal(RoughAmplitudeCal):
             target_angle=np.pi,
         )
 
-        self._analysis_param_name = "rabi_rate_12"
+        self._analysis_param_name = self.__outcome__
         self.experiment_options.angles_schedules = [
             AnglesSchedules(
                 target_angle=np.pi,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes an issue with the rough amplitude calibration experiment where the calibrations were not updated.

### Details and comments

The class variable `__outcome__` in the rough amplitude calibrations determines the `ParameterRepr`, i.e. the name of the result. This result is then used to update the cals. Before this PR there was the variable `self._analysis_param_name` that was set to the same string as `__outcome__`. This variable was (a) unnecessary and (b) pointed to the wrong string. Without this fix we get a
```
qiskit_experiments.database_service.exceptions.DbExperimentEntryNotFound: 'Analysis result rabi_rate not found.'
```
when running `RoughAmplitudeCal`.
