### PR TITLE
Manually set git branch on release note directive

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,1 +1,2 @@
 .. release-notes:: Release Notes
+    :branch: stable/0.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the recent 0.3.0 release the github actions docs publishing job the
github checkout action seems to be checking out the tag in a roundabout
way which prevents the git history scan that reno does internally from
seeing the full git history. This caused the published docs to only show
the release notes from the tagged release commit instead of the full
history. As a short term workaround until we come up with a pattern that
works (which might just be to manually checkout the tag after the
checkout action) this commit sets the branch to scan explicitly in the
reno sphinx directive so that reno will scan the stable/0.3 branch and
find all the release notes.


### Details and comments