### PR TITLE
Set earliest version in reno config

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -84,3 +84,4 @@ template: |
               needs to be worded so that it does not depend on any information only
               available in another section, such as the prelude. This may mean repeating
               some details.
+earliest_version: 0.1.0


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit sets the earliest_version configuration option for reno [1]
which is used to specify the earliest version to include. In local
testing with how the github actions checkout action works without this
set the reno history scan stops processing requests at the first tag it
encounters but by setting this option it scans the entire history.

### Details and comments

[1] https://docs.openstack.org/reno/latest/user/usage.html#configuring-reno