### PR TITLE
Add **experiment_option parameter to experiment classes

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -39,14 +39,21 @@ class BaseExperiment(ABC, StoreInitArgs):
         analysis: Optional[BaseAnalysis] = None,
         backend: Optional[Backend] = None,
         experiment_type: Optional[str] = None,
+        **experiment_options,
     ):
         """Initialize the experiment object.
+
+        `experiment_options` catches all keyword arguments not explicitly defined in `__init__`. As this
+        is the base class, `experiment_options` should be an empty dictionary. If it is not empty, then a
+        keyword argument provided to a subclass was not consumed and is thus not used.
+        :py:class:`BaseExperiment` gives a warning in this case.
 
         Args:
             qubits: list of physical qubits for the experiment.
             analysis: Optional, the analysis to use for the experiment.
             backend: Optional, the backend to run the experiment on.
             experiment_type: Optional, the experiment type string.
+            experiment_options: Catch-all for experiment options.
 
         Raises:
             QiskitError: if qubits contains duplicates.
@@ -93,6 +100,9 @@ class BaseExperiment(ABC, StoreInitArgs):
         self._backend = None
         if isinstance(backend, Backend):
             self._set_backend(backend)
+
+        # Set experiment options
+        self.set_experiment_options(**experiment_options)
 
     @property
     def experiment_type(self) -> str:

--- a/qiskit_experiments/library/characterization/cr_hamiltonian.py
+++ b/qiskit_experiments/library/characterization/cr_hamiltonian.py
@@ -139,7 +139,7 @@ class CrossResonanceHamiltonian(BaseExperiment):
         flat_top_widths: Iterable[float],
         backend: Optional[Backend] = None,
         cr_gate: Optional[Type[circuit.Gate]] = None,
-        **kwargs,
+        **experiment_options,
     ):
         """Create a new experiment.
 
@@ -151,8 +151,8 @@ class CrossResonanceHamiltonian(BaseExperiment):
                 falling edges is implicitly computed with experiment parameters ``sigma`` and
                 ``risefall``.
             backend: Optional, the backend to run the experiment on.
-            cr_gate: Optional, circuit gate instruction of cross resonance pulse.
-            kwargs: Pulse parameters. See :meth:`experiment_options` for details.
+            experiment_options: A catch-all for all experiment options. See
+                :py:meth:`_default_experiment_options` for valid parameters.
 
         Raises:
             QiskitError: When ``qubits`` length is not 2.
@@ -170,8 +170,14 @@ class CrossResonanceHamiltonian(BaseExperiment):
                 "Length of qubits is not 2. Please provide index for control and target qubit."
             )
 
-        super().__init__(qubits, analysis=CrossResonanceHamiltonianAnalysis(), backend=backend)
-        self.set_experiment_options(flat_top_widths=flat_top_widths, **kwargs)
+        experiment_options["flat_top_widths"] = flat_top_widths
+
+        super().__init__(
+            qubits,
+            analysis=CrossResonanceHamiltonianAnalysis(),
+            backend=backend,
+            **experiment_options,
+        )
 
     @classmethod
     def _default_experiment_options(cls) -> Options:

--- a/qiskit_experiments/library/quantum_volume/qv_experiment.py
+++ b/qiskit_experiments/library/quantum_volume/qv_experiment.py
@@ -74,29 +74,24 @@ class QuantumVolume(BaseExperiment):
         self,
         qubits: Sequence[int],
         backend: Optional[Backend] = None,
-        trials: Optional[int] = 100,
-        seed: Optional[Union[int, SeedSequence, BitGenerator, Generator]] = None,
         simulation_backend: Optional[Backend] = None,
+        **experiment_options,
     ):
         """Initialize a quantum volume experiment.
 
         Args:
             qubits: list of physical qubits for the experiment.
             backend: Optional, the backend to run the experiment on.
-            trials: The number of trials to run the quantum volume circuit.
-            seed: Optional, seed used to initialize ``numpy.random.default_rng``
-                  when generating circuits. The ``default_rng`` will be initialized
-                  with this seed value everytime :meth:`circuits` is called.
             simulation_backend: The simulator backend to use to generate
                 the expected results. the simulator must have a 'save_probabilities'
                 method. If None :class:`AerSimulator` simulator will be used
                 (in case :class:`AerSimulator` is not
                 installed :class:`qiskit.quantum_info.Statevector` will be used).
-        """
-        super().__init__(qubits, analysis=QuantumVolumeAnalysis(), backend=backend)
+            experiment_options: A catch-all for any experiment options. See
+                :py:meth:`_default_experiment_options` for valid parameters.
 
