### PR TITLE
[WIP] Rename physical_qubits to device_qubits

### DIFF
--- a/docs/tutorials/quantum_volume.rst
+++ b/docs/tutorials/quantum_volume.rst
@@ -44,7 +44,7 @@ To run the QV experiment we need need to provide the following QV
 parameters, in order to generate the QV circuits and run them on a
 backend and on an ideal simulator:
 
--  ``qubits``: The number of qubits or list of physical qubits for the
+-  ``qubits``: The number of qubits or list of device qubits for the
    experiment.
 
 -  ``trials``: The number of trials to run the quantum volume circuit

--- a/docs/tutorials/randomized_benchmarking.rst
+++ b/docs/tutorials/randomized_benchmarking.rst
@@ -30,7 +30,7 @@ Standard RB experiment
 To run the RB experiment we need to provide the following RB parameters,
 in order to generate the RB circuits and run them on a backend:
 
--  ``qubits``: The number of qubits or list of physical qubits for the
+-  ``qubits``: The number of qubits or list of device qubits for the
    experiment
 
 -  ``lengths``: A list of RB sequences lengths

--- a/qiskit_experiments/calibration_management/base_calibration_experiment.py
+++ b/qiskit_experiments/calibration_management/base_calibration_experiment.py
@@ -251,7 +251,7 @@ class BaseCalibrationExperiment(BaseExperiment, ABC):
             )
 
         transpile_opts["inst_map"] = self.calibrations.default_inst_map
-        transpile_opts["initial_layout"] = list(self.physical_qubits)
+        transpile_opts["initial_layout"] = list(self.device_qubits)
 
         return transpile(self.circuits(), self.backend, **transpile_opts)
 

--- a/qiskit_experiments/calibration_management/base_calibration_experiment.py
+++ b/qiskit_experiments/calibration_management/base_calibration_experiment.py
@@ -21,6 +21,7 @@ import warnings
 from qiskit import QuantumCircuit, transpile
 from qiskit.providers.backend import Backend
 from qiskit.pulse import ScheduleBlock
+from qiskit.utils import deprecate_arguments
 
 from qiskit_experiments.calibration_management.calibrations import Calibrations
 from qiskit_experiments.calibration_management.update_library import BaseUpdater
@@ -175,7 +176,8 @@ class BaseCalibrationExperiment(BaseExperiment, ABC):
                 schedule=self._sched_name,
             )
 
-    def _validate_channels(self, schedule: ScheduleBlock, physical_qubits: List[int]):
+    @deprecate_arguments({"physical_qubits": "device_qubits"})
+    def _validate_channels(self, schedule: ScheduleBlock, device_qubits: List[int]):
         """Check that the device qubits are contained in the schedule.
 
         This is a helper method that experiment developers can call in their implementation
@@ -183,12 +185,12 @@ class BaseCalibrationExperiment(BaseExperiment, ABC):
 
         Args:
             schedule: The schedule for which to check the qubits.
-            physical_qubits: The qubits that should be included in the schedule.
+            device_qubits: The qubits that should be included in the schedule.
 
         Raises:
             CalibrationError: If a device qubit is not contained in the channels schedule.
         """
-        for qubit in physical_qubits:
+        for qubit in device_qubits:
             if qubit not in set(ch.index for ch in schedule.channels):
                 raise CalibrationError(
                     f"Schedule {schedule.name} does not contain a channel "

--- a/qiskit_experiments/calibration_management/base_calibration_experiment.py
+++ b/qiskit_experiments/calibration_management/base_calibration_experiment.py
@@ -176,7 +176,7 @@ class BaseCalibrationExperiment(BaseExperiment, ABC):
             )
 
     def _validate_channels(self, schedule: ScheduleBlock, physical_qubits: List[int]):
-        """Check that the physical qubits are contained in the schedule.
+        """Check that the device qubits are contained in the schedule.
 
         This is a helper method that experiment developers can call in their implementation
         of :meth:`validate_schedules` when checking the schedules.
@@ -186,13 +186,13 @@ class BaseCalibrationExperiment(BaseExperiment, ABC):
             physical_qubits: The qubits that should be included in the schedule.
 
         Raises:
-            CalibrationError: If a physical qubit is not contained in the channels schedule.
+            CalibrationError: If a device qubit is not contained in the channels schedule.
         """
         for qubit in physical_qubits:
             if qubit not in set(ch.index for ch in schedule.channels):
                 raise CalibrationError(
                     f"Schedule {schedule.name} does not contain a channel "
-                    f"for the physical qubit {qubit}."
+                    f"for the device qubit {qubit}."
                 )
 
     def _validate_parameters(self, schedule: ScheduleBlock, n_expected_parameters: int):

--- a/qiskit_experiments/database_service/__init__.py
+++ b/qiskit_experiments/database_service/__init__.py
@@ -34,7 +34,7 @@ experiment data, which consists of the following:
       class only for convenience.
 
     * Experiment metadata. This is a freeform keyword-value dictionary. You can
-      use this to save extra information, such as the physical qubits the experiment
+      use this to save extra information, such as the device qubits the experiment
       operated on, in the database. :meth:`DbExperimentDataV1.set_metadata` and
       :meth:`DbExperimentDataV1.metadata` are methods to set and retrieve metadata,
       respectively.

--- a/qiskit_experiments/framework/__init__.py
+++ b/qiskit_experiments/framework/__init__.py
@@ -145,7 +145,7 @@ To create an experiment subclass
   the experiment payload.
 
 - Call the :meth:`BaseExperiment.__init__` method during the subclass
-  constructor with a list of physical qubits. The length of this list must
+  constructor with a list of device qubits. The length of this list must
   be equal to the number of qubits in each circuit and is used to map these
   circuits to this layout during execution.
   Arguments in the constructor can be overridden so that a subclass can

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -364,7 +364,7 @@ class BaseExperiment(ABC, StoreInitArgs):
 
         .. note::
             These circuits should be on qubits ``[0, .., N-1]`` for an
-            *N*-qubit experiment. The circuits mapped to physical qubits
+            *N*-qubit experiment. The circuits mapped to device qubits
             are obtained via the :meth:`transpiled_circuits` method.
         """
         # NOTE: Subclasses should override this method using the `options`
@@ -449,7 +449,7 @@ class BaseExperiment(ABC, StoreInitArgs):
         if "initial_layout" in fields:
             raise QiskitError(
                 "Initial layout cannot be specified as a transpile option"
-                " as it is determined by the experiment physical qubits."
+                " as it is determined by the experiment device qubits."
             )
         self._transpile_options.update_options(**fields)
         self._set_transpile_options = self._set_transpile_options.union(fields)

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -59,8 +59,8 @@ class BaseExperiment(ABC, StoreInitArgs):
 
         # Circuit parameters
         self._num_qubits = len(device_qubits)
-        self._physical_qubits = tuple(device_qubits)
-        if self._num_qubits != len(set(self._physical_qubits)):
+        self._device_qubits = tuple(device_qubits)
+        if self._num_qubits != len(set(self._device_qubits)):
             raise QiskitError("Duplicate qubits in device_qubits value.")
 
         # Experiment options
@@ -111,7 +111,7 @@ class BaseExperiment(ABC, StoreInitArgs):
     @property
     def device_qubits(self) -> Tuple[int, ...]:
         """Return the device qubits for the experiment."""
-        return self._physical_qubits
+        return self._device_qubits
 
     @property
     def num_qubits(self) -> int:
