### PR TITLE
Update deprecated use of `qiskit.test.mock`

### DIFF
--- a/docs/tutorials/quantum_volume.rst
+++ b/docs/tutorials/quantum_volume.rst
@@ -33,7 +33,7 @@ z_value = 2), and at least 100 trials have been ran.
     from qiskit.providers.aer import AerSimulator
     
     # For simulation
-    from qiskit.test.mock import FakeSydney
+    from qiskit.providers.fake_provider import FakeSydney
     
     backend = AerSimulator.from_backend(FakeSydney())
 

--- a/docs/tutorials/randomized_benchmarking.rst
+++ b/docs/tutorials/randomized_benchmarking.rst
@@ -20,7 +20,7 @@ for an explanation on the RB method, which is based on Ref. [1, 2].
     
     # For simulation
     from qiskit.providers.aer import AerSimulator
-    from qiskit.test.mock import FakeParis
+    from qiskit.providers.fake_provider import FakeParis
     
     backend = AerSimulator.from_backend(FakeParis())
 

--- a/docs/tutorials/readout_mitigation.rst
+++ b/docs/tutorials/readout_mitigation.rst
@@ -41,7 +41,7 @@ experiments to generate the corresponding mitigators.
     from qiskit_experiments.library import LocalReadoutError, CorrelatedReadoutError
     # For simulation
     from qiskit.providers.aer import AerSimulator
-    from qiskit.test.mock import FakeParis
+    from qiskit.providers.fake_provider import FakeParis
 
     from qiskit.result.mitigation.utils import (
         expval_with_stddev,

--- a/docs/tutorials/restless_measurements.rst
+++ b/docs/tutorials/restless_measurements.rst
@@ -66,7 +66,7 @@ they use always starts with the qubits in the ground state.
         FixedFrequencyTransmon,
     )
     from qiskit_experiments.data_processing.data_processor import DataProcessor
-    from qiskit.test.mock import FakeBogota
+    from qiskit.providers.fake_provider import FakeBogota
 
     # replace this lines with an IBM Quantum backend to run the experiment.
     backend = FakeBogota()

--- a/docs/tutorials/state_tomography.rst
+++ b/docs/tutorials/state_tomography.rst
@@ -9,7 +9,7 @@ Quantum State Tomography
     
     # For simulation
     from qiskit.providers.aer import AerSimulator
-    from qiskit.test.mock import FakeParis
+    from qiskit.providers.fake_provider import FakeParis
     
     # Noisy simulator backend
     backend = AerSimulator.from_backend(FakeParis())

--- a/docs/tutorials/t1.rst
+++ b/docs/tutorials/t1.rst
@@ -35,7 +35,7 @@ for qubit 0.
     from qiskit_experiments.library import T1
     
     # A T1 simulator
-    from qiskit.test.mock import FakeVigo
+    from qiskit.providers.fake_provider import FakeVigo
     from qiskit.providers.aer import AerSimulator
     from qiskit.providers.aer.noise import NoiseModel
     

--- a/docs/tutorials/t2ramsey_characterization.rst
+++ b/docs/tutorials/t2ramsey_characterization.rst
@@ -64,7 +64,7 @@ pure T1/T2 relaxation noise model.
 .. jupyter-execute::
 
     # A T1 simulator
-    from qiskit.test.mock import FakeVigo
+    from qiskit.providers.fake_provider import FakeVigo
     from qiskit.providers.aer import AerSimulator
     from qiskit.providers.aer.noise import NoiseModel
     

--- a/docs/tutorials/tphi_characterization.rst
+++ b/docs/tutorials/tphi_characterization.rst
@@ -22,7 +22,7 @@ we compute the results for :math:`T_\varphi.`
 .. jupyter-execute::
 
     # An Aer simulator
-    from qiskit.test.mock import FakeVigo
+    from qiskit.providers.fake_provider import FakeVigo
     from qiskit.providers.aer import AerSimulator
     from qiskit.providers.aer.noise import NoiseModel
     