-        # Set configurable options
-        self.set_experiment_options(trials=trials, seed=seed)
+        """
+        super().__init__(qubits, analysis=QuantumVolumeAnalysis(), backend=backend,**experiment_options,)
 
         if not simulation_backend and HAS_SIMULATION_BACKEND:
             self._simulation_backend = Aer.get_backend("aer_simulator")


### PR DESCRIPTION
### Summary

The signatures of the `__init__` functions for experiment classes are inconsistent between different experiments. For example, this can be seen when comparing the order of optional parameters in [`Rabi`](https://github.com/Qiskit/qiskit-experiments/blob/d648da2c12231d2c4cd89130264c07a2fa29d0d6/qiskit_experiments/library/characterization/rabi.py#L90) and [`CrossResonanceHamiltonian`](https://github.com/Qiskit/qiskit-experiments/blob/d648da2c12231d2c4cd89130264c07a2fa29d0d6/qiskit_experiments/library/characterization/cr_hamiltonian.py#L136). Some optional parameters are experiment options, which have defaults defined in `_default_experiment_options`. This PR proposes a new structure for the `__init__` functions for experiment classes.

### Details and comments

Having an inconsistent order in the signatures means that the two classes are instantiated differently when keywords are not used for all parameters. The most common optional parameter is `backend`, which is used in the example below.

```python
## Rabi
# We can provide `backend` as a positional argument only if we provide `amplitudes` as well.
Rabi(0,myschedule,amplitudes,backend)
# If we don't provide `amplitudes`, then we need to provide `backend` as a keyword argument.
Rabi(0,myschedule,backend=backend)

## CrossResonanceHamiltonian
# As `backend` is the first optional parameter in `__init__`, we don't need to provide a keyword to provide it.
CrossResonanceHamiltonian(0,flat_top_widths,backend)

```
Furthermore, some optional parameters are experiment options, such as `amplitudes` for `Rabi`. The proposed structure for experiment classes' `__init__` functions is as follows:

- `qubit` or `qubits` parameters come first in the signature (other than `self`).
- Required parameters follow `qubit`. Examples include `gate` and `schedule`. These can be required experiment options.
- The first optional parameter is `backend`.
- Any other optional parameters that are not experiment options (i.e., defined in `_default_experiment_options`) follow `backend`.
- Optional parameters that are experiment options are captured by a kwargs parameter `**experiment_options`. As experiment options should already be documented in `_default_experiment_options`, it does not make sense to repeat this information in `__init__`; other than to refer the reader to the `_default_experiment_options` documentation.

#### More on `**experiment_options`

The `experiment_options` parameter captures all keyword arguments that aren't explicitly defined in the `__init__` signature. This means that a user can accidentally provide a parameter that is not used by the class. The dictionary `experiment_options` is passed to `BaseExperiment.__init__` through `super().__init__` and then passed to `self.set_experiment_options` by `BaseExperiment`. This means that all experiment subclasses must pass `**experiment_options` on to their call to `super().__init__`. The function `set_experiment_options` will throw an error if an unknown parameter keyword is encountered, which is useful to handle parameters not used by the class.

Changes to `BaseExperiment` to handle `**experiment_options` are introduced in this PR. To demonstrate how this change looks in experiment classes, `QuantumVolume` and `CrossResonanceHamiltonian` have been updated to use `**experiment_options` and its integration with `BaseExperiment`.

`cr_gate` in `CrossResonanceHamiltonian` is a required experiment option. The updated experiment adds this argument to `**experiment_options` before passing it to `super().__init__`.

The recommended way to include `**experiment_options` is as follows:

```python
class MyExperiment(BaseExperiment):
	
	def __init__(
		self,
		qubit : int,
		backend : Optional[Backend] = None,
		**experiment_options,
	):
    """ Create a MyExperiment instance.

    Args:
        qubit: ...
        backend: ...
        experiment_options: A catch-all for any experiment options. See
            :py:meth:`_default_experiment_options` for valid parameters.
    """
		super().__init__(
			[qubit],
			backend=backend,
			**experiment_options,
		)
		
	@classmethod
	def _default_experiment_options(cls):
		"""Default experiment options.
		
		Experiment Options:
			option1: Experiment option 1.
		"""
		...
```
