### PR TITLE
Skip build of rst docs fix

### DIFF
--- a/docs/_ext/jupyter-execute-checkenv.py
+++ b/docs/_ext/jupyter-execute-checkenv.py
@@ -27,6 +27,7 @@ class JupyterCellCheckEnv(JupyterCell):
         [cell] = super().run()
         if os.getenv("QISKIT_DOCS_SKIP_RST", False):
             cell["execute"] = False
+            cell["hide_code"] = False
         return [cell]
 
 


### PR DESCRIPTION
### Summary

Fixes bug where `tox -edocsnorst` terminates with an error when there's a `hide-code` directive in the rst file.
