### PR TITLE
Set number of Aer threads to 1 for macOS test jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,12 @@ jobs:
         run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests
         run: tox -e py
+        if: runner.os != 'macOS'
+      - name: Install and Run Tests
+        run: tox -e py
+        if: runner.os == 'macOS'
+        env:
+          OMP_NUM_THREADS: 1
 
   lint:
     name: lint

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
   git+https://github.com/Qiskit/qiskit-ibmq-provider
   git+https://github.com/jupyter/jupyter-sphinx
   -r{toxinidir}/requirements-dev.txt
+passenv = OMP_NUM_THREADS QISKIT_PARALLEL RAYON_NUM_THREADS
 commands = stestr run {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In CI on macOS jobs we're seeing occasional job timeouts on the
tomography tests for >= Python 3.8 (which runs serially because
multiprocessing is disabled on macOS by default). These tests spend the
most amount of time in Aer running simulation. One possibility as to
why the jobs are running so much slower is that the small CI nodes are
being overloaded with work by the parallel execution of tests and the
parallel execution of Aer. This commit updates the tox config to pass
through the env variable to set the number of OpenMP threads and then
updates the macOS job configuration to set the number of threads to 1 to
rule this out. While this may not fix the issue it'll be useful in
debugging the cause of the timeouts.

### Details and comments