@@ -377,7 +377,7 @@ class BaseExperiment(ABC, StoreInitArgs):
         This function can be overridden to define custom transpilation.
         """
         transpile_opts = copy.copy(self.transpile_options.__dict__)
-        transpile_opts["initial_layout"] = list(self.physical_qubits)
+        transpile_opts["initial_layout"] = list(self.device_qubits)
         transpiled = transpile(self.circuits(), self.backend, **transpile_opts)
 
         # TODO remove this deprecation after 0.3.0 release
@@ -515,7 +515,7 @@ class BaseExperiment(ABC, StoreInitArgs):
         Subclasses can override this method to add custom experiment
         metadata to the returned experiment result data.
         """
-        metadata = {"physical_qubits": list(self.physical_qubits)}
+        metadata = {"physical_qubits": list(self.device_qubits)}
         return metadata
 
     def __json_encode__(self):

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -24,18 +24,21 @@ from qiskit.providers import Job, Backend
 from qiskit.exceptions import QiskitError
 from qiskit.qobj.utils import MeasLevel
 from qiskit.providers.options import Options
+from qiskit.utils import deprecate_arguments
 from qiskit_experiments.framework.store_init_args import StoreInitArgs
 from qiskit_experiments.framework.base_analysis import BaseAnalysis
 from qiskit_experiments.framework.experiment_data import ExperimentData
 from qiskit_experiments.framework.configs import ExperimentConfig
+from qiskit_experiments.warnings import deprecated_function
 
 
 class BaseExperiment(ABC, StoreInitArgs):
     """Abstract base class for experiments."""
 
