### PR TITLE
Small typo fix

### DIFF
--- a/qiskit_experiments/library/characterization/analysis/fine_amplitude_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/fine_amplitude_analysis.py
@@ -38,7 +38,7 @@ class FineAmplitudeAnalysis(curve.ErrorAmplificationAnalysis):
             models=[
                 lmfit.models.ExpressionModel(
                     expr="amp / 2 * (2 * x - 1) + base",
-                    name="smap cal.",
+                    name="spam cal.",
                     data_sort_key={"series": "spam-cal"},
                 ),
                 lmfit.models.ExpressionModel(


### PR DESCRIPTION
This fixes a typo in the label of a plot curve for fine amplitude analysis.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes a typo.

### Details and comments

`smap cal.` in the plot label is fixed to `spam cal.`
