### PR TITLE
Fix non-default delays not working with numpy arrays

### DIFF
--- a/qiskit_experiments/library/characterization/ramsey_xy.py
+++ b/qiskit_experiments/library/characterization/ramsey_xy.py
@@ -117,7 +117,8 @@ class RamseyXY(BaseExperiment, RestlessMixin):
         """
         super().__init__([qubit], analysis=RamseyXYAnalysis(), backend=backend)
 
-        delays = delays or self.experiment_options.delays
+        if delays is None:
+            delays = self.experiment_options.delays
         self.set_experiment_options(delays=delays, osc_freq=osc_freq)
 
     def _set_backend(self, backend: Backend):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes the case of  non-default `delays` rising an exaptation with numpy arrays:
`ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`
 


### Details and comments


