### PR TITLE
Deprecate scipy tomography fitters

### DIFF
--- a/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
@@ -16,7 +16,7 @@ Linear least-square MLE tomography fitter.
 from typing import Optional, Dict, Tuple
 import numpy as np
 import scipy.linalg as la
-
+from qiskit.utils import deprecate_function
 from qiskit_experiments.exceptions import AnalysisError
 from qiskit_experiments.library.tomography.basis import (
     MeasurementBasis,
@@ -24,7 +24,15 @@ from qiskit_experiments.library.tomography.basis import (
 )
 from . import lstsq_utils
 
+# Note this warning doesnt show up when run in analysis so we
+# also add a warning when setting the option value that calls this function
 
+# pylint: disable = bad-docstring-quotes
+@deprecate_function(
+    "The scipy lstsq tomography fitters have been deprecated and will "
+    "be removed in the 0.5.0 release. Use the `linear_lstsq`, "
+    "`cvxpy_linear_lstsq`, or `cvxpy_gaussian_lstsq` fitter instead."
+)
 def scipy_linear_lstsq(
     outcome_data: np.ndarray,
     shot_data: np.ndarray,

--- a/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
@@ -29,9 +29,9 @@ from . import lstsq_utils
 
 # pylint: disable = bad-docstring-quotes
 @deprecate_function(
-    "The scipy lstsq tomography fitters have been deprecated and will "
-    "be removed in the 0.5.0 release. Use the `linear_lstsq`, "
-    "`cvxpy_linear_lstsq`, or `cvxpy_gaussian_lstsq` fitter instead."
+    "The scipy lstsq tomography fitters are deprecated as of 0.4 and will "
+    "be removed after the 0.5 release. Use the `linear_lstsq`, "
+    "`cvxpy_linear_lstsq`, or `cvxpy_gaussian_lstsq` fitters instead."
 )
 def scipy_linear_lstsq(
     outcome_data: np.ndarray,

--- a/qiskit_experiments/library/tomography/tomography_analysis.py
+++ b/qiskit_experiments/library/tomography/tomography_analysis.py
@@ -104,8 +104,8 @@ class TomographyAnalysis(BaseAnalysis):
             scipy_gaussian_lstsq,
         ]:
             warnings.warn(
-                "The scipy lstsq tomography fitters have been deprecated and will "
-                "be removed in the 0.5.0 release. Use the `linear_lstsq`, "
+                "The scipy lstsq tomography fitters are deprecated as of 0.4 and will "
+                "be removed after the 0.5 release. Use the `linear_lstsq`, "
                 "`cvxpy_linear_lstsq`, or `cvxpy_gaussian_lstsq` fitter instead.",
                 DeprecationWarning,
                 stacklevel=2,

--- a/qiskit_experiments/library/tomography/tomography_analysis.py
+++ b/qiskit_experiments/library/tomography/tomography_analysis.py
@@ -15,6 +15,7 @@ Quantum process tomography analysis
 
 
 from typing import List, Dict, Tuple, Union, Optional, Callable
+import warnings
 import functools
 import time
 import numpy as np
@@ -94,6 +95,22 @@ class TomographyAnalysis(BaseAnalysis):
         options.rescale_trace = True
         options.target = None
         return options
+
+    def set_options(self, **fields):
+        if fields.get("fitter", None) in [
+            "scipy_linear_lstsq",
+            "scipy_gaussian_lstsq",
+            scipy_linear_lstsq,
+            scipy_gaussian_lstsq,
+        ]:
+            warnings.warn(
+                "The scipy lstsq tomography fitters have been deprecated and will "
+                "be removed in the 0.5.0 release. Use the `linear_lstsq`, "
+                "`cvxpy_linear_lstsq`, or `cvxpy_gaussian_lstsq` fitter instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        super().set_options(**fields)
 
     @classmethod
     def _get_fitter(cls, fitter: Union[str, Callable]) -> Callable:

--- a/releasenotes/notes/tomography-fitters-4a12b2ca9dee2625.yaml
+++ b/releasenotes/notes/tomography-fitters-4a12b2ca9dee2625.yaml
@@ -5,9 +5,10 @@ deprecations:
     :class:`.StateTomographyAnalysis` and :class:`.ProcessTomographyAnalysis`
     classes have been deprecated.
 
-    The unconstrained least-squares fitting performed by ``scipy_linear_lstsq``
-    is equivalent to the :func:`.linear_inversion` fitter, but with worse
-    performance and memory usage. For weighted least-squares fitting the CVXPY
-    fitters :func:`.cvxpy_linear_lstsq` or :func:`.cvxpy_gaussian_lstsq` should
-    be used instead. The CVXPY fitters also support PSD and CPTP constraints
-    unlike the SciPy fitters.
+    The unweighted, unconstrained least-squares fitting performed by
+    ``scipy_linear_lstsq`` is equivalent to the :func:`.linear_inversion`
+    fitter, but with worse performance and memory usage.
+
+    For weighted least-squares fitting the CVXPY fitters
+    :func:`.cvxpy_linear_lstsq` or :func:`.cvxpy_gaussian_lstsq`, which also
+    support support PSD and CPTP constraints, should be used instead.

--- a/releasenotes/notes/tomography-fitters-4a12b2ca9dee2625.yaml
+++ b/releasenotes/notes/tomography-fitters-4a12b2ca9dee2625.yaml
@@ -1,0 +1,8 @@
+---
+deprecations:
+  - |
+    The ``scipy_linear_lstsq`` and ``scipy_gaussian_lstsq`` fitters of the
+    :class:`.StateTomographyAnalysis` and :class:`.ProcessTomographyAnalysis`
+    classes have been deprecated. The ``linear_inversion``, 
+    ``cvxpy_linear_lstsq`` or ``cvxpy_gaussian_lstsq`` fitters should be used
+    instead.

--- a/releasenotes/notes/tomography-fitters-4a12b2ca9dee2625.yaml
+++ b/releasenotes/notes/tomography-fitters-4a12b2ca9dee2625.yaml
@@ -1,8 +1,13 @@
 ---
 deprecations:
   - |
-    The ``scipy_linear_lstsq`` and ``scipy_gaussian_lstsq`` fitters of the
+    The ``scipy_linear_lstsq`` and ``scipy_gaussian_lstsq`` fitters for the
     :class:`.StateTomographyAnalysis` and :class:`.ProcessTomographyAnalysis`
-    classes have been deprecated. The ``linear_inversion``, 
-    ``cvxpy_linear_lstsq`` or ``cvxpy_gaussian_lstsq`` fitters should be used
-    instead.
+    classes have been deprecated.
+
+    The unconstrained least-squares fitting performed by ``scipy_linear_lstsq``
+    is equivalent to the :func:`.linear_inversion` fitter, but with worse
+    performance and memory usage. For weighted least-squares fitting the CVXPY
+    fitters :func:`.cvxpy_linear_lstsq` or :func:`.cvxpy_gaussian_lstsq` should
+    be used instead. The CVXPY fitters also support PSD and CPTP constraints
+    unlike the SciPy fitters.

--- a/test/tomography/tomo_utils.py
+++ b/test/tomography/tomo_utils.py
@@ -19,8 +19,6 @@ from qiskit import QuantumCircuit
 FITTERS = [
     None,
     "linear_inversion",
-    "scipy_linear_lstsq",
-    "scipy_gaussian_lstsq",
     "cvxpy_linear_lstsq",
     "cvxpy_gaussian_lstsq",
 ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Deprecates the scipy tomography fitters since they are strictly worse than using linear inversion (for faster performance) or cvxpy fitters (for PSD/CP/TP constraints).

### Details and comments


