### PR TITLE
[WIP] Add caching of transpiled circuit generation to BaseExperiment

### DIFF
--- a/qiskit_experiments/framework/composite/batch_experiment.py
+++ b/qiskit_experiments/framework/composite/batch_experiment.py
@@ -19,7 +19,8 @@ from collections import OrderedDict
 from qiskit import QuantumCircuit
 from qiskit.providers.backend import Backend
 
-from .composite_experiment import CompositeExperiment, BaseExperiment
+from qiskit_experiments.framework.base_experiment import BaseExperiment, cached_method
+from .composite_experiment import CompositeExperiment
 from .composite_analysis import CompositeAnalysis
 
 
@@ -81,6 +82,7 @@ class BatchExperiment(CompositeExperiment):
     def circuits(self):
         return self._batch_circuits(to_transpile=False)
 
+    @cached_method
     def _transpiled_circuits(self):
         return self._batch_circuits(to_transpile=True)
 

--- a/qiskit_experiments/library/characterization/tphi.py
+++ b/qiskit_experiments/library/characterization/tphi.py
@@ -16,8 +16,8 @@ Tphi Experiment class.
 from typing import List, Optional, Union
 import numpy as np
 
-from qiskit import QiskitError
 from qiskit.providers import Backend
+from qiskit_experiments.framework import Options
 from qiskit_experiments.framework.composite.batch_experiment import BatchExperiment
 from qiskit_experiments.library.characterization import (
     T1,
@@ -51,6 +51,14 @@ class Tphi(BatchExperiment):
         :doc:`/tutorials/tphi_characterization`
     """
 
+    @classmethod
+    def _default_experiment_options(cls):
+        return Options(
+            delays_t1=None,
+            delays_t2=None,
+            osc_freq=0.0,
+        )
+
     def set_experiment_options(self, **fields):
         """Set the experiment options.
         Args:
@@ -59,16 +67,14 @@ class Tphi(BatchExperiment):
         Raises:
              QiskitError : Error for invalid input option.
         """
+        super().set_experiment_options(**fields)
         # propagate options to the sub-experiments.
-        for key in fields:
-            if key == "delays_t1":
-                self.component_experiment(0).set_experiment_options(delays=fields["delays_t1"])
-            elif key == "delays_t2":
-                self.component_experiment(1).set_experiment_options(delays=fields["delays_t2"])
-            elif key == "osc_freq":
-                self.component_experiment(1).set_experiment_options(osc_freq=fields["osc_freq"])
-            else:
-                raise QiskitError(f"Tphi experiment does not support option {key}")
+        if "delays_t1" in fields:
+            self.component_experiment(0).set_experiment_options(delays=fields["delays_t1"])
+        if "delays_t2" in fields:
+            self.component_experiment(1).set_experiment_options(delays=fields["delays_t2"])
+        if "osc_freq" in fields:
+            self.component_experiment(1).set_experiment_options(osc_freq=fields["osc_freq"])
 
     def __init__(
         self,
@@ -99,4 +105,4 @@ class Tphi(BatchExperiment):
 
         # Create batch experiment
         super().__init__([exp_t1, exp_t2], backend=backend, analysis=analysis)
-        self.set_experiment_options(delays_t1=delays_t1, delays_t2=delays_t2)
+        self.set_experiment_options(delays_t1=delays_t1, delays_t2=delays_t2, osc_freq=osc_freq)

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -25,7 +25,7 @@ from qiskit.circuit import Instruction
 from qiskit.quantum_info import Clifford
 from qiskit.providers.backend import Backend
 
-from qiskit_experiments.framework import BaseExperiment, Options
+from qiskit_experiments.framework.base_experiment import BaseExperiment, Options, cached_method
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
 from .rb_analysis import RBAnalysis
 from .clifford_utils import CliffordUtils
@@ -211,6 +211,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
                 circuits.append(rb_circ)
         return circuits
 
+    @cached_method
     def _transpiled_circuits(self) -> List[QuantumCircuit]:
         """Return a list of experiment circuits, transpiled."""
         transpiled = super()._transpiled_circuits()

--- a/releasenotes/notes/cached-method-87b5d878f585ca92.yaml
+++ b/releasenotes/notes/cached-method-87b5d878f585ca92.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Adds caching of transpiled circuit generation to :class:`.BaseExperiment`
+    so that repeated calls of :class:`~.BaseExperiment.run` will avoid
+    repeated circuit generation and transpilation costs if no experiment options
+    are changed between run calls.
+
+    Changing experiment or transpilation options with the
+    :meth:`~.BaseExperiment.set_experiment_options` or
+    :meth:`~.BaseExperiment.set_transpilation_options` will clear the
+    cached circuits. The cache can also be manually cleared by calling the
+    :meth:`~.BaseExperiment.cache_clear` method.

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -18,6 +18,7 @@ import ddt
 
 from qiskit import QuantumCircuit
 from qiskit_experiments.framework import ExperimentData
+from qiskit_experiments.framework.base_experiment import cached_method
 from qiskit_experiments.test.fake_backend import FakeBackend
 
 
@@ -117,3 +118,37 @@ class TestFramework(QiskitExperimentsTestCase):
         target_opts["figure_names"] = None
 
         self.assertEqual(analysis.options.__dict__, target_opts)
+
+    def test_cached_method(self):
+        """Test cached method decorator"""
+
+        class Experiment(FakeExperiment):
+            """Test experiment"""
+
+            @cached_method
+            def custom_method(self):
+                """Cached method"""
+                return [1, 2, 3]
+
+        exp = Experiment([0])
+        value1 = exp.custom_method()
+        value2 = exp.custom_method()
+        self.assertIn("Experiment.custom_method", exp._cache)
+        self.assertTrue(value1 is value2)
+
+    def test_cached_transpiled_circuits(self):
+        """Test transpiled circuits are cached"""
+        exp = FakeExperiment([0])
+        value1 = exp._transpiled_circuits()
+        value2 = exp._transpiled_circuits()
+        self.assertIn("FakeExperiment._transpiled_circuits", exp._cache)
+        self.assertTrue(value1 is value2)
+
+    def test_cache_clear(self):
+        """Test cache_clear method"""
+        exp = FakeExperiment([0])
+        value1 = exp._transpiled_circuits()
+        exp.cache_clear()
+        self.assertNotIn("FakeExperiment._transpiled_circuits", exp._cache)
+        value2 = exp._transpiled_circuits()
+        self.assertFalse(value1 is value2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This adds caching of transpiled circuit generation to BaseExperiment so repeated calls to `run` will not incur cost of circuit generation and transpilation if no options have changed.

The cache is automatically cleared if experiment options or transpile options are changed, and can be manually cleared by calling the `cache_clear` method.

### Details and comments

Caching is implemented by a `cached_method` decorator which can be applied to BaseExperiment or subclass methods. This store the method return in a object instance `_cache` dict. This differs from built in methods like `lru_cache` in that it caches a single output per instance method regardless of any argument values of that method, and it stores the cached value inside the instance itself. The later point is to allow for potential saving and loading of the cache via pickling or other save/load methods.



