### PR TITLE
Coherence limit error of gates with three or more qubits

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -119,7 +119,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 # op = operation iterator
 # b = basis iterator
 good-names=a,b,i,j,k,d,n,m,ex,v,w,x,y,z,Run,_,logger,q,c,r,qr,cr,qc,nd,pi,op,b,ar,br,p,cp,dt,
-    __unittest,iSwapGate,mu
+    __unittest,iSwapGate,mu,t1,t2
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,toto,tutu,tata

--- a/qiskit_experiments/library/randomized_benchmarking/rb_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_utils.py
@@ -13,13 +13,16 @@
 """
 RB Helper functions
 """
+import functools
+import operator
 from typing import Tuple, Dict, Optional, List, Union, Sequence
 
 import numpy as np
 import uncertainties
+
+import qiskit.quantum_info as qi
 from qiskit import QiskitError, QuantumCircuit
 from qiskit.providers.backend import Backend
-
 from qiskit_experiments.database_service.device_component import Qubit
 from qiskit_experiments.framework import DbAnalysisResultV1, AnalysisResultData
 from qiskit_experiments.warnings import deprecated_function
@@ -138,6 +141,10 @@ class RBUtils:
         return {key: value[0] / value[1] for (key, value) in result.items()}
 
     @staticmethod
+    @deprecated_function(
+        last_version="0.4",
+        msg="Please use coherence_limit_error function that can handle three or more qubits instead.",
+    )
     def coherence_limit(nQ=2, T1_list=None, T2_list=None, gatelen=0.1):
         """
         The error per gate (1-average_gate_fidelity) given by the T1,T2 limit.
@@ -198,6 +205,79 @@ class RBUtils:
             raise ValueError("Not a valid number of qubits")
 
         return coherence_limit_err
+
+    @staticmethod
+    def coherence_limit_error(
+        num_qubits: int, gate_length: float, t1s: Sequence, t2s: Optional[Sequence] = None
+    ):
+        r"""
+        The error per gate (1 - average_gate_fidelity) given by the T1,T2 limit
+        assuming qubit-wise gate-independent amplitude damping error
+        (or thermal relaxation error with no excitation).
+
+        That means, suppose the gate length $t$, the Choi matrix of the amplitude damping channel
+        $\Lambda_q$ for a single qubit $q$ with $T_1$ and $T_2$ is give by
+        $$
+        \begin{bmatrix}
+            1 & 0 & 0 & e^{-\frac{t}{T_2}} \\
+            0 & 0 & 0 & 0 \\
+            0 & 0 & 1-e^{-\frac{t}{T_1}} & 0 \\
+            e^{-\frac{t}{T_2}} & 0 & 0 & e^{-\frac{t}{T_1}} \\
+        \end{bmatrix}
+        $$.
+        The coherence limit error computed by this function is $1 - F_{\text{ave}}(\mathcal{E}, U)$
+        where
+        And the following equality holds.
+        $$
+             \begin{align}
+             1 - F_{\text{ave}}(\mathcal{E}, U)
+                    &= \frac{d}{d+1} \left(1 - F_{\text{pro}}(\mathcal{E}, U)\right) \\
+                    &= \frac{d}{d+1} \left(1 - \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}\right) \\
+                    &= \frac{d}{d+1} \left(1 - \frac{Tr[S_{\Lambda}]}{d^2}\right)
+             \end{align}
+        $$
+        where $F_{\text{avg}}(\mathcal{E}, U)$ and $F_{\text{pro}}(\mathcal{E}, U)$ are
+        the average gate fidelity and the process fidelity of a quantum channel $\mathcal{E}$
+        with a target unitary $U$, respectively, and $d$ is the dimension of Hilbert space of
+        the considering qubit system.
+
+        Args:
+            num_qubits: Number of qubits.
+            gate_length: Duration of the gate in seconds.
+            t1s: List of T1's from qubit 0 to num_qubits-1.
+            t2s: List of T2's (as measured, not Tphi). If not given, assume T2 = 2 * T1.
+                 Each T2 value is truncated down to 2 * T1 if T2 > 2 * T1.
+
+        Returns:
+            float: coherence limited error per gate.
+        Raises:
+            ValueError: if there are invalid inputs
+        """
+        t1s = np.array(t1s)
+        if t2s is None:
+            t2s = 2 * t1s
+        else:
+            t2s = np.array([min(t2, 2 * t1) for t1, t2 in zip(t1s, t2s)])
+
+        if len(t1s) != num_qubits or len(t2s) != num_qubits:
+            raise ValueError("Length of t1s/t2s must equal num_qubits")
+
+        def amplitude_damping_choi(t1, t2, time):
+            return qi.Choi(
+                np.array(
+                    [
+                        [1, 0, 0, np.exp(-time / t2)],
+                        [0, 0, 0, 0],
+                        [0, 0, 1 - np.exp(-time / t1), 0],
+                        [np.exp(-time / t2), 0, 0, np.exp(-time / t1)],
+                    ]
+                )
+            )
+
+        chois = [amplitude_damping_choi(t1, t2, gate_length) for t1, t2 in zip(t1s, t2s)]
+        traces = [np.real(np.trace(np.array(qi.SuperOp(choi)))) for choi in chois]
+        d = 2**num_qubits
+        return d / (d + 1) * (1 - functools.reduce(operator.mul, traces) / (d * d))
 
     @staticmethod
     @deprecated_function(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Extend coherence limit error computation to handle gates with three or more qubits.


### Details and comments
Deprecate the original function `RBUtils.coherence_limit` and reimplement it from scratch as a new function `RBUtils.coherence_limit_error`. Is there a better place to put the new function than under RBUtils?