--- a/qiskit_experiments/library/characterization/ramsey_xy.py
+++ b/qiskit_experiments/library/characterization/ramsey_xy.py
@@ -18,7 +18,7 @@ import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.providers.backend import Backend
-from qiskit.test.mock import FakeBackend
+from qiskit.providers.fake_provider import FakeBackend
 
 from qiskit_experiments.framework import BaseExperiment
 from qiskit_experiments.framework.restless_mixin import RestlessMixin

--- a/qiskit_experiments/library/characterization/t1.py
+++ b/qiskit_experiments/library/characterization/t1.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from qiskit import QuantumCircuit
 from qiskit.providers.backend import Backend
-from qiskit.test.mock import FakeBackend
+from qiskit.providers.fake_provider import FakeBackend
 
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.library.characterization.analysis.t1_analysis import T1Analysis

--- a/qiskit_experiments/library/characterization/t2hahn.py
+++ b/qiskit_experiments/library/characterization/t2hahn.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from qiskit import QuantumCircuit, QiskitError
 from qiskit.providers.backend import Backend
-from qiskit.test.mock import FakeBackend
+from qiskit.providers.fake_provider import FakeBackend
 
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.library.characterization.analysis.t2hahn_analysis import T2HahnAnalysis

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -20,7 +20,7 @@ import numpy as np
 import qiskit
 from qiskit import QuantumCircuit
 from qiskit.providers.backend import Backend
-from qiskit.test.mock import FakeBackend
+from qiskit.providers.fake_provider import FakeBackend
 
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.library.characterization.analysis.t2ramsey_analysis import T2RamseyAnalysis

--- a/qiskit_experiments/test/mock_iq_backend.py
+++ b/qiskit_experiments/test/mock_iq_backend.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from qiskit import QuantumCircuit
 from qiskit.result import Result
-from qiskit.test.mock import FakeOpenPulse2Q
+from qiskit.providers.fake_provider import FakeOpenPulse2Q
 
 from qiskit.qobj.utils import MeasLevel
 from qiskit_experiments.framework import Options

--- a/test/calibration/experiments/test_fine_drag.py
+++ b/test/calibration/experiments/test_fine_drag.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from qiskit import transpile
 from qiskit.circuit import Gate
-from qiskit.test.mock import FakeArmonk
+from qiskit.providers.fake_provider import FakeArmonk
 import qiskit.pulse as pulse
 
 from qiskit_experiments.library import FineDrag, FineXDrag, FineDragCal

--- a/test/calibration/experiments/test_fine_frequency.py
+++ b/test/calibration/experiments/test_fine_frequency.py
@@ -16,7 +16,7 @@ from test.base import QiskitExperimentsTestCase
 import numpy as np
 from ddt import ddt, data
 
