### PR TITLE
Bugfix for composite experiments data settings

### DIFF
--- a/qiskit_experiments/framework/analysis_result.py
+++ b/qiskit_experiments/framework/analysis_result.py
@@ -331,6 +331,11 @@ class AnalysisResult:
         """
         return self._db_data.experiment_id
 
+    @experiment_id.setter
+    def experiment_id(self, new_id: str) -> None:
+        """Sets the experiment id"""
+        self._db_data.experiment_id = new_id
+
     @property
     def chisq(self) -> Optional[float]:
         """Return the reduced χ² of this analysis."""

--- a/qiskit_experiments/framework/base_analysis.py
+++ b/qiskit_experiments/framework/base_analysis.py
@@ -200,7 +200,7 @@ class BaseAnalysis(ABC, StoreInitArgs):
         if isinstance(data, AnalysisResult):
             # Update device components and experiment id
             data.device_components = device_components
-            data._experiment_id = experiment_id
+            data.experiment_id = experiment_id
             return data
 
         return AnalysisResult(

--- a/qiskit_experiments/framework/composite/composite_analysis.py
+++ b/qiskit_experiments/framework/composite/composite_analysis.py
@@ -300,7 +300,7 @@ class CompositeAnalysis(BaseAnalysis):
         component_expdata = []
         for i, _ in enumerate(self._analyses):
             subdata = ExperimentData(backend=experiment_data.backend)
-            subdata._type = experiment_types[i]
+            subdata.experiment_type = experiment_types[i]
             subdata.metadata.update(component_metadata[i])
 
             if self._flatten_results:

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -417,6 +417,11 @@ class ExperimentData:
 
         return self._db_data.experiment_type
 
+    @experiment_type.setter
+    def experiment_type(self, new_type: str) -> None:
+        """Sets the parent id"""
+        self._db_data.experiment_type = new_type
+
     @property
     def parent_id(self) -> str:
         """Return parent experiment ID

--- a/releasenotes/notes/fix_composite_data_setting-6fe361e91d5625e2.yaml
+++ b/releasenotes/notes/fix_composite_data_setting-6fe361e91d5625e2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes a bug with the way composite experiments set the `experiment_id`
+    and `experiment_type` of `AnalysisResult` and `ExperimentData`.

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -707,7 +707,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
             self.assertEqual(expected, sub_data[0])
 
     def test_composite_properties_setting(self):
-        """Test whether DB-critical are properties being set in the
+        """Test whether DB-critical properties are being set in the
         subexperiment data"""
         exp1 = FakeExperiment([0])
         exp1.analysis = FakeAnalysis()

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -706,6 +706,23 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
 
             self.assertEqual(expected, sub_data[0])
 
+    def test_composite_properties_setting(self):
+        """Test whether DB-critical are properties being set in the
+        subexperiment data"""
+        exp1 = FakeExperiment([0])
+        exp1.analysis = FakeAnalysis()
+        exp2 = FakeExperiment([1])
+        exp2.analysis = FakeAnalysis()
+        batch_exp = BatchExperiment([exp1, exp2], flatten_results=True)
+        exp_data = batch_exp.run(backend=self.backend).block_for_results()
+        # when flattening, individual analysis result share exp id
+        for result in exp_data.analysis_results():
+            self.assertEqual(result.experiment_id, exp_data.experiment_id)
+        batch_exp = BatchExperiment([exp1, exp2], flatten_results=False)
+        exp_data = batch_exp.run(backend=self.backend).block_for_results()
+        self.assertEqual(exp_data.child_data(0).experiment_type, exp1.experiment_type)
+        self.assertEqual(exp_data.child_data(1).experiment_type, exp2.experiment_type)
+
 
 class TestBatchTranspileOptions(QiskitExperimentsTestCase):
     """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #848 


### Details and comments
When experiment data is created for composite experiments, the new experiment data is generated and only afterwards it is changed by direct access to the `ExperimentData` and `AnalysisResult` objects. Because of the change in those classes in #812, those changes did not affect the data that was sent to the DB, resulting in errors with DB communication.

This PR addresses this bug by adding the relevant setters for the classes and using them in the relevant composite experiment code.

