### PR TITLE
Calibrations libraries

### DIFF
--- a/docs/tutorials/calibrating_armonk.ipynb
+++ b/docs/tutorials/calibrating_armonk.ipynb
@@ -150,7 +150,7 @@
    "outputs": [],
    "source": [
     "library = FixedFrequencyTransmon(default_values={\"duration\": 320})\n",
-    "cals = Calibrations.from_backend(backend, library)"
+    "cals = Calibrations.from_backend(backend, libraries=[library])"
    ]
   },
   {
@@ -897,19 +897,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 1,
    "id": "317994db",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/daniel/Documents/IBM/qiskit/qiskit-experiments/qiskit_experiments/calibration_management/calibrations.py:1333: UserWarning: Schedules are only saved in text format. They cannot be re-loaded.\n",
-      "  warnings.warn(\"Schedules are only saved in text format. They cannot be re-loaded.\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cals.save(file_type=\"csv\", overwrite=True, file_prefix=\"Armonk\")"
    ]

--- a/docs/tutorials/calibrating_armonk.ipynb
+++ b/docs/tutorials/calibrating_armonk.ipynb
@@ -897,7 +897,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 27,
    "id": "317994db",
    "metadata": {},
    "outputs": [],

--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -123,7 +123,7 @@ class Calibrations:
         if library:
             warnings.warn(
                 "library has been deprecated, please provide libraries instead."
-                "This warning will be removed with backport in Qiskit Experiments 0.4.",
+                'The "library" argument along with this warning will be removed in Qiskit Experiments 0.4.',
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -113,15 +113,16 @@ class Calibrations:
             backend_version: The version of the backend that these calibrations are attached to.
 
         Raises:
-            NotImplementedError: if a list of libraries is given. This will be implemented in
-                the future.
+            CalibrationError: if both library and libraries are given. Note that library will be
+                removed in future versions.
+
         """
         self._backend_name = backend_name
         self._backend_version = backend_version
 
         if library:
             warnings.warn(
-                f"library has been deprecated, please provide libraries instead."
+                "library has been deprecated, please provide libraries instead."
                 "This warning will be removed with backport in Qiskit Experiments 0.4.",
                 DeprecationWarning,
                 stacklevel=2,
@@ -291,7 +292,7 @@ class Calibrations:
     def library(self) -> Optional[List[BasisGateLibrary]]:
         """Return the libraries used to initialize the calibrations."""
         warnings.warn(
-            f"library has been deprecated, use libraries instead."
+            "library has been deprecated, use libraries instead."
             "This warning will be removed with backport in Qiskit Experiments 0.4.",
             DeprecationWarning,
             stacklevel=2,

--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -122,8 +122,9 @@ class Calibrations:
 
         if library:
             warnings.warn(
-                "library has been deprecated, please provide libraries instead."
-                'The "library" argument along with this warning will be removed in Qiskit Experiments 0.4.',
+                "library has been deprecated, please provide `libraries` instead."
+                "The `library` argument along with this warning will be removed "
+                "in Qiskit Experiments 0.4.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -73,22 +73,25 @@ class Calibrations:
         coupling_map: Optional[List[List[int]]] = None,
         control_channel_map: Optional[Dict[Tuple[int, ...], List[ControlChannel]]] = None,
         library: Optional[Union[BasisGateLibrary, List[BasisGateLibrary]]] = None,
+        libraries: Optional[List[BasisGateLibrary]] = None,
         add_parameter_defaults: bool = True,
         backend_name: Optional[str] = None,
         backend_version: Optional[str] = None,
     ):
         """Initialize the calibrations.
 
-        Calibrations can be initialized from a basis gate library, i.e. a subclass of
+        Calibrations can be initialized from a list of basis gate libraries, i.e. a subclass of
         :class:`BasisGateLibrary`. As example consider the following code:
 
         .. code-block:: python
 
             cals = Calibrations(
-                    library=FixedFrequencyTransmon(
-                        basis_gates=["x", "sx"],
-                        default_values={duration: 320}
-                    )
+                    libraries=[
+                        FixedFrequencyTransmon(
+                            basis_gates=["x", "sx"],
+                            default_values={duration: 320}
+                        )
+                    ]
                 )
 
         Args:
@@ -99,10 +102,12 @@ class Calibrations:
                 keys are tuples of qubits and the values are a list of ControlChannels
                 that correspond to the qubits in the keys. If a control_channel_map is given
                 then the qubits must be in the coupling_map.
-            library: A library instance from which to get template schedules to register as well
-                as default parameter values.
+            library (deprecated): A library instance from which to get template schedules to
+                register as well as default parameter values.
+            libraries: A list of library instance from which to get template schedules to register
+                as well as default parameter values.
             add_parameter_defaults: A boolean to indicate weather the default parameter values of
-                the given library should be used to populate the calibrations. By default this
+                the given libraries should be used to populate the calibrations. By default this
                 value is True but can be set to false when deserializing a calibrations object.
             backend_name: The name of the backend that these calibrations are attached to.
             backend_version: The version of the backend that these calibrations are attached to.
@@ -114,11 +119,21 @@ class Calibrations:
         self._backend_name = backend_name
         self._backend_version = backend_version
 
-        if isinstance(library, list):
-            raise NotImplementedError(
-                "Passing a list of libraries from which to instantiate "
-                "will be supported in future releases."
+        if library:
+            warnings.warn(
+                f"library has been deprecated, please provide libraries instead."
+                "This warning will be removed with backport in Qiskit Experiments 0.4.",
+                DeprecationWarning,
+                stacklevel=2,
             )
+
+            if libraries:
+                raise CalibrationError("Cannot supply both library and libraries.")
+
+            if not isinstance(library, list):
+                libraries = [library]
+            else:
+                libraries = library
 
         # Mapping between qubits and their control channels.
         self._control_channel_map = control_channel_map if control_channel_map else {}
@@ -149,18 +164,18 @@ class Calibrations:
         self._hash_to_counter_map = {}
         self._parameter_counter = 0
 
-        self._library = None
-        if library is not None:
-            self._library = library
+        self._libraries = libraries
+        if libraries is not None:
+            for lib in libraries:
 
-            # Add the basis gates
-            for gate in library.basis_gates:
-                self.add_schedule(library[gate], num_qubits=library.num_qubits(gate))
+                # Add the basis gates
+                for gate in lib.basis_gates:
+                    self.add_schedule(lib[gate], num_qubits=lib.num_qubits(gate))
 
-            # Add the default values
-            if add_parameter_defaults:
-                for param_conf in library.default_values():
-                    self.add_parameter_value(*param_conf, update_inst_map=False)
+                # Add the default values
+                if add_parameter_defaults:
+                    for param_conf in lib.default_values():
+                        self.add_parameter_value(*param_conf, update_inst_map=False)
 
         # This internal parameter is False so that if a schedule is added after the
         # init it will be set to True and serialization will raise an error.
@@ -220,6 +235,7 @@ class Calibrations:
         cls,
         backend: Backend,
         library: Optional[BasisGateLibrary] = None,
+        libraries: Optional[List[BasisGateLibrary]] = None,
         add_parameter_defaults: bool = True,
     ) -> "Calibrations":
         """Create an instance of Calibrations from a backend.
@@ -228,8 +244,10 @@ class Calibrations:
             backend: A backend instance from which to extract the qubit and readout frequencies
                 (which will be added as first guesses for the corresponding parameters) as well
                 as the coupling map.
-            library: A library instance from which to get template schedules to register as well
-                as default parameter values.
+            library: A library or list thereof from which to get template schedules to register as
+                well as default parameter values.
+            libraries: A list of libraries from which to get template schedules to register as
+                well as default parameter values.
             add_parameter_defaults: A boolean to indicate whether the default parameter values of
                 the given library should be used to populate the calibrations. By default this
                 value is ``True``.
@@ -246,6 +264,7 @@ class Calibrations:
             getattr(backend.configuration(), "coupling_map", []),
             getattr(backend.configuration(), "control_channels", None),
             library,
+            libraries,
             add_parameter_defaults,
             backend_name,
             getattr(backend, "version", None),
@@ -264,9 +283,20 @@ class Calibrations:
         return cals
 
     @property
-    def library(self) -> Optional[BasisGateLibrary]:
-        """Return the name of the library, e.g. for experiment metadata."""
-        return self._library
+    def libraries(self) -> Optional[List[BasisGateLibrary]]:
+        """Return the libraries used to initialize the calibrations."""
+        return self._libraries
+
+    @property
+    def library(self) -> Optional[List[BasisGateLibrary]]:
+        """Return the libraries used to initialize the calibrations."""
+        warnings.warn(
+            f"library has been deprecated, use libraries instead."
+            "This warning will be removed with backport in Qiskit Experiments 0.4.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._libraries
 
     def _get_operated_qubits(self) -> Dict[int, List[int]]:
         """Get a dict describing qubit couplings.
@@ -1609,7 +1639,7 @@ class Calibrations:
         - The backends have the same name.
         - The backends have the same version.
         - The calibrations contain the same schedules.
-        - The stored paramters have the same values.
+        - The stored parameters have the same values.
         """
         if self.backend_name != other.backend_name:
             return False
@@ -1654,7 +1684,7 @@ class Calibrations:
         kwargs = {
             "coupling_map": self._coupling_map,
             "control_channel_map": ControlChannelMap(self._control_channel_map),
-            "library": self.library,
+            "libraries": self.libraries,
             "add_parameter_defaults": False,  # the parameters will be added outside of the init
             "backend_name": self._backend_name,
             "backend_version": self._backend_version,

--- a/releasenotes/notes/deprecate-cals-library-128909c1379330fe.yaml
+++ b/releasenotes/notes/deprecate-cals-library-128909c1379330fe.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    The library argument to :class:`.Calibrations` has been deprecated in favour
+    of a new argument called libraries.

--- a/test/calibration/experiments/test_drag.py
+++ b/test/calibration/experiments/test_drag.py
@@ -172,7 +172,7 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
         library = FixedFrequencyTransmon()
 
         self.backend = DragBackend(gate_name="Drag(x)")
-        self.cals = Calibrations.from_backend(self.backend, library)
+        self.cals = Calibrations.from_backend(self.backend, libraries=[library])
         self.test_tol = 0.05
 
     def test_update(self):

--- a/test/calibration/experiments/test_fine_amplitude.py
+++ b/test/calibration/experiments/test_fine_amplitude.py
@@ -209,7 +209,7 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         library = FixedFrequencyTransmon()
 
         self.backend = MockFineAmp(-np.pi * 0.07, np.pi, "xp")
-        self.cals = Calibrations.from_backend(self.backend, library)
+        self.cals = Calibrations.from_backend(self.backend, libraries=[library])
 
     def test_cal_options(self):
         """Test that the options are properly propagated."""

--- a/test/calibration/experiments/test_fine_drag.py
+++ b/test/calibration/experiments/test_fine_drag.py
@@ -97,7 +97,7 @@ class TestFineDragCal(QiskitExperimentsTestCase):
         library = FixedFrequencyTransmon()
 
         self.backend = FineDragTestBackend()
-        self.cals = Calibrations.from_backend(self.backend, library)
+        self.cals = Calibrations.from_backend(self.backend, libraries=[library])
 
     def test_experiment_config(self):
         """Test converting to and from config works"""

--- a/test/calibration/experiments/test_fine_frequency.py
+++ b/test/calibration/experiments/test_fine_frequency.py
@@ -44,7 +44,7 @@ class TestFineFreqEndToEnd(QiskitExperimentsTestCase):
 
         self.inst_map.add("sx", 0, sx_sched)
 
-        self.cals = Calibrations.from_backend(FakeArmonk(), FixedFrequencyTransmon())
+        self.cals = Calibrations.from_backend(FakeArmonk(), libraries=[FixedFrequencyTransmon()])
 
     @data(-0.5e6, -0.1e6, 0.1e6, 0.5e6)
     def test_end_to_end(self, freq_shift):

--- a/test/calibration/experiments/test_ramsey_xy.py
+++ b/test/calibration/experiments/test_ramsey_xy.py
@@ -31,7 +31,7 @@ class TestRamseyXY(QiskitExperimentsTestCase):
         super().setUp()
 
         library = FixedFrequencyTransmon()
-        self.cals = Calibrations.from_backend(FakeArmonk(), library)
+        self.cals = Calibrations.from_backend(FakeArmonk(), libraries=[library])
 
     def test_end_to_end(self):
         """Test that we can run on a mock backend and perform a fit.

--- a/test/calibration/experiments/test_rough_amplitude.py
+++ b/test/calibration/experiments/test_rough_amplitude.py
@@ -35,7 +35,7 @@ class TestRoughAmpCal(QiskitExperimentsTestCase):
         library = FixedFrequencyTransmon()
 
         self.backend = FakeArmonk()
-        self.cals = Calibrations.from_backend(self.backend, library)
+        self.cals = Calibrations.from_backend(self.backend, libraries=[library])
 
     def test_circuits(self):
         """Test the quantum circuits."""
@@ -86,7 +86,7 @@ class TestSpecializations(QiskitExperimentsTestCase):
         library = FixedFrequencyTransmon()
 
         self.backend = FakeArmonk()
-        self.cals = Calibrations.from_backend(self.backend, library)
+        self.cals = Calibrations.from_backend(self.backend, libraries=[library])
 
         # Add some pulses on the 1-2 transition.
         d0 = pulse.DriveChannel(0)

--- a/test/calibration/experiments/test_rough_frequency.py
+++ b/test/calibration/experiments/test_rough_frequency.py
@@ -53,7 +53,7 @@ class TestRoughFrequency(QiskitExperimentsTestCase):
         backend.defaults().qubit_freq_est = [freq01, freq01]
 
         library = FixedFrequencyTransmon(basis_gates=["x", "sx"])
-        cals = Calibrations.from_backend(FakeArmonk(), library=library)
+        cals = Calibrations.from_backend(FakeArmonk(), libraries=[library])
 
         prev_freq = cals.get_parameter_value(cals.__drive_freq_parameter__, (0,))
         self.assertEqual(prev_freq, freq01)

--- a/test/calibration/test_calibrations.py
+++ b/test/calibration/test_calibrations.py
@@ -1459,9 +1459,7 @@ class TestInstructionScheduleMap(QiskitExperimentsTestCase):
         cals = Calibrations.from_backend(
             FakeArmonk(),
             libraries=[
-                FixedFrequencyTransmon(
-                    basis_gates=["x", "sx"], default_values={"duration": 320}
-                )
+                FixedFrequencyTransmon(basis_gates=["x", "sx"], default_values={"duration": 320})
             ],
         )
 

--- a/test/calibration/test_calibrations.py
+++ b/test/calibration/test_calibrations.py
@@ -1434,7 +1434,7 @@ class TestSavingAndLoading(CrossResonanceTest):
 
         library = FixedFrequencyTransmon()
         backend = FakeArmonk()
-        cals = Calibrations.from_backend(backend, library)
+        cals = Calibrations.from_backend(backend, libraries=[library])
 
         cals.parameters_table()
 
@@ -1458,9 +1458,11 @@ class TestInstructionScheduleMap(QiskitExperimentsTestCase):
 
         cals = Calibrations.from_backend(
             FakeArmonk(),
-            library=FixedFrequencyTransmon(
-                basis_gates=["x", "sx"], default_values={"duration": 320}
-            ),
+            libraries=[
+                FixedFrequencyTransmon(
+                    basis_gates=["x", "sx"], default_values={"duration": 320}
+                )
+            ],
         )
 
         # Check the x gate
@@ -1482,7 +1484,7 @@ class TestInstructionScheduleMap(QiskitExperimentsTestCase):
 
         cals = Calibrations.from_backend(
             backend,
-            library=FixedFrequencyTransmon(basis_gates=["sx"]),
+            libraries=[FixedFrequencyTransmon(basis_gates=["sx"])],
         )
 
         u_chan = pulse.ControlChannel(Parameter("ch0.1"))
@@ -1508,7 +1510,7 @@ class TestInstructionScheduleMap(QiskitExperimentsTestCase):
 
         cals = Calibrations.from_backend(
             FakeArmonk(),
-            library=FixedFrequencyTransmon(basis_gates=["x"]),
+            libraries=[FixedFrequencyTransmon(basis_gates=["x"])],
         )
 
         param = Parameter("amp")
@@ -1558,7 +1560,7 @@ class TestInstructionScheduleMap(QiskitExperimentsTestCase):
 
         cals = Calibrations.from_backend(
             FakeBelem(),
-            library=FixedFrequencyTransmon(basis_gates=["sx", "x"]),
+            libraries=[FixedFrequencyTransmon(basis_gates=["sx", "x"])],
         )
 
         # Test the schedules before the update.
@@ -1656,9 +1658,9 @@ class TestInstructionScheduleMap(QiskitExperimentsTestCase):
         backend = FakeBelem()
         library = FixedFrequencyTransmon(basis_gates=["sx", "x"])
 
-        cals1 = Calibrations.from_backend(backend, library)
+        cals1 = Calibrations.from_backend(backend, libraries=[library])
         cals2 = Calibrations(
-            library=library,
+            libraries=[library],
             control_channel_map=backend.configuration().control_channels,
             coupling_map=backend.configuration().coupling_map,
         )
@@ -1675,7 +1677,7 @@ class TestSerialization(QiskitExperimentsTestCase):
         backend = FakeBelem()
         library = FixedFrequencyTransmon(basis_gates=["sx", "x"])
 
-        cals = Calibrations.from_backend(backend, library)
+        cals = Calibrations.from_backend(backend, libraries=[library])
         cals.add_parameter_value(0.12345, "amp", 3, "x")
 
         self.assertRoundTripSerializable(cals, self.json_equiv)
@@ -1685,8 +1687,12 @@ class TestSerialization(QiskitExperimentsTestCase):
         backend = FakeBelem()
         library = FixedFrequencyTransmon(basis_gates=["sx", "x"])
 
-        cals1 = Calibrations.from_backend(backend, library, add_parameter_defaults=False)
-        cals2 = Calibrations.from_backend(backend, library, add_parameter_defaults=False)
+        cals1 = Calibrations.from_backend(
+            backend, libraries=[library], add_parameter_defaults=False
+        )
+        cals2 = Calibrations.from_backend(
+            backend, libraries=[library], add_parameter_defaults=False
+        )
         self.assertTrue(cals1 == cals2)
 
         date_time = datetime.now(timezone.utc).astimezone()
@@ -1702,7 +1708,9 @@ class TestSerialization(QiskitExperimentsTestCase):
         self.assertFalse(cals1 == cals2)
 
         # The two objects are different due to missing parameter value
-        cals3 = Calibrations.from_backend(backend, library, add_parameter_defaults=False)
+        cals3 = Calibrations.from_backend(
+            backend, libraries=[library], add_parameter_defaults=False
+        )
         self.assertFalse(cals1 == cals3)
 
         # The two objects are identical due to time stamps
@@ -1711,13 +1719,17 @@ class TestSerialization(QiskitExperimentsTestCase):
 
         # The schedules contained in the cals are different.
         library2 = FixedFrequencyTransmon(basis_gates=["sx", "x", "y"])
-        cals1 = Calibrations.from_backend(backend, library)
-        cals2 = Calibrations.from_backend(backend, library2)
+        cals1 = Calibrations.from_backend(backend, libraries=[library])
+        cals2 = Calibrations.from_backend(backend, libraries=[library2])
         self.assertFalse(cals1 == cals2)
 
         # Ensure that the equality is not sensitive to parameter adding order.
-        cals1 = Calibrations.from_backend(backend, library, add_parameter_defaults=False)
-        cals2 = Calibrations.from_backend(backend, library, add_parameter_defaults=False)
+        cals1 = Calibrations.from_backend(
+            backend, libraries=[library], add_parameter_defaults=False
+        )
+        cals2 = Calibrations.from_backend(
+            backend, libraries=[library], add_parameter_defaults=False
+        )
         param_val1 = ParameterValue(0.54321, date_time=date_time)
         param_val2 = ParameterValue(0.12345, date_time=date_time - timedelta(seconds=1))
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The library argument to the calibrations has been deprecated in favor of the libraries argument.
Ideally, we should get this in for 0.3 to avoid keeping library until release 0.5.

### Details and comments

See code.
