### PR TITLE
Remove legacy backend support

### DIFF
--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -31,7 +31,7 @@ import numpy as np
 
 from matplotlib import pyplot
 from qiskit import QiskitError
-from qiskit.providers import Job, BaseJob, Backend, BaseBackend, Provider
+from qiskit.providers import Job, Backend, Provider
 from qiskit.result import Result
 from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
 from qiskit_experiments.framework.json import ExperimentEncoder, ExperimentDecoder
@@ -163,7 +163,7 @@ class DbExperimentDataV1(DbExperimentData):
     def __init__(
         self,
         experiment_type: Optional[str] = "Unknown",
-        backend: Optional[Union[Backend, BaseBackend]] = None,
+        backend: Optional[Backend] = None,
         service: Optional[DatabaseServiceV1] = None,
         experiment_id: Optional[str] = None,
         parent_id: Optional[str] = None,
@@ -248,7 +248,7 @@ class DbExperimentDataV1(DbExperimentData):
             self._deleted_figures.append(key)
         self._figures = ThreadSafeOrderedDict()
 
-    def _set_service_from_backend(self, backend: Union[Backend, BaseBackend]) -> None:
+    def _set_service_from_backend(self, backend: Backend) -> None:
         """Set the service to be used from the input backend.
 
         Args:
@@ -290,7 +290,7 @@ class DbExperimentDataV1(DbExperimentData):
         jobs = []
         with self._data.lock:
             for datum in data:
-                if isinstance(datum, (Job, BaseJob)):
+                if isinstance(datum, Job):
                     jobs.append(datum)
                 elif isinstance(datum, dict):
                     self._data.append(datum)
@@ -345,7 +345,7 @@ class DbExperimentDataV1(DbExperimentData):
                 "Not all analysis has finished running. Adding new jobs may "
                 "create unexpected analysis results."
             )
-        if isinstance(jobs, (Job, BaseJob)):
+        if isinstance(jobs, Job):
             jobs = [jobs]
 
         # Add futures for extracting finished job data
@@ -414,7 +414,7 @@ class DbExperimentDataV1(DbExperimentData):
 
     def _add_job_data(
         self,
-        job: Union[Job, BaseJob],
+        job: Job,
     ) -> Tuple[str, bool]:
         """Wait for a job to finish and add job result data.
 
@@ -1613,7 +1613,7 @@ class DbExperimentDataV1(DbExperimentData):
         return self._jobs.keys()
 
     @property
-    def backend(self) -> Optional[Union[BaseBackend, Backend]]:
+    def backend(self) -> Optional[Backend]:
         """Return backend.
 
         Returns:

--- a/qiskit_experiments/test/utils.py
+++ b/qiskit_experiments/test/utils.py
@@ -19,14 +19,13 @@ from datetime import datetime, timezone
 from qiskit.providers.job import JobV1 as Job
 from qiskit.providers.jobstatus import JobStatus
 from qiskit.providers.backend import BackendV1 as Backend
-from qiskit.providers import BaseBackend
 from qiskit.result import Result
 
 
 class FakeJob(Job):
     """Fake job."""
 
-    def __init__(self, backend: Union[Backend, BaseBackend], result: Optional[Result] = None):
+    def __init__(self, backend: Backend, result: Optional[Result] = None):
         """Initialize FakeJob."""
         if result:
             job_id = result.job_id

--- a/qiskit_experiments/test/utils.py
+++ b/qiskit_experiments/test/utils.py
@@ -13,7 +13,7 @@
 """Test utility functions."""
 
 import uuid
-from typing import Optional, Union, Dict
+from typing import Optional, Dict
 from datetime import datetime, timezone
 
 from qiskit.providers.job import JobV1 as Job

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ deps =
   git+https://github.com/Qiskit/qiskit-ibmq-provider
   git+https://github.com/jupyter/jupyter-sphinx
   -r{toxinidir}/requirements-dev.txt
-  git+https://github.com/Qiskit/qiskit-terra
 commands = stestr run {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The legacy BaseJob and BaseProvider classes have been removed in the qiskit-terra main branch. This removes legacy support for these classes from experiments.

### Details and comments

Fixes #774 