-from qiskit.test.mock import FakeArmonk
+from qiskit.providers.fake_provider import FakeArmonk
 import qiskit.pulse as pulse
 
 from qiskit_experiments.library import (

--- a/test/calibration/experiments/test_ramsey_xy.py
+++ b/test/calibration/experiments/test_ramsey_xy.py
@@ -14,7 +14,7 @@
 
 import unittest
 from test.base import QiskitExperimentsTestCase
-from qiskit.test.mock import FakeArmonk
+from qiskit.providers.fake_provider import FakeArmonk
 
 from qiskit_experiments.calibration_management.calibrations import Calibrations
 from qiskit_experiments.calibration_management.basis_gate_library import FixedFrequencyTransmon

--- a/test/calibration/experiments/test_rough_amplitude.py
+++ b/test/calibration/experiments/test_rough_amplitude.py
@@ -18,7 +18,7 @@ import numpy as np
 from qiskit import transpile
 import qiskit.pulse as pulse
 from qiskit.circuit import Parameter
-from qiskit.test.mock import FakeArmonk
+from qiskit.providers.fake_provider import FakeArmonk
 
 from qiskit_experiments.calibration_management.basis_gate_library import FixedFrequencyTransmon
 from qiskit_experiments.calibration_management import Calibrations

--- a/test/calibration/experiments/test_rough_frequency.py
+++ b/test/calibration/experiments/test_rough_frequency.py
@@ -15,7 +15,7 @@ from test.base import QiskitExperimentsTestCase
 
 import numpy as np
 
-from qiskit.test.mock import FakeArmonk
+from qiskit.providers.fake_provider import FakeArmonk
 
 from qiskit_experiments.library import RoughFrequencyCal
 from qiskit_experiments.calibration_management import Calibrations

--- a/test/calibration/test_calibrations.py
+++ b/test/calibration/test_calibrations.py
@@ -31,7 +31,7 @@ from qiskit.pulse import (
 from qiskit import transpile, QuantumCircuit
 from qiskit.pulse.transforms import inline_subroutines, block_to_schedule
 import qiskit.pulse as pulse
-from qiskit.test.mock import FakeArmonk, FakeBelem
+from qiskit.providers.fake_provider import FakeArmonk, FakeBelem
 from qiskit_experiments.calibration_management.calibrations import Calibrations, ParameterKey
 from qiskit_experiments.calibration_management.parameter_value import ParameterValue
 from qiskit_experiments.calibration_management.basis_gate_library import FixedFrequencyTransmon

--- a/test/calibration/test_update_library.py
+++ b/test/calibration/test_update_library.py
@@ -17,7 +17,7 @@ import numpy as np
 from qiskit.circuit import Parameter
 from qiskit.qobj.utils import MeasLevel
 import qiskit.pulse as pulse
-from qiskit.test.mock import FakeAthens
+from qiskit.providers.fake_provider import FakeAthens
 
 from qiskit_experiments.library import QubitSpectroscopy
 from qiskit_experiments.calibration_management.calibrations import Calibrations

--- a/test/database_service/test_db_experiment_data.py
+++ b/test/database_service/test_db_experiment_data.py
@@ -27,7 +27,7 @@ import uuid
 import matplotlib.pyplot as plt
 import numpy as np
 
-from qiskit.test.mock import FakeMelbourne
+from qiskit.providers.fake_provider import FakeMelbourne
 from qiskit.result import Result
 from qiskit.providers import JobV1 as Job
 from qiskit.providers import JobStatus

--- a/test/test_cross_resonance_hamiltonian.py
+++ b/test/test_cross_resonance_hamiltonian.py
@@ -19,7 +19,7 @@ import functools
 import numpy as np
 from ddt import ddt, data, unpack
 from qiskit import QuantumCircuit, pulse, quantum_info as qi
-from qiskit.test.mock import FakeBogota
+from qiskit.providers.fake_provider import FakeBogota
 from qiskit.extensions.hamiltonian_gate import HamiltonianGate
 from qiskit.providers.aer import AerSimulator
 from qiskit_experiments.library.characterization import cr_hamiltonian

--- a/test/test_half_angle.py
+++ b/test/test_half_angle.py
@@ -16,7 +16,7 @@ from test.base import QiskitExperimentsTestCase
 import copy
 
 from qiskit import transpile
-from qiskit.test.mock import FakeAthens
+from qiskit.providers.fake_provider import FakeAthens
 import qiskit.pulse as pulse
 from qiskit.pulse import InstructionScheduleMap
 

--- a/test/test_readout_error.py
+++ b/test/test_readout_error.py
@@ -20,7 +20,7 @@ from test.base import QiskitExperimentsTestCase
 import numpy as np
 from qiskit.quantum_info.operators.predicates import matrix_equal
 from qiskit.providers.aer import AerSimulator
-from qiskit.test.mock import FakeParis
+from qiskit.providers.fake_provider import FakeParis
 from qiskit_experiments.library.characterization import LocalReadoutError, CorrelatedReadoutError
 from qiskit_experiments.framework import ExperimentData
 from qiskit_experiments.framework import ParallelExperiment


### PR DESCRIPTION
### Summary

Terra 0.21 issues deprecation warnings for `qiskit.test.mock`, as the
fake backends have been promoted to having full public support.  They
have been exposed as `qiskit.providers.fake_provider` since Terra 0.20,
so this change does not require updating any requirements.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

This should just be a simple swap of what's used in the documentation, code and examples - the actual objects in Terra are unchanged.
