### PR TITLE
FigureData wrapper for figures

### DIFF
--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -128,11 +128,15 @@ class AnalysisCallback:
     def __json_encode__(self):
         return self.__getstate__()
 
-class FigureData():
-    def __init__(self, figure, name = None, metadata = None):
+
+class FigureData:
+    """Wrapper for figures and figure metadata"""
+
+    def __init__(self, figure, name=None, metadata=None):
         self.figure = figure
         self.name = name
         self.metadata = metadata if metadata is not None else {}
+
 
 class DbExperimentData:
     """Base common type for all versioned DbExperimentData classes.
@@ -707,10 +711,7 @@ class DbExperimentDataV1(DbExperimentData):
                 with open(figure, "rb") as file:
                     figure = file.read()
 
-            figure_metadata = {
-                'qubits': self.metadata.get("physical_qubits")
-            }
-            print(f"Adding figure {fig_name} with metadata {figure_metadata}")
+            figure_metadata = {"qubits": self.metadata.get("physical_qubits")}
             figure_data = FigureData(figure=figure, name=fig_name, metadata=figure_metadata)
             self._figures[fig_name] = figure_data
 
@@ -792,9 +793,7 @@ class DbExperimentDataV1(DbExperimentData):
 
         figure_data = self._figures.get(figure_key, None)
         if figure_data is None and self.service:
-            figure = self.service.figure(
-                experiment_id=self.experiment_id, figure_name=figure_key
-            )
+            figure = self.service.figure(experiment_id=self.experiment_id, figure_name=figure_key)
             figure_data = FigureData(figure=figure, name=figure_key)
             self._figures[figure_key] = figure_data
 

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -1107,6 +1107,7 @@ class DbExperimentDataV1(DbExperimentData):
                 # currently only the figure and its name are stored in the database
                 if isinstance(figure, FigureData):
                     figure = figure.figure
+                    LOG.warning("Figure metadata is currently not saved to the database")
                 if isinstance(figure, pyplot.Figure):
                     figure = plot_to_svg_bytes(figure)
                 data = {"experiment_id": self.experiment_id, "figure": figure, "figure_name": name}

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -802,7 +802,7 @@ class DbExperimentDataV1(DbExperimentData):
 
         if file_name:
             with open(file_name, "wb") as output:
-                num_bytes = output.write(figure_data)
+                num_bytes = output.write(figure_data.figure)
                 return num_bytes
         if image_only:
             return figure_data.figure

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -159,8 +159,8 @@ class FigureData:
 
     def copy(self, new_name: Optional[str] = None):
         """Creates a deep copy of the figure data"""
-        name = new_name if new_name is not None else self.name
-        return FigureData(figure=self.figure, name=name, metadata=copy.deepcopy(self.metadata))
+        name = new_name or self.name
+        return FigureData(figure=copy.deepcopy(self.figure), name=name, metadata=copy.deepcopy(self.metadata))
 
     def __json_encode__(self) -> Dict[str, Any]:
         """Return the json representation of the figure data"""

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -134,8 +134,14 @@ class FigureData:
 
     def __init__(self, figure, name=None, metadata=None):
         self.figure = figure
-        self.name = name
+        self._name = name
         self.metadata = metadata if metadata is not None else {}
+
+    # name is read only
+    @property
+    def name(self):
+        """The name of the figure"""
+        return self._name
 
 
 class DbExperimentData:
@@ -1056,6 +1062,9 @@ class DbExperimentDataV1(DbExperimentData):
             for name, figure in self._figures.items():
                 if figure is None:
                     continue
+                # currently only the figure and its name are stored in the database
+                if isinstance(figure, FigureData):
+                    figure = figure.figure
                 if isinstance(figure, pyplot.Figure):
                     figure = plot_to_svg_bytes(figure)
                 data = {"experiment_id": self.experiment_id, "figure": figure, "figure_name": name}

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -1088,7 +1088,7 @@ class DbExperimentDataV1(DbExperimentData):
 
         self._save_experiment_metadata()
         if not self._created_in_db:
-            LOG.debug("Could not save experiment metadata to DB, aborting experiment save")
+            LOG.warning("Could not save experiment metadata to DB, aborting experiment save")
             return
 
         for result in self._analysis_results.values():
@@ -1106,7 +1106,7 @@ class DbExperimentDataV1(DbExperimentData):
                 # currently only the figure and its name are stored in the database
                 if isinstance(figure, FigureData):
                     figure = figure.figure
-                    LOG.warning("Figure metadata is currently not saved to the database")
+                    LOG.debug("Figure metadata is currently not saved to the database")
                 if isinstance(figure, pyplot.Figure):
                     figure = plot_to_svg_bytes(figure)
                 data = {"experiment_id": self.experiment_id, "figure": figure, "figure_name": name}

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -711,8 +711,13 @@ class DbExperimentDataV1(DbExperimentData):
                 with open(figure, "rb") as file:
                     figure = file.read()
 
-            figure_metadata = {"qubits": self.metadata.get("physical_qubits")}
-            figure_data = FigureData(figure=figure, name=fig_name, metadata=figure_metadata)
+            # check whether the figure is already wrapped, meaning it came from a sub-experiment
+            if isinstance(figure, FigureData):
+                figure_data = figure
+            else:
+                figure_metadata = {"qubits": self.metadata.get("physical_qubits")}
+                figure_data = FigureData(figure=figure, name=fig_name, metadata=figure_metadata)
+
             self._figures[fig_name] = figure_data
 
             save = save_figure if save_figure is not None else self.auto_save

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -151,17 +151,12 @@ class FigureData:
 
     def __json_encode__(self) -> Dict[str, Any]:
         """Return the json reresentation of the figure data"""
-        return {
-            'figure': self.figure,
-            'name': self.name,
-            'metadata': self.metadata
-        }
+        return {"figure": self.figure, "name": self.name, "metadata": self.metadata}
 
     @classmethod
     def __json_decode__(cls, args: Dict[str, Any]) -> "FigureData":
         """Initialize a figure data from the json representation"""
         return cls(**args)
-
 
 
 class DbExperimentData:
@@ -739,7 +734,7 @@ class DbExperimentDataV1(DbExperimentData):
 
             # check whether the figure is already wrapped, meaning it came from a sub-experiment
             if isinstance(figure, FigureData):
-                figure_data = figure.copy(new_name = fig_name)
+                figure_data = figure.copy(new_name=fig_name)
 
             else:
                 figure_metadata = {"qubits": self.metadata.get("physical_qubits")}

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -837,7 +837,7 @@ class DbExperimentDataV1(DbExperimentData):
 
         Returns:
             The size of the figure if `file_name` is specified.
-            Otherwise the `FigureData`.
+            Otherwise the :class:`.FigureData`.
 
         Raises:
             DbExperimentEntryNotFound: If the figure cannot be found.

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -1088,7 +1088,7 @@ class DbExperimentDataV1(DbExperimentData):
 
         self._save_experiment_metadata()
         if not self._created_in_db:
-            LOG.warning("Could not save experiment metadata to DB, aborting experiment save")
+            LOG.debug("Could not save experiment metadata to DB, aborting experiment save")
             return
 
         for result in self._analysis_results.values():

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -150,7 +150,7 @@ class FigureData:
         return FigureData(figure=self.figure, name=name, metadata=copy.deepcopy(self.metadata))
 
     def __json_encode__(self) -> Dict[str, Any]:
-        """Return the json reresentation of the figure data"""
+        """Return the json representation of the figure data"""
         return {"figure": self.figure, "name": self.name, "metadata": self.metadata}
 
     @classmethod

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -158,7 +158,6 @@ class FigureData:
             raise ValueError("figure metadata must be a dictionary")
         self._metadata = new_metadata
 
-
     def copy(self, new_name: Optional[str] = None):
         """Creates a deep copy of the figure data"""
         name = new_name or self.name

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -159,7 +159,7 @@ class FigureData:
         self._metadata = new_metadata
 
     def copy(self, new_name: Optional[str] = None):
-        """Creates a deep copy of the figure data"""
+        """Creates a copy of the figure data"""
         name = new_name or self.name
         return FigureData(figure=self.figure, name=name, metadata=copy.deepcopy(self.metadata))
 

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -136,13 +136,26 @@ class FigureData:
         """Creates a new figure data object"""
         self.figure = figure
         self._name = name
-        self.metadata = metadata if metadata is not None else {}
+        self.metadata = metadata or {}
 
     # name is read only
     @property
-    def name(self):
+    def name(self) -> str:
         """The name of the figure"""
         return self._name
+
+    @property
+    def metadata(self) -> dict:
+        """The metadata dictionary stored with the figure"""
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, new_metadata: dict):
+        """Set the metadata to new value; must be a dictionary"""
+        if not isinstance(new_metadata, dict):
+            raise ValueError("figure metadata must be a dictionary")
+        self._metadata = new_metadata
+
 
     def copy(self, new_name: Optional[str] = None):
         """Creates a deep copy of the figure data"""

--- a/qiskit_experiments/database_service/db_experiment_data.py
+++ b/qiskit_experiments/database_service/db_experiment_data.py
@@ -133,6 +133,7 @@ class FigureData:
     """Wrapper for figures and figure metadata"""
 
     def __init__(self, figure, name=None, metadata=None):
+        """Creates a new figure data object"""
         self.figure = figure
         self._name = name
         self.metadata = metadata if metadata is not None else {}
@@ -142,6 +143,25 @@ class FigureData:
     def name(self):
         """The name of the figure"""
         return self._name
+
+    def copy(self, new_name: Optional[str] = None):
+        """Creates a deep copy of the figure data"""
+        name = new_name if new_name is not None else self.name
+        return FigureData(figure=self.figure, name=name, metadata=copy.deepcopy(self.metadata))
+
+    def __json_encode__(self) -> Dict[str, Any]:
+        """Return the json reresentation of the figure data"""
+        return {
+            'figure': self.figure,
+            'name': self.name,
+            'metadata': self.metadata
+        }
+
+    @classmethod
+    def __json_decode__(cls, args: Dict[str, Any]) -> "FigureData":
+        """Initialize a figure data from the json representation"""
+        return cls(**args)
+
 
 
 class DbExperimentData:
@@ -719,7 +739,8 @@ class DbExperimentDataV1(DbExperimentData):
 
             # check whether the figure is already wrapped, meaning it came from a sub-experiment
             if isinstance(figure, FigureData):
-                figure_data = figure
+                figure_data = figure.copy(new_name = fig_name)
+
             else:
                 figure_metadata = {"qubits": self.metadata.get("physical_qubits")}
                 figure_data = FigureData(figure=figure, name=fig_name, metadata=figure_metadata)

--- a/qiskit_experiments/framework/__init__.py
+++ b/qiskit_experiments/framework/__init__.py
@@ -216,6 +216,7 @@ Experiment Data Classes
     AnalysisConfig
     ExperimentEncoder
     ExperimentDecoder
+    FigureData
 
 .. _composite-experiment:
 
@@ -253,6 +254,7 @@ from qiskit_experiments.database_service.db_experiment_data import (
     ExperimentStatus,
     JobStatus,
     AnalysisStatus,
+    FigureData,
 )
 from .base_analysis import BaseAnalysis
 from .base_experiment import BaseExperiment

--- a/releasenotes/notes/figure_data-ecf5a82c95844b6a.yaml
+++ b/releasenotes/notes/figure_data-ecf5a82c95844b6a.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Figures added to `ExperimentData` are now wrapped with a `FigureData` class
+    capable of storing metadata (e.g. qubits). This object can be returned using
+    the `figure` method with the additional parameter `image_only=False`.

--- a/releasenotes/notes/figure_data-ecf5a82c95844b6a.yaml
+++ b/releasenotes/notes/figure_data-ecf5a82c95844b6a.yaml
@@ -1,7 +1,7 @@
 ---
 upgrade:
   - |
-    Adds a :class:`.FigureData` class for adding metadata to a analysis result figures. Figures added to
+    Adds a :class:`.FigureData` class for adding metadata to analysis result figures. Figures added to
     `ExperimentData` are now stored using this class. The raw image object (SVG or matplotlib.Figure)
     can be accessed using the :attr:`.FigureData.figure` attribute.
 

--- a/releasenotes/notes/figure_data-ecf5a82c95844b6a.yaml
+++ b/releasenotes/notes/figure_data-ecf5a82c95844b6a.yaml
@@ -2,7 +2,7 @@
 upgrade:
   - |
     Adds a :class:`.FigureData` class for adding metadata to analysis result figures. Figures added to
-    `ExperimentData` are now stored using this class. The raw image object (SVG or matplotlib.Figure)
+    :class:`.ExperimentData` are now stored using this class. The raw image object (SVG or matplotlib.Figure)
     can be accessed using the :attr:`.FigureData.figure` attribute.
 
     Note that currently metadata is only stored locally and will be discarded when saved to the cloud

--- a/releasenotes/notes/figure_data-ecf5a82c95844b6a.yaml
+++ b/releasenotes/notes/figure_data-ecf5a82c95844b6a.yaml
@@ -1,6 +1,9 @@
 ---
-features:
+upgrade:
   - |
-    Figures added to `ExperimentData` are now wrapped with a `FigureData` class
-    capable of storing metadata (e.g. qubits). This object can be returned using
-    the `figure` method with the additional parameter `image_only=False`.
+    Adds a :class:`.FigureData` class for adding metadata to a analysis result figures. Figures added to
+    `ExperimentData` are now stored using this class. The raw image object (SVG or matplotlib.Figure)
+    can be accessed using the :attr:`.FigureData.figure` attribute.
+
+    Note that currently metadata is only stored locally and will be discarded when saved to the cloud
+    experiment service database.

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -270,7 +270,7 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
             with self.subTest(name=name):
                 exp_data = DbExperimentData(backend=self.backend, experiment_type="qiskit_test")
                 fn = exp_data.add_figures(figure, figure_name)
-                self.assertEqual(hello_bytes, exp_data.figure(fn))
+                self.assertEqual(hello_bytes, exp_data.figure(fn).figure)
 
     def test_add_figure_plot(self):
         """Test adding a matplotlib figure."""
@@ -280,7 +280,7 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         service = self._set_mock_service()
         exp_data = DbExperimentData(backend=self.backend, experiment_type="qiskit_test")
         exp_data.add_figures(figure, save_figure=True)
-        self.assertEqual(figure, exp_data.figure(0))
+        self.assertEqual(figure, exp_data.figure(0).figure)
         service.create_figure.assert_called_once()
         _, kwargs = service.create_figure.call_args
         self.assertIsInstance(kwargs["figure"], bytes)
@@ -305,7 +305,7 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
                 exp_data = DbExperimentData(backend=self.backend, experiment_type="qiskit_test")
                 added_names = exp_data.add_figures(figures, figure_names)
                 for idx, added_fn in enumerate(added_names):
-                    self.assertEqual(hello_bytes[idx], exp_data.figure(added_fn))
+                    self.assertEqual(hello_bytes[idx], exp_data.figure(added_fn).figure)
 
     def test_add_figure_overwrite(self):
         """Test updating an existing figure."""
@@ -318,7 +318,7 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
             exp_data.add_figures(friend_bytes, fn)
 
         exp_data.add_figures(friend_bytes, fn, overwrite=True)
-        self.assertEqual(friend_bytes, exp_data.figure(fn))
+        self.assertEqual(friend_bytes, exp_data.figure(fn).figure)
 
     def test_add_figure_save(self):
         """Test saving a figure in the database."""
@@ -386,8 +386,8 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
             )
         idx = randrange(3)
         expected_figure = str.encode(figure_template.format(idx))
-        self.assertEqual(expected_figure, exp_data.figure(name_template.format(idx)))
-        self.assertEqual(expected_figure, exp_data.figure(idx))
+        self.assertEqual(expected_figure, exp_data.figure(name_template.format(idx)).figure)
+        self.assertEqual(expected_figure, exp_data.figure(idx).figure)
 
         file_name = uuid.uuid4().hex
         self.addCleanup(os.remove, file_name)

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -340,8 +340,8 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
             metadata={"physical_qubits": qubits},
         )
         exp_data.add_figures(hello_bytes)
-        exp_data.figure(0, image_only=False).metadata["foo"] = "bar"
-        figure_data = exp_data.figure(0, image_only=False)
+        exp_data.figure(0).metadata["foo"] = "bar"
+        figure_data = exp_data.figure(0)
 
         self.assertEqual(figure_data.metadata["qubits"], qubits)
         self.assertEqual(figure_data.metadata["foo"], "bar")
@@ -354,7 +354,7 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
             metadata={"physical_qubits": [1, 2, 3, 4]},
         )
         exp_data2.add_figures(figure_data, "new_name.svg")
-        figure_data = exp_data2.figure("new_name.svg", image_only=False)
+        figure_data = exp_data2.figure("new_name.svg")
 
         # metadata should not change when adding to new ExperimentData
         self.assertEqual(figure_data.metadata["qubits"], qubits)

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -335,23 +335,31 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         hello_bytes = str.encode("hello world")
         service = self._set_mock_service()
         qubits = [0, 1, 2]
-        exp_data = DbExperimentData(backend=self.backend, experiment_type="qiskit_test", metadata={'physical_qubits': qubits})
+        exp_data = DbExperimentData(
+            backend=self.backend,
+            experiment_type="qiskit_test",
+            metadata={"physical_qubits": qubits},
+        )
         exp_data.add_figures(hello_bytes)
-        exp_data.figure(0, image_only=False).metadata['foo'] = 'bar'
+        exp_data.figure(0, image_only=False).metadata["foo"] = "bar"
         figure_data = exp_data.figure(0, image_only=False)
 
-        self.assertEqual(figure_data.metadata['qubits'], qubits)
-        self.assertEqual(figure_data.metadata['foo'], 'bar')
+        self.assertEqual(figure_data.metadata["qubits"], qubits)
+        self.assertEqual(figure_data.metadata["foo"], "bar")
         expected_name_prefix = "qiskit_test_Fig-0_Exp-"
-        self.assertEqual(figure_data.name[:len(expected_name_prefix)], expected_name_prefix)
+        self.assertEqual(figure_data.name[: len(expected_name_prefix)], expected_name_prefix)
 
-        exp_data2 = DbExperimentData(backend=self.backend, experiment_type="qiskit_test", metadata={'physical_qubits': [1,2,3,4]})
+        exp_data2 = DbExperimentData(
+            backend=self.backend,
+            experiment_type="qiskit_test",
+            metadata={"physical_qubits": [1, 2, 3, 4]},
+        )
         exp_data2.add_figures(figure_data, "new_name.svg")
         figure_data = exp_data2.figure("new_name.svg", image_only=False)
 
         # metadata should not change when adding to new ExperimentData
-        self.assertEqual(figure_data.metadata['qubits'], qubits)
-        self.assertEqual(figure_data.metadata['foo'], 'bar')
+        self.assertEqual(figure_data.metadata["qubits"], qubits)
+        self.assertEqual(figure_data.metadata["foo"], "bar")
         # name should change
         self.assertEqual(figure_data.name, "new_name.svg")
 
@@ -1074,7 +1082,3 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         mock_service = mock.create_autospec(DatabaseServiceV1, instance=True)
         mock_provider.service.return_value = mock_service
         return mock_service
-
-import unittest
-if __name__ == "__main__":
-    unittest.main()

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -362,6 +362,14 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         # name should change
         self.assertEqual(figure_data.name, "new_name.svg")
 
+        # can set the metadata to new dictionary
+        figure_data.metadata = {"bar": "foo"}
+        self.assertEqual(figure_data.metadata['bar'], 'foo')
+
+        # cannot set the metadata to something other than dictionary
+        with self.assertRaises(ValueError):
+            figure_data.metadata = ["foo", "bar"]
+
     def test_add_figure_bad_input(self):
         """Test adding figures with bad input."""
         exp_data = DbExperimentData(backend=self.backend, experiment_type="qiskit_test")

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -333,7 +333,6 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
 
     def test_add_figure_metadata(self):
         hello_bytes = str.encode("hello world")
-        service = self._set_mock_service()
         qubits = [0, 1, 2]
         exp_data = DbExperimentData(
             backend=self.backend,

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -364,7 +364,7 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
 
         # can set the metadata to new dictionary
         figure_data.metadata = {"bar": "foo"}
-        self.assertEqual(figure_data.metadata['bar'], 'foo')
+        self.assertEqual(figure_data.metadata["bar"], "foo")
 
         # cannot set the metadata to something other than dictionary
         with self.assertRaises(ValueError):

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -331,6 +331,30 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         self.assertEqual(kwargs["figure"], hello_bytes)
         self.assertEqual(kwargs["experiment_id"], exp_data.experiment_id)
 
+    def test_add_figure_metadata(self):
+        hello_bytes = str.encode("hello world")
+        service = self._set_mock_service()
+        qubits = [0, 1, 2]
+        exp_data = DbExperimentData(backend=self.backend, experiment_type="qiskit_test", metadata={'physical_qubits': qubits})
+        exp_data.add_figures(hello_bytes)
+        exp_data.figure(0, image_only=False).metadata['foo'] = 'bar'
+        figure_data = exp_data.figure(0, image_only=False)
+
+        self.assertEqual(figure_data.metadata['qubits'], qubits)
+        self.assertEqual(figure_data.metadata['foo'], 'bar')
+        expected_name_prefix = "qiskit_test_Fig-0_Exp-"
+        self.assertEqual(figure_data.name[:len(expected_name_prefix)], expected_name_prefix)
+
+        exp_data2 = DbExperimentData(backend=self.backend, experiment_type="qiskit_test", metadata={'physical_qubits': [1,2,3,4]})
+        exp_data2.add_figures(figure_data, "new_name.svg")
+        figure_data = exp_data2.figure("new_name.svg", image_only=False)
+
+        # metadata should not change when adding to new ExperimentData
+        self.assertEqual(figure_data.metadata['qubits'], qubits)
+        self.assertEqual(figure_data.metadata['foo'], 'bar')
+        # name should change
+        self.assertEqual(figure_data.name, "new_name.svg")
+
     def test_add_figure_bad_input(self):
         """Test adding figures with bad input."""
         exp_data = DbExperimentData(backend=self.backend, experiment_type="qiskit_test")
@@ -1050,3 +1074,7 @@ class TestDbExperimentData(QiskitExperimentsTestCase):
         mock_service = mock.create_autospec(DatabaseServiceV1, instance=True)
         mock_provider.service.return_value = mock_service
         return mock_service
+
+import unittest
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR adds a `FigureData` wrapper around figures added to `ExperimentData` to enable saving additional metadata (e.g. qubits) with the figure. This data is currently not saved in the result database.


### Details and comments


