### PR TITLE
Fix curve figure fit report

### DIFF
--- a/qiskit_experiments/curve_analysis/visualization/mpl_drawer.py
+++ b/qiskit_experiments/curve_analysis/visualization/mpl_drawer.py
@@ -367,6 +367,7 @@ class MplCurveDrawer(BaseCurveDrawer):
             va="top",
             size=self.options.fit_report_text_size,
             transform=self._axis.transAxes,
+            zorder=6,
         )
         report_handler.set_bbox(bbox_props)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`zorder` for the fit report window is missing, and the window is drawn behind the curve lines. This PR fixes the vertical position of the report window.

(now)
![image](https://user-images.githubusercontent.com/39517270/180230268-24072ae9-a29c-4ddb-92e5-78520be6add0.png)

(fixed)
![image](https://user-images.githubusercontent.com/39517270/180230431-6d238d20-bb6a-4261-9544-d343b57fc422.png)


### Details and comments


