### PR TITLE
Fix curve analysis multi-canvas plotting

### DIFF
--- a/qiskit_experiments/curve_analysis/curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis.py
@@ -174,10 +174,11 @@ class CurveAnalysis(BaseCurveAnalysis):
         formatted_data = self._format_data(processed_data)
         if self.options.plot:
             for s in self.__series__:
+                sub_data = formatted_data.get_subset_of(s.name)
                 self.drawer.draw_formatted_data(
-                    x_data=formatted_data.x,
-                    y_data=formatted_data.y,
-                    y_err_data=formatted_data.y_err,
+                    x_data=sub_data.x,
+                    y_data=sub_data.y,
+                    y_err_data=sub_data.y_err,
                     name=s.name,
                     ax_index=s.canvas,
                     color=s.plot_color,
@@ -244,13 +245,14 @@ class CurveAnalysis(BaseCurveAnalysis):
                                 alpha=alpha,
                                 color=s.plot_color,
                             )
-                    # Write fitting report
-                    report_description = ""
-                    for res in analysis_results:
-                        if isinstance(res.value, (float, UFloat)):
-                            report_description += f"{analysis_result_to_repr(res)}\n"
-                    report_description += r"Fit $\chi^2$ = " + f"{fit_data.reduced_chisq: .4g}"
-                    self.drawer.draw_fit_report(description=report_description)
+
+                # Write fitting report
+                report_description = ""
+                for res in analysis_results:
+                    if isinstance(res.value, (float, UFloat)):
+                        report_description += f"{analysis_result_to_repr(res)}\n"
+                report_description += r"Fit $\chi^2$ = " + f"{fit_data.reduced_chisq: .4g}"
+                self.drawer.draw_fit_report(description=report_description)
 
         # Add raw data points
         analysis_results.extend(self._create_curve_data(formatted_data, self.__series__))

--- a/releasenotes/notes/fix-multi-series-plot-ac5ff39cabf5d578.yaml
+++ b/releasenotes/notes/fix-multi-series-plot-ac5ff39cabf5d578.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix broken curve analysis output figure when multi canvas mode is enabled.
+    It has been plotting all series data in the same canvas due to the bug.

--- a/releasenotes/notes/fix-multi-series-plot-ac5ff39cabf5d578.yaml
+++ b/releasenotes/notes/fix-multi-series-plot-ac5ff39cabf5d578.yaml
@@ -2,4 +2,5 @@
 fixes:
   - |
     Fix broken curve analysis output figure when multi canvas mode is enabled.
+    Currently this feature is only used by :class:`.CrossResonanceHamiltonianAnalysis`.
     It has been plotting all series data in the same canvas due to the bug.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There was missing data filtering in curve analysis plotting, which results in the broken output figure when multi canvas plotting is enabled. Currently this feature is only used by CR Hamtomo experiment.

Current: data filtering is missing and all series are plotted on every canvas
![image](https://user-images.githubusercontent.com/39517270/167455355-79eb0531-31e7-45ef-9e64-2a6cf5e84854.png)

Fixed:
![image](https://user-images.githubusercontent.com/39517270/167455380-6b2ad163-7253-4c89-951a-096f1749fe47.png)


### Details and comments

This doesn't affect the result of fitting. Just visualization issue.