+    @deprecate_arguments({"qubits": "device_qubits"})
     def __init__(
         self,
-        qubits: Sequence[int],
+        device_qubits: Optional[Sequence[int]] = None,
         analysis: Optional[BaseAnalysis] = None,
         backend: Optional[Backend] = None,
         experiment_type: Optional[str] = None,
@@ -43,7 +46,7 @@ class BaseExperiment(ABC, StoreInitArgs):
         """Initialize the experiment object.
 
         Args:
-            qubits: list of physical qubits for the experiment.
+            device_qubits: list of device qubits for the experiment.
             analysis: Optional, the analysis to use for the experiment.
             backend: Optional, the backend to run the experiment on.
             experiment_type: Optional, the experiment type string.
@@ -55,10 +58,10 @@ class BaseExperiment(ABC, StoreInitArgs):
         self._type = experiment_type if experiment_type else type(self).__name__
 
         # Circuit parameters
-        self._num_qubits = len(qubits)
-        self._physical_qubits = tuple(qubits)
+        self._num_qubits = len(device_qubits)
+        self._physical_qubits = tuple(device_qubits)
         if self._num_qubits != len(set(self._physical_qubits)):
-            raise QiskitError("Duplicate qubits in physical qubits list.")
+            raise QiskitError("Duplicate qubits in device_qubits value.")
 
         # Experiment options
         self._experiment_options = self._default_experiment_options()
@@ -100,7 +103,13 @@ class BaseExperiment(ABC, StoreInitArgs):
         return self._type
 
     @property
+    @deprecated_function("0.4.0", "It has been renamed to 'device_qubits'")
     def physical_qubits(self) -> Tuple[int, ...]:
+        """Return the device qubits for the experiment."""
+        return self.device_qubits
+
+    @property
+    def device_qubits(self) -> Tuple[int, ...]:
         """Return the device qubits for the experiment."""
         return self._physical_qubits
 

--- a/qiskit_experiments/framework/composite/batch_experiment.py
+++ b/qiskit_experiments/framework/composite/batch_experiment.py
@@ -69,9 +69,9 @@ class BatchExperiment(CompositeExperiment):
         self._qubit_map = OrderedDict()
         logical_qubit = 0
         for expr in experiments:
-            for physical_qubit in expr.device_qubits:
-                if physical_qubit not in self._qubit_map:
-                    self._qubit_map[physical_qubit] = logical_qubit
+            for device_qubit in expr.device_qubits:
+                if device_qubit not in self._qubit_map:
+                    self._qubit_map[device_qubit] = logical_qubit
                     logical_qubit += 1
         qubits = tuple(self._qubit_map.keys())
         super().__init__(

--- a/qiskit_experiments/framework/composite/batch_experiment.py
+++ b/qiskit_experiments/framework/composite/batch_experiment.py
@@ -69,7 +69,7 @@ class BatchExperiment(CompositeExperiment):
         self._qubit_map = OrderedDict()
         logical_qubit = 0
         for expr in experiments:
-            for physical_qubit in expr.physical_qubits:
+            for physical_qubit in expr.device_qubits:
                 if physical_qubit not in self._qubit_map:
                     self._qubit_map[physical_qubit] = logical_qubit
                     logical_qubit += 1
@@ -89,10 +89,10 @@ class BatchExperiment(CompositeExperiment):
 
         # Generate data for combination
         for index, expr in enumerate(self._experiments):
-            if self.physical_qubits == expr.physical_qubits or to_transpile:
+            if self.device_qubits == expr.device_qubits or to_transpile:
                 qubit_mapping = None
             else:
-                qubit_mapping = [self._qubit_map[qubit] for qubit in expr.physical_qubits]
+                qubit_mapping = [self._qubit_map[qubit] for qubit in expr.device_qubits]
 
             if isinstance(expr, BatchExperiment):
                 # Batch experiments don't contain their own native circuits.

--- a/qiskit_experiments/framework/composite/batch_experiment.py
+++ b/qiskit_experiments/framework/composite/batch_experiment.py
@@ -120,7 +120,7 @@ class BatchExperiment(CompositeExperiment):
         return batch_circuits
 
     def _remap_qubits(self, circuit, qubit_mapping):
-        """Remap qubits if physical qubit layout is different to batch layout"""
+        """Remap qubits if device qubit layout is different to batch layout"""
         num_qubits = self.num_qubits
         num_clbits = circuit.num_clbits
         new_circuit = QuantumCircuit(num_qubits, num_clbits, name="batch_" + circuit.name)

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -38,7 +38,7 @@ class CompositeExperiment(BaseExperiment):
 
         Args:
             experiments: a list of experiment objects.
-            qubits: list of physical qubits for the experiment.
+            qubits: list of device qubits for the experiment.
             backend: Optional, the backend to run the experiment on.
             experiment_type: Optional, composite experiment subclass name.
             flatten_results: If True flatten all component experiment results

--- a/qiskit_experiments/framework/composite/parallel_experiment.py
+++ b/qiskit_experiments/framework/composite/parallel_experiment.py
@@ -64,7 +64,7 @@ class ParallelExperiment(CompositeExperiment):
         """
         qubits = []
         for exp in experiments:
-            qubits += exp.physical_qubits
+            qubits += exp.device_qubits
         super().__init__(
             experiments, qubits, backend=backend, analysis=analysis, flatten_results=flatten_results
         )
@@ -92,7 +92,7 @@ class ParallelExperiment(CompositeExperiment):
             sub_qubits.append(qubits)
             # Construct mapping for the sub-experiments logical qubits to physical qubits
             # in the full combined circuits
-            sub_maps.append({q: qubits[i] for i, q in enumerate(sub_exp.physical_qubits)})
+            sub_maps.append({q: qubits[i] for i, q in enumerate(sub_exp.device_qubits)})
             num_qubits += sub_exp.num_qubits
 
         # Generate empty joint circuits

--- a/qiskit_experiments/framework/composite/parallel_experiment.py
+++ b/qiskit_experiments/framework/composite/parallel_experiment.py
@@ -90,7 +90,7 @@ class ParallelExperiment(CompositeExperiment):
             # Sub experiment logical qubits in the combined circuits full qubits
             qubits = list(range(num_qubits, num_qubits + sub_exp.num_qubits))
             sub_qubits.append(qubits)
-            # Construct mapping for the sub-experiments logical qubits to physical qubits
+            # Construct mapping for the sub-experiments logical qubits to device qubits
             # in the full combined circuits
             sub_maps.append({q: qubits[i] for i, q in enumerate(sub_exp.device_qubits)})
             num_qubits += sub_exp.num_qubits
@@ -120,14 +120,14 @@ class ParallelExperiment(CompositeExperiment):
 
                     # Apply transpiled subcircuit
                     # Note that this assumes the circuit was not expanded to use
-                    # any qubits outside the specified physical qubits
+                    # any qubits outside the specified device qubits
                     for inst, qargs, cargs in sub_circ.data:
                         try:
                             mapped_qargs = [
                                 circuit.qubits[qargs_map[sub_circ.find_bit(i).index]] for i in qargs
                             ]
                         except KeyError as ex:
-                            # Instruction is outside physical qubits for the component
+                            # Instruction is outside device qubits for the component
                             # experiment.
                             # This could legitimately happen if the subcircuit was
                             # explicitly scheduled during transpilation which would
@@ -137,7 +137,7 @@ class ParallelExperiment(CompositeExperiment):
                                 continue
                             raise QiskitError(
                                 "Component experiment has been transpiled outside of the "
-                                "allowed physical qubits for that component. Check the "
+                                "allowed device qubits for that component. Check the "
                                 "experiment is valid on the backends coupling map."
                             ) from ex
                         mapped_cargs = [

--- a/qiskit_experiments/framework/restless_mixin.py
+++ b/qiskit_experiments/framework/restless_mixin.py
@@ -134,8 +134,8 @@ class RestlessMixin:
         else:
             raise DataProcessorError(
                 f"The specified repetition delay {rep_delay} is equal to or greater "
-                f"than the T1 time of one of the physical qubits"
-                f"{self._physical_qubits} in the experiment. Consider choosing "
+                f"than the T1 time of one of the device qubits"
+                f"{self.device_qubits} in the experiment. Consider choosing "
                 f"a smaller repetition delay for the restless experiment."
             )
 
@@ -183,8 +183,8 @@ class RestlessMixin:
 
         try:
             t1_values = [
-                self._backend.properties().qubit_property(physical_qubit)["T1"][0]
-                for physical_qubit in self._physical_qubits
+                self._backend.properties().qubit_property(qubit)["T1"][0]
+                for qubit in self.device_qubits
             ]
 
             if all(rep_delay / t1_value < 1.0 for t1_value in t1_values):

--- a/qiskit_experiments/framework/restless_mixin.py
+++ b/qiskit_experiments/framework/restless_mixin.py
@@ -81,7 +81,7 @@ class RestlessMixin:
             DataProcessorError: if the experiment analysis does not have the data_processor
                 option.
             DataProcessorError: if the rep_delay is equal to or greater than the
-                T1 time of one of the physical qubits in the experiment.
+                T1 time of one of the device qubits in the experiment.
         """
         try:
             if not rep_delay:
@@ -167,7 +167,7 @@ class RestlessMixin:
             )
 
     def _t1_check(self, rep_delay: float) -> bool:
-        """Check that repetition delay < T1 of the physical qubits in the experiment.
+        """Check that repetition delay < T1 of the device qubits in the experiment.
 
         Args:
             rep_delay: The repetition delay. This is the delay between a measurement

--- a/qiskit_experiments/framework/restless_mixin.py
+++ b/qiskit_experiments/framework/restless_mixin.py
@@ -55,7 +55,7 @@ class RestlessMixin:
     _default_run_options: Options()
     set_run_options: Callable
     _backend: Backend
-    _physical_qubits: Sequence[int]
+    _device_qubits: Sequence[int]
     _num_qubits: int
 
     def enable_restless(

--- a/qiskit_experiments/library/calibration/fine_amplitude.py
+++ b/qiskit_experiments/library/calibration/fine_amplitude.py
@@ -96,7 +96,7 @@ class FineAmplitudeCal(BaseCalibrationExperiment, FineAmplitude):
 
         param_val = self._cals.get_parameter_value(
             self._param_name,
-            self.physical_qubits,
+            self.device_qubits,
             self._sched_name,
             group=self.experiment_options.group,
         )

--- a/qiskit_experiments/library/calibration/fine_drag_cal.py
+++ b/qiskit_experiments/library/calibration/fine_drag_cal.py
@@ -97,7 +97,7 @@ class FineDragCal(BaseCalibrationExperiment, FineDrag):
 
         param_val = self._cals.get_parameter_value(
             self._param_name,
-            self.physical_qubits,
+            self.device_qubits,
             self._sched_name,
             group=self.experiment_options.group,
         )

--- a/qiskit_experiments/library/calibration/fine_frequency_cal.py
+++ b/qiskit_experiments/library/calibration/fine_frequency_cal.py
@@ -104,7 +104,7 @@ class FineFrequencyCal(BaseCalibrationExperiment, FineFrequency):
 
         param_val = self._cals.get_parameter_value(
             self._param_name,
-            self.physical_qubits,
+            self.device_qubits,
             group=self.experiment_options.group,
         )
 

--- a/qiskit_experiments/library/calibration/frequency_cal.py
+++ b/qiskit_experiments/library/calibration/frequency_cal.py
@@ -67,7 +67,7 @@ class FrequencyCal(BaseCalibrationExperiment, RamseyXY):
 
         param_val = self._cals.get_parameter_value(
             self._param_name,
-            self.physical_qubits,
+            self.device_qubits,
             group=self.experiment_options.group,
         )
 

--- a/qiskit_experiments/library/calibration/half_angle_cal.py
+++ b/qiskit_experiments/library/calibration/half_angle_cal.py
@@ -76,7 +76,7 @@ class HalfAngleCal(BaseCalibrationExperiment, HalfAngle):
 
         param_val = self._cals.get_parameter_value(
             self._param_name,
-            self._physical_qubits,
+            self.device_qubits,
             self._sched_name,
             group=self.experiment_options.group,
         )

--- a/qiskit_experiments/library/calibration/rough_amplitude_cal.py
+++ b/qiskit_experiments/library/calibration/rough_amplitude_cal.py
@@ -133,7 +133,7 @@ class RoughAmplitudeCal(BaseCalibrationExperiment, Rabi):
         for angle, param_name, schedule_name, _ in self.experiment_options.angles_schedules:
             param_val = self._cals.get_parameter_value(
                 param_name,
-                self._physical_qubits,
+                self.device_qubits,
                 schedule_name,
                 group=self.experiment_options.group,
             )

--- a/qiskit_experiments/library/calibration/rough_drag_cal.py
+++ b/qiskit_experiments/library/calibration/rough_drag_cal.py
@@ -88,7 +88,7 @@ class RoughDragCal(BaseCalibrationExperiment, RoughDrag):
         """
 
         prev_beta = self._cals.get_parameter_value(
-            self._param_name, self.physical_qubits, self._sched_name, self.experiment_options.group
+            self._param_name, self.device_qubits, self._sched_name, self.experiment_options.group
         )
 
         experiment_data.metadata["cal_param_value"] = prev_beta

--- a/qiskit_experiments/library/characterization/cr_hamiltonian.py
+++ b/qiskit_experiments/library/characterization/cr_hamiltonian.py
@@ -204,7 +204,7 @@ class CrossResonanceHamiltonian(BaseExperiment):
 
             # Extract control channel index
             try:
-                cr_channels = backend.configuration().control(self.physical_qubits)
+                cr_channels = backend.configuration().control(self.device_qubits)
                 self._cr_channel = cr_channels[0].index
             except AttributeError:
                 warnings.warn(
@@ -279,13 +279,13 @@ class CrossResonanceHamiltonian(BaseExperiment):
                         sigma=opt.sigma,
                         width=flat_top_width,
                     ),
-                    pulse.DriveChannel(self.physical_qubits[1]),
+                    pulse.DriveChannel(self.device_qubits[1]),
                 )
             else:
-                pulse.delay(valid_duration, pulse.DriveChannel(self.physical_qubits[1]))
+                pulse.delay(valid_duration, pulse.DriveChannel(self.device_qubits[1]))
 
             # place holder for empty drive channels. this is necessary due to known pulse gate bug.
-            pulse.delay(valid_duration, pulse.DriveChannel(self.physical_qubits[0]))
+            pulse.delay(valid_duration, pulse.DriveChannel(self.device_qubits[0]))
 
         return cross_resonance
 
@@ -332,7 +332,7 @@ class CrossResonanceHamiltonian(BaseExperiment):
 
                     tomo_circ.metadata = {
                         "experiment_type": self.experiment_type,
-                        "qubits": self.physical_qubits,
+                        "qubits": self.device_qubits,
                         "xval": flat_top_width * self._dt,  # in units of sec
                         "control_state": control_state,
                         "meas_basis": meas_basis,
@@ -341,7 +341,7 @@ class CrossResonanceHamiltonian(BaseExperiment):
                         # Attach calibration if this is bare pulse gate
                         tomo_circ.add_calibration(
                             gate=cr_gate,
-                            qubits=self.physical_qubits,
+                            qubits=self.device_qubits,
                             schedule=cr_schedule,
                         )
 

--- a/qiskit_experiments/library/characterization/drag.py
+++ b/qiskit_experiments/library/characterization/drag.py
@@ -192,7 +192,7 @@ class RoughDrag(BaseExperiment, RestlessMixin):
             circuit.measure_active()
 
             circuit.add_calibration(
-                "Drag(" + schedule.name + ")", self.physical_qubits, schedule, params=[beta]
+                "Drag(" + schedule.name + ")", self.device_qubits, schedule, params=[beta]
             )
 
             for beta_val in self.experiment_options.betas:
@@ -202,7 +202,7 @@ class RoughDrag(BaseExperiment, RestlessMixin):
 
                 assigned_circuit.metadata = {
                     "experiment_type": self._type,
-                    "qubits": self.physical_qubits,
+                    "qubits": self.device_qubits,
                     "xval": beta_val,
                     "series": idx,
                 }

--- a/qiskit_experiments/library/characterization/fine_amplitude.py
+++ b/qiskit_experiments/library/characterization/fine_amplitude.py
@@ -133,7 +133,7 @@ class FineAmplitude(BaseExperiment, RestlessMixin):
         self.set_experiment_options(gate=gate)
 
         if measurement_qubits is not None:
-            self._measurement_qubits = [self.physical_qubits.index(q) for q in measurement_qubits]
+            self._measurement_qubits = [self.device_qubits.index(q) for q in measurement_qubits]
         else:
             self._measurement_qubits = range(self.num_qubits)
 
@@ -163,7 +163,7 @@ class FineAmplitude(BaseExperiment, RestlessMixin):
 
             circ.metadata = {
                 "experiment_type": self._type,
-                "qubits": self.physical_qubits,
+                "qubits": self.device_qubits,
                 "xval": add_x,
                 "unit": "gate number",
                 "series": "spam-cal",
@@ -230,7 +230,7 @@ class FineAmplitude(BaseExperiment, RestlessMixin):
 
             circuit.metadata = {
                 "experiment_type": self._type,
-                "qubits": self.physical_qubits,
+                "qubits": self.device_qubits,
                 "xval": repetition,
                 "unit": "gate number",
                 "series": 1,

--- a/qiskit_experiments/library/characterization/fine_amplitude.py
+++ b/qiskit_experiments/library/characterization/fine_amplitude.py
@@ -126,7 +126,7 @@ class FineAmplitude(BaseExperiment, RestlessMixin):
             qubits: The qubit(s) on which to run the fine amplitude calibration experiment.
             gate: The gate that will be repeated.
             backend: Optional, the backend to run the experiment on.
-            measurement_qubits: The qubits in the given physical qubits that need to
+            measurement_qubits: The qubits in the given device qubits that need to
                 be measured.
         """
         super().__init__(qubits, analysis=FineAmplitudeAnalysis(), backend=backend)

--- a/qiskit_experiments/library/characterization/fine_drag.py
+++ b/qiskit_experiments/library/characterization/fine_drag.py
@@ -213,14 +213,14 @@ class FineDrag(BaseExperiment, RestlessMixin):
             if schedule is not None:
                 circuit.add_calibration(
                     self.experiment_options.gate.name,
-                    self.physical_qubits,
+                    self.device_qubits,
                     schedule,
                     params=[],
                 )
 
             circuit.metadata = {
                 "experiment_type": self._type,
-                "qubits": self.physical_qubits,
+                "qubits": self.device_qubits,
                 "xval": repetition,
                 "unit": "gate number",
             }

--- a/qiskit_experiments/library/characterization/fine_frequency.py
+++ b/qiskit_experiments/library/characterization/fine_frequency.py
@@ -128,7 +128,7 @@ class FineFrequency(BaseExperiment):
 
             circuit.metadata = {
                 "experiment_type": self._type,
-                "qubits": self.physical_qubits,
+                "qubits": self.device_qubits,
                 "xval": repetition,
                 "unit": "Number of delays",
             }

--- a/qiskit_experiments/library/characterization/half_angle.py
+++ b/qiskit_experiments/library/characterization/half_angle.py
@@ -132,7 +132,7 @@ class HalfAngle(BaseExperiment):
 
             circuit.metadata = {
                 "experiment_type": self._type,
-                "qubits": self.physical_qubits,
+                "qubits": self.device_qubits,
                 "xval": repetition,
                 "unit": "repetition number",
             }

--- a/qiskit_experiments/library/characterization/qubit_spectroscopy.py
+++ b/qiskit_experiments/library/characterization/qubit_spectroscopy.py
@@ -60,7 +60,7 @@ class QubitSpectroscopy(Spectroscopy):
         if self.backend is None:
             raise QiskitError("backend not set. Cannot determine the center frequency.")
 
-        return self.backend.defaults().qubit_freq_est[self.physical_qubits[0]]
+        return self.backend.defaults().qubit_freq_est[self.device_qubits[0]]
 
     def _template_circuit(self, freq_param) -> QuantumCircuit:
         """Return the template quantum circuit."""
@@ -81,7 +81,7 @@ class QubitSpectroscopy(Spectroscopy):
         width = granularity * (self.experiment_options.width / dt // granularity)
 
         with pulse.build(backend=self.backend, name="spectroscopy") as schedule:
-            pulse.shift_frequency(freq_param, pulse.DriveChannel(self.physical_qubits[0]))
+            pulse.shift_frequency(freq_param, pulse.DriveChannel(self.device_qubits[0]))
             pulse.play(
                 pulse.GaussianSquare(
                     duration=duration,
@@ -89,9 +89,9 @@ class QubitSpectroscopy(Spectroscopy):
                     sigma=sigma,
                     width=width,
                 ),
-                pulse.DriveChannel(self.physical_qubits[0]),
+                pulse.DriveChannel(self.device_qubits[0]),
             )
-            pulse.shift_frequency(-freq_param, pulse.DriveChannel(self.physical_qubits[0]))
+            pulse.shift_frequency(-freq_param, pulse.DriveChannel(self.device_qubits[0]))
 
         return schedule, freq_param
 
@@ -109,7 +109,7 @@ class QubitSpectroscopy(Spectroscopy):
         sched, freq_param = self._schedule()
         circuit = self._template_circuit(freq_param)
         circuit.add_calibration(
-            self.__spec_gate_name__, self.physical_qubits, sched, params=[freq_param]
+            self.__spec_gate_name__, self.device_qubits, sched, params=[freq_param]
         )
 
         # Create the circuits to run

--- a/qiskit_experiments/library/characterization/rabi.py
+++ b/qiskit_experiments/library/characterization/rabi.py
@@ -140,7 +140,7 @@ class Rabi(BaseExperiment, RestlessMixin):
         circuit = self._pre_circuit()
         circuit.append(gate, (0,))
         circuit.measure_active()
-        circuit.add_calibration(gate, self._physical_qubits, sched, params=[param])
+        circuit.add_calibration(gate, self.device_qubits, sched, params=[param])
 
         return circuit, param
 
@@ -162,7 +162,7 @@ class Rabi(BaseExperiment, RestlessMixin):
             assigned_circ = circuit.assign_parameters({param: amp}, inplace=False)
             assigned_circ.metadata = {
                 "experiment_type": self._type,
-                "qubits": self.physical_qubits,
+                "qubits": self.device_qubits,
                 "xval": amp,
                 "unit": "arb. unit",
                 "amplitude": amp,

--- a/qiskit_experiments/library/characterization/ramsey_xy.py
+++ b/qiskit_experiments/library/characterization/ramsey_xy.py
@@ -163,7 +163,7 @@ class RamseyXY(BaseExperiment, RestlessMixin):
         # Create the X and Y circuits.
         metadata = {
             "experiment_type": self._type,
-            "qubits": self.physical_qubits,
+            "qubits": self.device_qubits,
             "osc_freq": self.experiment_options.osc_freq,
             "unit": "s",
         }

--- a/qiskit_experiments/library/characterization/readout_angle.py
+++ b/qiskit_experiments/library/characterization/readout_angle.py
@@ -94,7 +94,7 @@ class ReadoutAngle(BaseExperiment):
         for i, circ in enumerate([circ0, circ1]):
             circ.metadata = {
                 "experiment_type": self._type,
-                "qubit": self.physical_qubits[0],
+                "qubit": self.device_qubits[0],
                 "xval": i,
             }
 

--- a/qiskit_experiments/library/characterization/resonator_spectroscopy.py
+++ b/qiskit_experiments/library/characterization/resonator_spectroscopy.py
@@ -156,7 +156,7 @@ class ResonatorSpectroscopy(Spectroscopy):
         if self.backend is None:
             raise QiskitError("backend not set. Cannot call center_frequency.")
 
-        return self.backend.defaults().meas_freq_est[self.physical_qubits[0]]
+        return self.backend.defaults().meas_freq_est[self.device_qubits[0]]
 
     def _template_circuit(self) -> QuantumCircuit:
         """Return the template quantum circuit."""
@@ -174,7 +174,7 @@ class ResonatorSpectroscopy(Spectroscopy):
         sigma = granularity * (self.experiment_options.sigma / dt // granularity)
         width = granularity * (self.experiment_options.width / dt // granularity)
 
-        qubit = self.physical_qubits[0]
+        qubit = self.device_qubits[0]
 
         freq_param = Parameter("frequency")
 
@@ -212,7 +212,7 @@ class ResonatorSpectroscopy(Spectroscopy):
             sched_ = sched.assign_parameters({freq_param: freq_shift}, inplace=False)
 
             circuit = self._template_circuit()
-            circuit.add_calibration("measure", self.physical_qubits, sched_)
+            circuit.add_calibration("measure", self.device_qubits, sched_)
             self._add_metadata(circuit, freq, sched)
 
             circs.append(circuit)

--- a/qiskit_experiments/library/characterization/spectroscopy.py
+++ b/qiskit_experiments/library/characterization/spectroscopy.py
@@ -128,7 +128,7 @@ class Spectroscopy(BaseExperiment, ABC):
 
         circuit.metadata = {
             "experiment_type": self._type,
-            "qubits": self.physical_qubits,
+            "qubits": self.device_qubits,
             "xval": np.round(freq, decimals=3),
             "unit": "Hz",
             "schedule": str(sched),

--- a/qiskit_experiments/library/characterization/t1.py
+++ b/qiskit_experiments/library/characterization/t1.py
@@ -122,7 +122,7 @@ class T1(BaseExperiment):
 
             circ.metadata = {
                 "experiment_type": self._type,
-                "qubit": self.physical_qubits[0],
+                "qubit": self.device_qubits[0],
                 "unit": "s",
             }
             if dt_unit:

--- a/qiskit_experiments/library/characterization/t2hahn.py
+++ b/qiskit_experiments/library/characterization/t2hahn.py
@@ -183,7 +183,7 @@ class T2Hahn(BaseExperiment):
             circ.measure(0, 0)  # measure
             circ.metadata = {
                 "experiment_type": self._type,
-                "qubit": self.physical_qubits[0],
+                "qubit": self.device_qubits[0],
                 "xval": total_delay,
                 "unit": "s",
             }

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -148,7 +148,7 @@ class T2Ramsey(BaseExperiment):
 
             circ.metadata = {
                 "experiment_type": self._type,
-                "qubit": self.physical_qubits[0],
+                "qubit": self.device_qubits[0],
                 "xval": real_delay_in_sec,
                 "osc_freq": self.experiment_options.osc_freq,
                 "unit": "s",

--- a/qiskit_experiments/library/quantum_volume/qv_experiment.py
+++ b/qiskit_experiments/library/quantum_volume/qv_experiment.py
@@ -170,7 +170,7 @@ class QuantumVolume(BaseExperiment):
                 "experiment_type": self._type,
                 "depth": depth,
                 "trial": trial,
-                "qubits": self.physical_qubits,
+                "qubits": self.device_qubits,
                 "ideal_probabilities": self._get_ideal_data(qv_circ),
             }
             circuits.append(qv_circ)

--- a/qiskit_experiments/library/quantum_volume/qv_experiment.py
+++ b/qiskit_experiments/library/quantum_volume/qv_experiment.py
@@ -81,7 +81,7 @@ class QuantumVolume(BaseExperiment):
         """Initialize a quantum volume experiment.
 
         Args:
-            qubits: list of physical qubits for the experiment.
+            qubits: list of device qubits for the experiment.
             backend: Optional, the backend to run the experiment on.
             trials: The number of trials to run the quantum volume circuit.
             seed: Optional, seed used to initialize ``numpy.random.default_rng``

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
@@ -63,7 +63,7 @@ class InterleavedRB(StandardRB):
         Args:
             interleaved_element: The element to interleave,
                     given either as a group element or as an instruction/circuit
-            qubits: list of physical qubits for the experiment.
+            qubits: list of device qubits for the experiment.
             lengths: A list of RB sequences lengths.
             backend: The backend to run the experiment on.
             num_samples: Number of samples to generate for each

--- a/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
@@ -81,7 +81,7 @@ class RBAnalysis(curve.CurveAnalysis):
     def __init__(self):
         super().__init__()
         self._gate_counts_per_clifford = None
-        self._physical_qubits = None
+        self._device_qubits = None
 
     @classmethod
     def _default_options(cls):
@@ -138,7 +138,7 @@ class RBAnalysis(curve.CurveAnalysis):
             b=(0, 1),
         )
 
-        b_guess = 1 / 2 ** len(self._physical_qubits)
+        b_guess = 1 / 2 ** len(self._device_qubits)
         a_guess = 1 - b_guess
         alpha_guess = curve.guess.rb_decay(curve_data.x, curve_data.y, a=a_guess, b=b_guess)
 
@@ -208,7 +208,7 @@ class RBAnalysis(curve.CurveAnalysis):
             List of analysis result data.
         """
         outcomes = super()._create_analysis_results(fit_data, quality, **metadata)
-        num_qubits = len(self._physical_qubits)
+        num_qubits = len(self._device_qubits)
 
         # Calculate EPC
         alpha = fit_data.fitval("alpha")
@@ -229,7 +229,7 @@ class RBAnalysis(curve.CurveAnalysis):
         if self.options.epg_1_qubit and num_qubits == 2:
             epc = _exclude_1q_error(
                 epc=epc,
-                qubits=self._physical_qubits,
+                qubits=self._device_qubits,
                 gate_counts_per_clifford=self._gate_counts_per_clifford,
                 extra_analyses=self.options.epg_1_qubit,
             )
@@ -247,7 +247,7 @@ class RBAnalysis(curve.CurveAnalysis):
         if self._gate_counts_per_clifford is not None and self.options.gate_error_ratio:
             epg_dict = _calculate_epg(
                 epc=epc,
-                qubits=self._physical_qubits,
+                qubits=self._device_qubits,
                 gate_error_ratio=self.options.gate_error_ratio,
                 gate_counts_per_clifford=self._gate_counts_per_clifford,
             )
@@ -315,7 +315,7 @@ class RBAnalysis(curve.CurveAnalysis):
                 self.set_options(gate_error_ratio=gate_error_ratio)
 
         # Get qubit number
-        self._physical_qubits = experiment_data.metadata["physical_qubits"]
+        self._device_qubits = experiment_data.metadata["physical_qubits"]
 
 
 def _lookup_epg_ratio(gate: str, n_qubits: int) -> Union[None, int]:

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -71,7 +71,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
         """Initialize a standard randomized benchmarking experiment.
 
         Args:
-            qubits: list of physical qubits for the experiment.
+            qubits: list of device qubits for the experiment.
             lengths: A list of RB sequences lengths.
             backend: The backend to run the experiment on.
             num_samples: Number of samples to generate for each sequence length.

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -205,7 +205,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
                     "experiment_type": self._type,
                     "xval": current_length + 1,
                     "group": "Clifford",
-                    "physical_qubits": self.physical_qubits,
+                    "physical_qubits": self.device_qubits,
                 }
                 rb_circ.measure_all()
                 circuits.append(rb_circ)
@@ -229,7 +229,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
                 if inst.name in ("measure", "reset", "delay", "barrier", "snapshot"):
                     continue
                 qinds = [circ.find_bit(q).index for q in qargs]
-                if not set(self.physical_qubits).issuperset(qinds):
+                if not set(self.device_qubits).issuperset(qinds):
                     continue
                 # Not aware of multi-qubit gate direction
                 formatted_key = tuple(sorted(qinds)), inst.name

--- a/qiskit_experiments/library/tomography/basis/base_basis.py
+++ b/qiskit_experiments/library/tomography/basis/base_basis.py
@@ -61,7 +61,7 @@ class BaseBasis(ABC):
 
         Args:
             index: a list of basis elements to tensor together.
-            qubits: Optional, the physical qubit subsystems for the index.
+            qubits: Optional, the device qubit subsystems for the index.
                     If None this will be set to ``(0, ..., N-1)`` for a
                     length N index.
 
@@ -71,7 +71,7 @@ class BaseBasis(ABC):
         .. note::
 
             This returns a logical circuit on the specified number of qubits
-            and should be remapped to the corresponding physical qubits
+            and should be remapped to the corresponding device qubits
             during experiment transpilation.
         """
 
@@ -85,7 +85,7 @@ class PreparationBasis(BaseBasis):
     * The :meth:`circuit` method which returns the logical preparation
       :class:`.QuantumCircuit` for basis element index on the specified
       qubits. This circuit should be a logical circuit on the specified
-      number of qubits and will be remapped to the corresponding physical
+      number of qubits and will be remapped to the corresponding device
       qubits during transpilation.
 
     * The :meth:`matrix` method which returns the density matrix prepared
@@ -112,7 +112,7 @@ class PreparationBasis(BaseBasis):
 
         Args:
             index: a list of subsystem basis indices.
-            qubits: Optional, the physical qubit subsystems for the index.
+            qubits: Optional, the device qubit subsystems for the index.
                     If None this will be set to ``(0, ..., N-1)`` for a
                     length N index.
 
@@ -129,9 +129,9 @@ class MeasurementBasis(BaseBasis):
 
     * The :meth:`circuit` method which returns the logical measurement
       :class:`.QuantumCircuit` for basis element index on the specified
-      physical qubits. This circuit should be a logical circuit on the
+      device qubits. This circuit should be a logical circuit on the
       specified number of qubits and will be remapped to the corresponding
-      physical qubits during transpilation. It should include classical
+      device qubits during transpilation. It should include classical
       bits and the measure instructions for the basis measurement storing
       the outcome value in these bits.
 
@@ -171,7 +171,7 @@ class MeasurementBasis(BaseBasis):
         Args:
             index: a list of subsystem basis indices.
             outcome: the composite system measurement outcome.
-            qubits: Optional, the physical qubit subsystems for the index.
+            qubits: Optional, the device qubit subsystems for the index.
                     If None this will be set to ``(0, ..., N-1)`` for a
                     length N index.
 

--- a/qiskit_experiments/library/tomography/basis/local_basis.py
+++ b/qiskit_experiments/library/tomography/basis/local_basis.py
@@ -48,7 +48,7 @@ class LocalPreparationBasis(PreparationBasis):
             default_states: Optional, default density matrices prepared by the
                             input instructions. If None these will be determined by
                             ideal simulation of the preparation instructions.
-            qubit_states: Optional, a dict with physical qubit keys and a list of
+            qubit_states: Optional, a dict with device qubit keys and a list of
                           density matrices prepared by the list of basis instructions
                           for a specific qubit. The default states will be used for any
                           qubits not specified in this dict.
@@ -213,7 +213,7 @@ class LocalMeasurementBasis(MeasurementBasis):
                            will be calculated by evolving the computation basis states
                            by the adjoint of the channel. If None the input instructions
                            will be used as the POVM channel.
-            qubit_povms: Optional, a dict with physical qubit keys and a list of POVMs
+            qubit_povms: Optional, a dict with device qubit keys and a list of POVMs
                          corresponding to each basis measurement instruction for the
                          specific qubit. The default POVMs will be used for any qubits
                          not specified in this dict.

--- a/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
@@ -100,10 +100,10 @@ def cvxpy_linear_lstsq(
         preparation_data: preparation basis indice data.
         measurement_basis: Optional, measurement matrix basis.
         preparation_basis: Optional, preparation matrix basis.
-        measurement_qubits: Optional, the physical qubits that were measured.
+        measurement_qubits: Optional, the device qubits that were measured.
                             If None they are assumed to be ``[0, ..., M-1]`` for
                             M measured qubits.
-        preparation_qubits: Optional, the physical qubits that were prepared.
+        preparation_qubits: Optional, the device qubits that were prepared.
                             If None they are assumed to be ``[0, ..., N-1]`` for
                             N preparated qubits.
         psd: If True rescale the eigenvalues of fitted matrix to be positive
@@ -238,10 +238,10 @@ def cvxpy_gaussian_lstsq(
         preparation_data: preparation basis indice data.
         measurement_basis: Optional, measurement matrix basis.
         preparation_basis: Optional, preparation matrix basis.
-        measurement_qubits: Optional, the physical qubits that were measured.
+        measurement_qubits: Optional, the device qubits that were measured.
                             If None they are assumed to be ``[0, ..., M-1]`` for
                             M measured qubits.
-        preparation_qubits: Optional, the physical qubits that were prepared.
+        preparation_qubits: Optional, the device qubits that were prepared.
                             If None they are assumed to be ``[0, ..., N-1]`` for
                             N preparated qubits.
         psd: If True rescale the eigenvalues of fitted matrix to be positive

--- a/qiskit_experiments/library/tomography/fitters/lininv.py
+++ b/qiskit_experiments/library/tomography/fitters/lininv.py
@@ -91,10 +91,10 @@ def linear_inversion(
         preparation_data: preparation basis indice data.
         measurement_basis: the tomography measurement basis.
         preparation_basis: the tomography preparation basis.
-        measurement_qubits: Optional, the physical qubits that were measured.
+        measurement_qubits: Optional, the device qubits that were measured.
                             If None they are assumed to be [0, ..., M-1] for
                             M measured qubits.
-        preparation_qubits: Optional, the physical qubits that were prepared.
+        preparation_qubits: Optional, the device qubits that were prepared.
                             If None they are assumed to be [0, ..., N-1] for
                             N preparated qubits.
 

--- a/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
@@ -75,10 +75,10 @@ def scipy_linear_lstsq(
         preparation_data: preparation basis indice data.
         measurement_basis: Optional, measurement matrix basis.
         preparation_basis: Optional, preparation matrix basis.
-        measurement_qubits: Optional, the physical qubits that were measured.
+        measurement_qubits: Optional, the device qubits that were measured.
                             If None they are assumed to be ``[0, ..., M-1]`` for
                             M measured qubits.
-        preparation_qubits: Optional, the physical qubits that were prepared.
+        preparation_qubits: Optional, the device qubits that were prepared.
                             If None they are assumed to be ``[0, ..., N-1]`` for
                             N preparated qubits.
         weights: Optional array of weights for least squares objective.
@@ -170,10 +170,10 @@ def scipy_gaussian_lstsq(
         preparation_data: preparation basis indice data.
         measurement_basis: Optional, measurement matrix basis.
         preparation_basis: Optional, preparation matrix basis.
-        measurement_qubits: Optional, the physical qubits that were measured.
+        measurement_qubits: Optional, the device qubits that were measured.
                             If None they are assumed to be ``[0, ..., M-1]`` for
                             M measured qubits.
-        preparation_qubits: Optional, the physical qubits that were prepared.
+        preparation_qubits: Optional, the device qubits that were prepared.
                             If None they are assumed to be ``[0, ..., N-1]`` for
                             N preparated qubits.
         kwargs: additional kwargs for :func:`scipy.linalg.lstsq`.

--- a/qiskit_experiments/library/tomography/qpt_experiment.py
+++ b/qiskit_experiments/library/tomography/qpt_experiment.py
@@ -81,7 +81,7 @@ class ProcessTomography(TomographyExperiment):
                 preparation basis index, and ``m[i]`` is the measurement basis index
                 for qubit-i. If not specified full tomography for all indices of the
                 preparation and measurement bases will be performed.
-            qubits: Optional, the physical qubits for the initial state circuit.
+            qubits: Optional, the device qubits for the initial state circuit.
         """
         super().__init__(
             circuit,

--- a/qiskit_experiments/library/tomography/qst_experiment.py
+++ b/qiskit_experiments/library/tomography/qst_experiment.py
@@ -70,7 +70,7 @@ class StateTomography(TomographyExperiment):
                 measurement basis configurations ``[m[0], m[1], ...]`` where ``m[i]``
                 is the measurement basis index for qubit-i. If not specified full
                 tomography for all indices of the measurement basis will be performed.
-            qubits: Optional, the physical qubits for the initial state circuit.
+            qubits: Optional, the device qubits for the initial state circuit.
         """
         if isinstance(circuit, Statevector):
             # Convert to circuit using initialize instruction

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -105,7 +105,7 @@ class TomographyExperiment(BaseExperiment):
         if measurement_qubits:
             # Convert logical qubits to device qubits
             self._meas_qubits = tuple(measurement_qubits)
-            self._meas_physical_qubits = tuple(self.device_qubits[i] for i in self._meas_qubits)
+            self._meas_device_qubits = tuple(self.device_qubits[i] for i in self._meas_qubits)
             for qubit in self._meas_qubits:
                 if qubit not in range(self.num_qubits):
                     raise QiskitError(
@@ -114,16 +114,16 @@ class TomographyExperiment(BaseExperiment):
                     )
         elif measurement_basis:
             self._meas_qubits = tuple(range(self.num_qubits))
-            self._meas_physical_qubits = self.device_qubits
+            self._meas_device_qubits = self.device_qubits
         else:
             self._meas_qubits = tuple()
-            self._meas_physical_qubits = tuple()
+            self._meas_device_qubits = tuple()
 
         # Preparation basis and qubits
         self._prep_circ_basis = preparation_basis
         if preparation_qubits:
             self._prep_qubits = tuple(preparation_qubits)
-            self._prep_physical_qubits = tuple(self.device_qubits[i] for i in self._prep_qubits)
+            self._prep_device_qubits = tuple(self.device_qubits[i] for i in self._prep_qubits)
             for qubit in self._prep_qubits:
                 if qubit not in range(self.num_qubits):
                     raise QiskitError(
@@ -132,10 +132,10 @@ class TomographyExperiment(BaseExperiment):
                     )
         elif preparation_basis:
             self._prep_qubits = tuple(range(self.num_qubits))
-            self._prep_physical_qubits = self.device_qubits
+            self._prep_device_qubits = self.device_qubits
         else:
             self._prep_qubits = tuple()
-            self._prep_physical_qubits = tuple()
+            self._prep_device_qubits = tuple()
 
         # Configure experiment options
         if basis_indices:
@@ -174,7 +174,7 @@ class TomographyExperiment(BaseExperiment):
 
             if prep_element:
                 # Add tomography preparation
-                prep_circ = self._prep_circ_basis.circuit(prep_element, self._prep_physical_qubits)
+                prep_circ = self._prep_circ_basis.circuit(prep_element, self._prep_device_qubits)
                 circ.reset(self._prep_qubits)
                 circ.compose(prep_circ, self._prep_qubits, inplace=True)
                 circ.barrier(self._prep_qubits)
@@ -186,7 +186,7 @@ class TomographyExperiment(BaseExperiment):
 
             # Add tomography measurement
             if meas_element:
-                meas_circ = self._meas_circ_basis.circuit(meas_element, self._meas_physical_qubits)
+                meas_circ = self._meas_circ_basis.circuit(meas_element, self._meas_device_qubits)
                 circ.barrier(self._meas_qubits)
                 circ.compose(meas_circ, self._meas_qubits, meas_clbits, inplace=True)
 
@@ -197,10 +197,10 @@ class TomographyExperiment(BaseExperiment):
 
     def _metadata(self):
         metadata = super()._metadata()
-        if self._meas_physical_qubits:
-            metadata["m_qubits"] = list(self._meas_physical_qubits)
-        if self._prep_physical_qubits:
-            metadata["p_qubits"] = list(self._prep_physical_qubits)
+        if self._meas_device_qubits:
+            metadata["m_qubits"] = list(self._meas_device_qubits)
+        if self._prep_device_qubits:
+            metadata["p_qubits"] = list(self._prep_device_qubits)
         return metadata
 
     def _basis_indices(self):
@@ -209,12 +209,12 @@ class TomographyExperiment(BaseExperiment):
         if basis_indices is not None:
             return basis_indices
         if self._meas_circ_basis:
-            meas_shape = self._meas_circ_basis.index_shape(self._meas_physical_qubits)
+            meas_shape = self._meas_circ_basis.index_shape(self._meas_device_qubits)
             meas_elements = product(*[range(i) for i in meas_shape])
         else:
             meas_elements = [None]
         if self._prep_circ_basis:
-            prep_shape = self._prep_circ_basis.index_shape(self._prep_physical_qubits)
+            prep_shape = self._prep_circ_basis.index_shape(self._prep_device_qubits)
             prep_elements = product(*[range(i) for i in prep_shape])
         else:
             prep_elements = [None]

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -105,7 +105,7 @@ class TomographyExperiment(BaseExperiment):
         if measurement_qubits:
             # Convert logical qubits to physical qubits
             self._meas_qubits = tuple(measurement_qubits)
-            self._meas_physical_qubits = tuple(self.physical_qubits[i] for i in self._meas_qubits)
+            self._meas_physical_qubits = tuple(self.device_qubits[i] for i in self._meas_qubits)
             for qubit in self._meas_qubits:
                 if qubit not in range(self.num_qubits):
                     raise QiskitError(
@@ -114,7 +114,7 @@ class TomographyExperiment(BaseExperiment):
                     )
         elif measurement_basis:
             self._meas_qubits = tuple(range(self.num_qubits))
-            self._meas_physical_qubits = self.physical_qubits
+            self._meas_physical_qubits = self.device_qubits
         else:
             self._meas_qubits = tuple()
             self._meas_physical_qubits = tuple()
@@ -123,7 +123,7 @@ class TomographyExperiment(BaseExperiment):
         self._prep_circ_basis = preparation_basis
         if preparation_qubits:
             self._prep_qubits = tuple(preparation_qubits)
-            self._prep_physical_qubits = tuple(self.physical_qubits[i] for i in self._prep_qubits)
+            self._prep_physical_qubits = tuple(self.device_qubits[i] for i in self._prep_qubits)
             for qubit in self._prep_qubits:
                 if qubit not in range(self.num_qubits):
                     raise QiskitError(
@@ -132,7 +132,7 @@ class TomographyExperiment(BaseExperiment):
                     )
         elif preparation_basis:
             self._prep_qubits = tuple(range(self.num_qubits))
-            self._prep_physical_qubits = self.physical_qubits
+            self._prep_physical_qubits = self.device_qubits
         else:
             self._prep_qubits = tuple()
             self._prep_physical_qubits = tuple()

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -76,7 +76,7 @@ class TomographyExperiment(BaseExperiment):
                 to the logical qubits in the process circuit.
             basis_indices: Optional, the basis elements to be measured. If None
                 All basis elements will be measured.
-            qubits: Optional, the physical qubits for the initial state circuit.
+            qubits: Optional, the device qubits for the initial state circuit.
             analysis: Optional, analysis class to use for experiment. If None the default
                 tomography analysis will be used.
 
@@ -103,7 +103,7 @@ class TomographyExperiment(BaseExperiment):
         # Measurement basis and qubits
         self._meas_circ_basis = measurement_basis
         if measurement_qubits:
-            # Convert logical qubits to physical qubits
+            # Convert logical qubits to device qubits
             self._meas_qubits = tuple(measurement_qubits)
             self._meas_physical_qubits = tuple(self.device_qubits[i] for i in self._meas_qubits)
             for qubit in self._meas_qubits:

--- a/test/calibration/experiments/test_fine_drag.py
+++ b/test/calibration/experiments/test_fine_drag.py
@@ -104,7 +104,7 @@ class TestFineDragCal(QiskitExperimentsTestCase):
         drag_cal = FineDragCal(0, self.cals, "x", self.backend)
 
         transpile_opts = copy.copy(drag_cal.transpile_options.__dict__)
-        transpile_opts["initial_layout"] = list(drag_cal.physical_qubits)
+        transpile_opts["initial_layout"] = list(drag_cal.device_qubits)
         circs = transpile(
             drag_cal.circuits(), inst_map=self.cals.default_inst_map, **transpile_opts
         )
@@ -127,7 +127,7 @@ class TestFineDragCal(QiskitExperimentsTestCase):
         new_beta = -np.sqrt(np.pi) * d_theta * sigma / target_angle**2
 
         transpile_opts = copy.copy(drag_cal.transpile_options.__dict__)
-        transpile_opts["initial_layout"] = list(drag_cal.physical_qubits)
+        transpile_opts["initial_layout"] = list(drag_cal.device_qubits)
         circs = transpile(
             drag_cal.circuits(), inst_map=self.cals.default_inst_map, **transpile_opts
         )

--- a/test/calibration/experiments/test_rough_frequency.py
+++ b/test/calibration/experiments/test_rough_frequency.py
@@ -40,7 +40,7 @@ class TestRoughFrequency(QiskitExperimentsTestCase):
             qubit, cals, frequencies, auto_update=auto_update, absolute=absolute
         )
 
-        self.assertEqual(freq.physical_qubits, (qubit,))
+        self.assertEqual(freq.device_qubits, (qubit,))
         self.assertEqual(freq._frequencies, frequencies)
         self.assertEqual(freq._absolute, False)
         self.assertEqual(freq.auto_update, False)

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -475,7 +475,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
                 self._ncircs = num_circs
 
             def circuits(self):
-                nqubits = len(self._physical_qubits)
+                nqubits = len(self.device_qubits)
                 circs = []
                 for _ in range(self._ncircs):
                     circ = QuantumCircuit(nqubits, nqubits)

--- a/test/test_half_angle.py
+++ b/test/test_half_angle.py
@@ -58,7 +58,7 @@ class TestHalfAngle(QiskitExperimentsTestCase):
 
         # mimic what will happen in the experiment.
         transpile_opts = copy.copy(hac.transpile_options.__dict__)
-        transpile_opts["initial_layout"] = list(hac._physical_qubits)
+        transpile_opts["initial_layout"] = list(hac.device_qubits)
         circuits = transpile(hac.circuits(), FakeAthens(), **transpile_opts)
 
         for idx, circ in enumerate(circuits):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR proposes deprecating the `physical_qubits` experiment property and renaming it with `device_qubits` to be more clear what qubits this is referring to, and use terminology closer to other qiskit documentation of device properties.

It also renames the `qubits` init argument of BaseExperiment to `device_qubits` to be consistent (and renames other method args taking `physical_qubits` to `device_qubits`)

This also updates all API and tutorial documentation to refer to device qubits instead of physical qubits.

### Details and comments

Note that this PR does not rename all usage of physical qubits in library experiments. If this proposed change is accepted and merged there should be follow up PRs to:
* Deprecate the "physical_qubits" experiment metadata field for "device_qubits" field.
* Deprecate qubit/qubits arguments of library experiments to use `device_qubit/device_qubits` terminology for those arguments to be more consistent in our documentation when referring to device qubits vs logical/circuit qubits.
