### PR TITLE
Fix spelling mistakes in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Qiskit Experiments are documented below.
       * [Linking to issues](#linking-to-issues)
     - [Generating release notes](#generating-release-notes)
   + [Documentation](#documentation)
-    + [Experiment class documentation](#experiment-class-documenation)
+    + [Experiment class documentation](#experiment-class-documentation)
     + [Analysis class documentation](#analysis-class-documentation)
     + [Populating the table of contents](#populating-the-table-of-contents)
     + [Updating the tutorials](#updating-the-tutorials)
@@ -312,7 +312,7 @@ formatted in the same manner throughout our experiment library. You can use stan
 [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html)
 directives along with our syntax.
 
-#### Experiment class documenation
+#### Experiment class documentation
 
 You should complete or update the class documentation and method documentation for
 `_default_experiment_options`. You can use several predefined sections for the class docstring.
@@ -432,7 +432,7 @@ You can use the same syntax and section headers for the analysis class documenta
        variable names shown in analysis results. You can write symbol :math:`a` here too.
    
    # section: fit_parameters
-       Optional. Description for fit parametres in the model.
+       Optional. Description for fit parameters in the model.
        You can also write how initial guess is generated and how fit bound is determined.
        
        defpar a:

--- a/docs/tutorials/quantum_volume.rst
+++ b/docs/tutorials/quantum_volume.rst
@@ -78,7 +78,7 @@ Extra data included in the analysis results includes
 
 -  The number of trials and depth of the QV circuits
 
--  Whether the QV circuit was succesful
+-  Whether the QV circuit was successful
 
 .. jupyter-execute::
 
@@ -180,7 +180,7 @@ circuits, Phys. Rev. A 100, 032328 (2019).
 https://arxiv.org/pdf/1811.12926
 
 [2] Petar Jurcevic et. al. Demonstration of quantum volume 64 on
-asuperconducting quantum computing system,
+a superconducting quantum computing system,
 https://arxiv.org/pdf/2008.08571
 
 .. jupyter-execute::

--- a/docs/tutorials/randomized_benchmarking.rst
+++ b/docs/tutorials/randomized_benchmarking.rst
@@ -171,7 +171,7 @@ The EPGs of two-qubit RB are analyzed with the corrected EPC if available.
     seed = 1010
     qubits = (1, 4)
 
-    # Run a 1-qubit RB expriment on qubits 1, 4 to determine the error-per-gate of 1-qubit gates
+    # Run a 1-qubit RB experiment on qubits 1, 4 to determine the error-per-gate of 1-qubit gates
     single_exps = BatchExperiment(
         [
             StandardRB([qubit], lengths_1_qubit, num_samples=num_samples, seed=seed)

--- a/docs/tutorials/state_tomography.rst
+++ b/docs/tutorials/state_tomography.rst
@@ -112,8 +112,8 @@ Tomography Fitters
 
 The default fitters is ``linear_inversion``, which reconstructs the
 state using *dual basis* of the tomography basis. This will typically
-result in a non-postive reconstructed state. This state is rescaled to
-be postive-semidfinite (PSD) by computing its eigen-decomposition and
+result in a non-positive reconstructed state. This state is rescaled to
+be positive-semidefinite (PSD) by computing its eigen-decomposition and
 rescaling its eigenvalues using the approach from \*J Smolin, JM
 Gambetta, G Smith, Phys. Rev. Lett. 108, 070502 (2012), `open
 access <https://arxiv.org/abs/arXiv:1106.5458>`__.

--- a/docs/tutorials/t2hahn_characterization.rst
+++ b/docs/tutorials/t2hahn_characterization.rst
@@ -213,18 +213,18 @@ total delay time.
         readout0to1=[0.02],
         readout1to0=[0.02],)
     
-    # Analysis for Hahn Echo experiemnt with 0 echoes.
+    # Analysis for Hahn Echo experiment with 0 echoes.
     expdata2_0echoes = exp2_0echoes.run(backend=backend2, shots=2000, seed_simulator=101)
     expdata2_0echoes.block_for_results()  # Wait for job/analysis to finish.
     
-    # Analysis for Hahn Echo experiemnt with 1 echo
+    # Analysis for Hahn Echo experiment with 1 echo
     expdata2_1echoes = exp2_1echoes.run(backend=backend2, shots=2000, seed_simulator=101)
     expdata2_1echoes.block_for_results()  # Wait for job/analysis to finish.
     
     # Display the figure
     print("Hahn Echo with 0 echoes:")
     display(expdata2_0echoes.figure(0))
-    print("Hahn Echo with 1 echoe:")
+    print("Hahn Echo with 1 echo:")
     display(expdata2_1echoes.figure(0))
 
 

--- a/qiskit_experiments/library/characterization/analysis/tphi_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/tphi_analysis.py
@@ -40,7 +40,7 @@ class TphiAnalysis(CompositeAnalysis):
             or not isinstance(analyses[1], T2RamseyAnalysis)
         ):
             raise QiskitError(
-                "Invlaid component analyses for T2phi, analyses must be a pair of "
+                "Invalid component analyses for T2phi, analyses must be a pair of "
                 "T1Analysis and T2RamseyAnalysis instances."
             )
         super().__init__(analyses, flatten_results=True)

--- a/qiskit_experiments/library/characterization/fine_drag.py
+++ b/qiskit_experiments/library/characterization/fine_drag.py
@@ -67,7 +67,7 @@ class FineDrag(BaseExperiment, RestlessMixin):
         Here, the :math:`s` terms are coefficients of the expansion of an operator :math:`S(t)`
         that generates a transformation that keeps the qubit sub-space isolated from the
         higher-order states. :math:`t_g` is the gate time, :math:`\Omega_x(t)` is the pulse envelope
-        on the in-phase component of the drive and :math:`\lambda_1` is a parmeter of the Hamiltonian.
+        on the in-phase component of the drive and :math:`\lambda_1` is a parameter of the Hamiltonian.
         For additional details please see Ref. [2].
         As in Ref. [2] we now set :math:`s^{(1)}_{x,0,1}` and :math:`s^{(1)}_{z,1}` to zero
         and set :math:`s^{(1)}_{y,0,1}` to :math:`-\lambda_1^2 t_g\Omega_x(t)/8`. This

--- a/qiskit_experiments/library/quantum_volume/qv_analysis.py
+++ b/qiskit_experiments/library/quantum_volume/qv_analysis.py
@@ -117,7 +117,7 @@ class QuantumVolumeAnalysis(BaseAnalysis):
         Calculate the probability of measuring heavy output string in the data
 
         Args:
-            data (dict): the result of the circuit exectution
+            data (dict): the result of the circuit execution
             heavy_outputs (list): the bit strings of the heavy output from the ideal simulation
 
         Returns:
@@ -140,7 +140,7 @@ class QuantumVolumeAnalysis(BaseAnalysis):
             sigma (float): standard deviation
 
         Returns:
-            float: z_value in standard normal distibution.
+            float: z_value in standard normal distribution.
         """
 
         if sigma == 0:
@@ -161,7 +161,7 @@ class QuantumVolumeAnalysis(BaseAnalysis):
         where z = (X - mu)/sigma = (hmean - 2/3)/sigma
 
         Args:
-            z_value (float): z value in in standard normal distibution.
+            z_value (float): z value in in standard normal distribution.
 
         Returns:
             float: confidence level in decimal (not percentage).

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
@@ -81,7 +81,7 @@ class InterleavedRBAnalysis(curve.CurveAnalysis):
             bounds: [0, 1]
         defpar \alpha_c:
             desc: Ratio of the depolarizing parameter of interleaved RB to standard RB curve.
-            init_guess: Determined by alpha of interleaved RB curve devided by one of
+            init_guess: Determined by alpha of interleaved RB curve divided by one of
                 standard RB curve. Both alpha values are estimated by :func:`~rb_decay`.
             bounds: [0, 1]
 

--- a/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
@@ -27,7 +27,7 @@ from qiskit_experiments.framework.analysis_result import AnalysisResult
 if TYPE_CHECKING:
     from uncertainties import UFloat
 
-# A dictionary key of qubit aware quantum instruciton; type alias for better readability
+# A dictionary key of qubit aware quantum instruction; type alias for better readability
 QubitGateTuple = Tuple[Tuple[int, ...], str]
 
 
@@ -444,17 +444,17 @@ def _exclude_1q_error(
     """
     # Extract EPC of non-measured qubits from previous experiments
     epg_1qs = {}
-    for analyis_data in extra_analyses:
+    for analysis_data in extra_analyses:
         if (
-            not analyis_data.name.startswith("EPG_")
-            or len(analyis_data.device_components) > 1
-            or not str(analyis_data.device_components[0]).startswith("Q")
+            not analysis_data.name.startswith("EPG_")
+            or len(analysis_data.device_components) > 1
+            or not str(analysis_data.device_components[0]).startswith("Q")
         ):
             continue
-        qind = analyis_data.device_components[0]._index
-        gate = analyis_data.name[4:]
+        qind = analysis_data.device_components[0]._index
+        gate = analysis_data.name[4:]
         formatted_key = (qind,), gate
-        epg_1qs[formatted_key] = analyis_data.value
+        epg_1qs[formatted_key] = analysis_data.value
 
     if not epg_1qs:
         return epc

--- a/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
@@ -93,7 +93,7 @@ class RBAnalysis(curve.CurveAnalysis):
                 you can skip analysis of EPGs by setting this options to ``None``.
             epg_1_qubit (List[AnalysisResult]): Analysis results from previous RB experiments
                 for individual single qubit gates. If this is provided, EPC of
-                2Q RB is corected to exclude the deporalization of underlying 1Q channels.
+                2Q RB is corrected to exclude the depolarization of underlying 1Q channels.
         """
         default_options = super()._default_options()
         default_options.curve_drawer.set_options(
@@ -403,7 +403,7 @@ def _calculate_epg(
     gate_error_ratio: Dict[str, float],
     gate_counts_per_clifford: Dict[QubitGateTuple, float],
 ) -> Dict[str, Union[float, "UFloat"]]:
-    """A helper mehtod to compute EPGs of basis gates from fit EPC value.
+    """A helper method to compute EPGs of basis gates from fit EPC value.
 
     Args:
         epc: Error per Clifford.

--- a/qiskit_experiments/library/randomized_benchmarking/rb_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_utils.py
@@ -216,7 +216,7 @@ class RBUtils:
         Args:
             epc_1_qubit: The error per clifford rate obtained via experiment
             qubits: The qubits for which to compute epg
-            gate_error_ratio: Estiamte for the ratios between errors on different gates
+            gate_error_ratio: Estimate for the ratios between errors on different gates
             gates_per_clifford: The computed gates per clifford data
         Returns:
             A dictionary of the form (qubits, gate) -> value where value
@@ -256,7 +256,7 @@ class RBUtils:
         Args:
             epc_2_qubit: The error per clifford rate obtained via experiment
             qubits: The qubits for which to compute epg
-            gate_error_ratio: Estiamte for the ratios between errors on different gates
+            gate_error_ratio: Estimate for the ratios between errors on different gates
             gates_per_clifford: The computed gates per clifford data
             epg_1_qubit: analysis results containing EPG for the 1-qubits gate involved,
                 assumed to have been obtained from previous experiments

--- a/qiskit_experiments/library/randomized_benchmarking/rb_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_utils.py
@@ -33,7 +33,7 @@ class RBUtils:
     @deprecated_function(
         last_version="0.4",
         msg=(
-            "This method may return errorneous error ratio. "
+            "This method may return erroneous error ratio. "
             "Please directly provide known gate error ratio to the analysis option."
         ),
     )
@@ -72,7 +72,7 @@ class RBUtils:
     @deprecated_function(
         last_version="0.4",
         msg=(
-            "Now this method is integarated into 'StandardRB._transpiled_circuits' method. "
+            "Now this method is integrated into 'StandardRB._transpiled_circuits' method. "
             "You don't need to explicitly call this method."
         ),
     )

--- a/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
@@ -105,7 +105,7 @@ def cvxpy_linear_lstsq(
                             M measured qubits.
         preparation_qubits: Optional, the physical qubits that were prepared.
                             If None they are assumed to be ``[0, ..., N-1]`` for
-                            N preparated qubits.
+                            N prepared qubits.
         psd: If True rescale the eigenvalues of fitted matrix to be positive
              semidefinite (default: True)
         trace_preserving: Enforce the fitted matrix to be
@@ -243,7 +243,7 @@ def cvxpy_gaussian_lstsq(
                             M measured qubits.
         preparation_qubits: Optional, the physical qubits that were prepared.
                             If None they are assumed to be ``[0, ..., N-1]`` for
-                            N preparated qubits.
+                            N prepared qubits.
         psd: If True rescale the eigenvalues of fitted matrix to be positive
              semidefinite (default: True)
         trace_preserving: Enforce the fitted matrix to be

--- a/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
@@ -139,7 +139,7 @@ def cvxpy_linear_lstsq(
         probability_data = weights * probability_data
 
     # Since CVXPY only works with real variables we must specify the real
-    # and imaginary parts of rho seperately: rho = rho_r + 1j * rho_i
+    # and imaginary parts of rho separately: rho = rho_r + 1j * rho_i
 
     dim = int(np.sqrt(basis_matrix.shape[1]))
     rho_r, rho_i, cons = cvxpy_utils.complex_matrix_variable(
@@ -147,7 +147,7 @@ def cvxpy_linear_lstsq(
     )
 
     # Trace preserving constraint when fitting Choi-matrices for
-    # quantum process tomography. Note that this adds an implicity
+    # quantum process tomography. Note that this adds an implicitly
     # trace constraint of trace(rho) = sqrt(len(rho)) = dim
     # if a different trace constraint is specified above this will
     # cause the fitter to fail.

--- a/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """
-Contrained convex least-squares tomography fitter.
+Constrained convex least-squares tomography fitter.
 """
 
 from typing import Optional, Dict, Tuple
@@ -57,11 +57,11 @@ def cvxpy_linear_lstsq(
         subject to
 
         - *Positive-semidefinite* (``psd=True``): :math:`\rho \gg 0` is constrained
-          to be a postive-semidefinite matrix.
-        - *Trace* (``trace=t``): :math:`\mbox{Tr}(\rho) = t` is constained to have
+          to be a positive-semidefinite matrix.
+        - *Trace* (``trace=t``): :math:`\mbox{Tr}(\rho) = t` is constrained to have
           the specified trace.
         - *Trace preserving* (``trace_preserving=True``): When performing process
-          tomography the Choi-state :math:`\rho` represents is contstained to be
+          tomography the Choi-state :math:`\rho` represents is constrained to be
           trace preserving.
 
         where

--- a/qiskit_experiments/library/tomography/fitters/lininv.py
+++ b/qiskit_experiments/library/tomography/fitters/lininv.py
@@ -96,7 +96,7 @@ def linear_inversion(
                             M measured qubits.
         preparation_qubits: Optional, the physical qubits that were prepared.
                             If None they are assumed to be [0, ..., N-1] for
-                            N preparated qubits.
+                            N prepared qubits.
 
     Raises:
         AnalysisError: If the fitted vector is not a square matrix

--- a/qiskit_experiments/library/tomography/fitters/lininv.py
+++ b/qiskit_experiments/library/tomography/fitters/lininv.py
@@ -51,7 +51,7 @@ def linear_inversion(
         * :math:`A = \sum_j |j \rangle\!\langle\!\langle E_j|` is the matrix of measured
           basis elements.
         * :math:`y = \sum_j \hat{p}_j |j\rangle` is the vector of estimated measurement
-          outcome probabilites for each basis element.
+          outcome probabilities for each basis element.
         * :math:`x = |\rho\rangle\!\rangle` is the vectorized density matrix.
 
     Additional Details

--- a/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
@@ -80,7 +80,7 @@ def scipy_linear_lstsq(
                             M measured qubits.
         preparation_qubits: Optional, the physical qubits that were prepared.
                             If None they are assumed to be ``[0, ..., N-1]`` for
-                            N preparated qubits.
+                            N prepared qubits.
         weights: Optional array of weights for least squares objective.
         kwargs: additional kwargs for :func:`scipy.linalg.lstsq`.
 
@@ -175,7 +175,7 @@ def scipy_gaussian_lstsq(
                             M measured qubits.
         preparation_qubits: Optional, the physical qubits that were prepared.
                             If None they are assumed to be ``[0, ..., N-1]`` for
-                            N preparated qubits.
+                            N prepared qubits.
         kwargs: additional kwargs for :func:`scipy.linalg.lstsq`.
 
     Raises:

--- a/qiskit_experiments/library/tomography/tomography_analysis.py
+++ b/qiskit_experiments/library/tomography/tomography_analysis.py
@@ -71,7 +71,7 @@ class TomographyAnalysis(BaseAnalysis):
                 supply a custom fitter function. See the `Fitter Functions` section for
                 additional information.
             fitter_options (dict): Any addition kwarg options to be supplied to the fitter
-                function. For documentation of available kargs refer to the fitter function
+                function. For documentation of available kwargs refer to the fitter function
                 documentation.
             rescale_positive (bool): If True rescale the state returned by the fitter
                 to be positive-semidefinite. See the `PSD Rescaling` section for
@@ -130,7 +130,7 @@ class TomographyAnalysis(BaseAnalysis):
         if measurement_qubits is None:
             measurement_qubits = tuple(range(measurement_data.shape[1]))
 
-        # Get dimension of the preparation and measurement qubits subystems
+        # Get dimension of the preparation and measurement qubits subsystems
         prep_dims = (1,)
         if preparation_qubits:
             prep_dims = preparation_basis.matrix_shape(preparation_qubits)

--- a/qiskit_experiments/library/tomography/tomography_analysis.py
+++ b/qiskit_experiments/library/tomography/tomography_analysis.py
@@ -501,7 +501,7 @@ def _int_outcome_function(outcome_shape: Tuple[int, ...]) -> Callable:
         base = outcome_shape[0]
         return lambda outcome: int(outcome, base)
 
-    # General function where each dit could be a differnet base
+    # General function where each dit could be a different base
     @functools.lru_cache(2048)
     def _int_outcome_general(outcome: str):
         """Convert a general dit-string outcome to integer"""

--- a/qiskit_experiments/test/__init__.py
+++ b/qiskit_experiments/test/__init__.py
@@ -12,7 +12,7 @@
 
 """
 =================================================================
-Qiskit Experiments Test Utilties (:mod:`qiskit_experiments.test`)
+Qiskit Experiments Test Utilities (:mod:`qiskit_experiments.test`)
 =================================================================
 
 .. currentmodule:: qiskit_experiments.test

--- a/qiskit_experiments/test/fake_service.py
+++ b/qiskit_experiments/test/fake_service.py
@@ -132,7 +132,7 @@ class FakeService:
         # share_level - not a parameter of `DatabaseService.create_experiment` but a parameter of
         #    `IBMExperimentService.create_experiment`. It must be supported because it is used
         #    in `DbExperimentData`.
-        # device_components - the user speicifies the device components when adding a result
+        # device_components - the user specifies the device components when adding a result
         #    (this is not a local decision of the fake service but the interface of DatabaseService
         #    and IBMExperimentService). The components of the different results of the same
         #    experiment are aggregated here in the device_components column.
@@ -145,7 +145,7 @@ class FakeService:
         # figure_names - the fake service currently does not support figures. The column
         #    (degenerated to []) is required to prevent a flaw in the work with DbExperimentData.
         # backend - the query methods `experiment` and `experiments` are supposed to return an
-        #    an instansiated backend object, and not only the backend name. We assume that the fake
+        #    an instantiated backend object, and not only the backend name. We assume that the fake
         #    service works with the fake backend (class FakeBackend).
         self.exps = pd.concat(
             [
@@ -482,7 +482,7 @@ class FakeService:
         return df.to_dict("records")
 
     def delete_analysis_result(self, result_id: str) -> None:
-        """Deletes an anylsis result"""
+        """Deletes an analysis result"""
         if result_id not in self.results.result_id.values:
             return
 
@@ -517,5 +517,5 @@ class FakeService:
 
     @property
     def preferences(self) -> Dict:
-        """Returns the db service prefrences"""
+        """Returns the db service preferences"""
         return {"auto_save": False}

--- a/qiskit_experiments/test/fake_service.py
+++ b/qiskit_experiments/test/fake_service.py
@@ -427,8 +427,8 @@ class FakeService:
         # pylint: disable = unused-argument
         df = self.results
 
-        # TODO: skipping device components for now until we conslidate more with the provider service
-        # (in the qiskit-experiments service there is no opertor for device components,
+        # TODO: skipping device components for now until we consolidate more with the provider service
+        # (in the qiskit-experiments service there is no operator for device components,
         # so the specification for filtering is not clearly defined)
 
         if experiment_id is not None:

--- a/qiskit_experiments/test/mock_iq_helpers.py
+++ b/qiskit_experiments/test/mock_iq_helpers.py
@@ -591,7 +591,7 @@ class MockIQFineFreqHelper(MockIQExperimentHelper):
         """
         Args:
             sx_duration: duration of the single-qubit sx gate.
-            freq_shift: the detunning from the ideal frequency that this mock backend will mimic.
+            freq_shift: the detuning from the ideal frequency that this mock backend will mimic.
             dt: duration of a sample.
         """
         super().__init__(iq_cluster_centers, iq_cluster_width)

--- a/test/base.py
+++ b/test/base.py
@@ -109,7 +109,7 @@ class QiskitExperimentsTestCase(QiskitTestCase):
     def json_equiv(cls, data1, data2) -> bool:
         """Check if two experiments are equivalent by comparing their configs"""
         # pylint: disable = too-many-return-statements
-        configrable_type = (BaseExperiment, BaseAnalysis, BaseCurveDrawer)
+        configurable_type = (BaseExperiment, BaseAnalysis, BaseCurveDrawer)
         compare_repr = (DataAction, DataProcessor)
         list_type = (list, tuple, set)
         skipped = tuple()
@@ -117,7 +117,7 @@ class QiskitExperimentsTestCase(QiskitTestCase):
         if isinstance(data1, skipped) and isinstance(data2, skipped):
             warnings.warn(f"Equivalence check for data {data1.__class__.__name__} is skipped.")
             return True
-        elif isinstance(data1, configrable_type) and isinstance(data2, configrable_type):
+        elif isinstance(data1, configurable_type) and isinstance(data2, configurable_type):
             return cls.json_equiv(data1.config(), data2.config())
         elif dataclasses.is_dataclass(data1) and dataclasses.is_dataclass(data2):
             # not using asdict. this copies all objects.
@@ -198,7 +198,7 @@ class QiskitExperimentsTestCase(QiskitTestCase):
     def experiment_data_equiv(cls, data1, data2):
         """Check two experiment data containers are equivalent"""
 
-        # Check basic attrbiutes
+        # Check basic attributes
         # Skip non-compatible backend
         for att in [
             "experiment_id",
@@ -236,7 +236,7 @@ class QiskitExperimentsTestCase(QiskitTestCase):
         if not cls.json_equiv(data1.data(), data2.data()):
             return False
 
-        # Check analysis resultsx
+        # Check analysis results
         for result1, result2 in zip(data1.analysis_results(), data2.analysis_results()):
             if not cls.analysis_result_equiv(result1, result2):
                 return False

--- a/test/calibration/test_calibrations.py
+++ b/test/calibration/test_calibrations.py
@@ -1347,7 +1347,7 @@ class TestFiltering(QiskitExperimentsTestCase):
         self.assertTrue(table["data"][0]["value"], 0.2)
 
     def test_get_parameter_value(self):
-        """Test that getting parameter values funcions properly."""
+        """Test that getting parameter values functions properly."""
 
         amp = self.cals.get_parameter_value(self.amp, (0,), "xp")
         self.assertEqual(amp, 0.2)
@@ -1601,8 +1601,8 @@ class TestInstructionScheduleMap(QiskitExperimentsTestCase):
         We use FakeBelem which has a linear coupling map and will restrict ourselves to
         qubits 0, 1, and 2. The Cals will define a template schedule for CX and CZ. We will
         mock this with GaussianSquare and Gaussian pulses since the nature of the schedules
-        is irrelevant here. The parameters for CX will only have values for qubis 0 and 1 while
-        the parameters for CZ will only have values for qubis 1 and 2. We therefore will have
+        is irrelevant here. The parameters for CX will only have values for qubits 0 and 1 while
+        the parameters for CZ will only have values for qubits 1 and 2. We therefore will have
         a CX on qubits 0, 1 in the inst. map and a CZ on qubits 1, 2.
         """
 

--- a/test/database_service/test_fitval.py
+++ b/test/database_service/test_fitval.py
@@ -29,7 +29,7 @@ from qiskit_experiments.framework import ExperimentDecoder
 class TestFitVal(QiskitExperimentsTestCase):
     """Test for serialization."""
 
-    __signle_value__ = [
+    __signal_value__ = [
         [3.0123, 0.001, "s"],
         [2, 0, "m"],
         [-5.678, 0.02, "g"],
@@ -45,7 +45,7 @@ class TestFitVal(QiskitExperimentsTestCase):
 
         self.assertIsInstance(instance, uncertainties.core.Variable)
 
-    @data(*__signle_value__)
+    @data(*__signal_value__)
     def test_can_load(self, val):
         """Test if we can still load cache data from old Qiskit Experiments."""
         value, stderr, unit = val
@@ -84,7 +84,7 @@ class TestFitVal(QiskitExperimentsTestCase):
         self.assertEqual(loaded_val.std_dev, stderr)
         self.assertEqual(loaded_val.tag, unit)
 
-    @data(*__signle_value__)
+    @data(*__signal_value__)
     def test_can_access(self, val):
         """Test if we can still use old properties."""
         with self.assertWarns(FutureWarning):

--- a/test/randomized_benchmarking/test_randomized_benchmarking.py
+++ b/test/randomized_benchmarking/test_randomized_benchmarking.py
@@ -443,9 +443,9 @@ class TestInterleavedRB(RBTestCase):
 
 
 class TestEPGAnalysis(QiskitExperimentsTestCase):
-    """Test case for EPG colculation from EPC.
+    """Test case for EPG calculation from EPC.
 
-    EPG and depplarizing probability p are assumed to have following relationship
+    EPG and depolarizing probability p are assumed to have following relationship
 
         EPG = (2^n - 1) / 2^n · p
 

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -239,7 +239,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         self.assertEqual(new_instance.parent_id, None)
 
     def test_composite_copy_analysis_ref(self):
-        """Test copy of composite expeirment preserves component analysis refs"""
+        """Test copy of composite experiment preserves component analysis refs"""
 
         class Analysis(FakeAnalysis):
             """Fake analysis class with options"""
@@ -441,7 +441,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
 
         class Backend(FakeBackend):
             """
-            Bacekend to be used in test_composite_subexp_data
+            Backend to be used in test_composite_subexp_data
             """
 
             def run(self, run_input, **options):
@@ -796,7 +796,7 @@ class TestBatchTranspileOptions(QiskitExperimentsTestCase):
 
     def test_batch_transpile_options_integrated(self):
         """
-        The goal is to verify that not only `_trasnpiled_circuits` works well
+        The goal is to verify that not only `_transpiled_circuits` works well
         (`test_batch_transpiled_circuits` takes care of it) but that it's correctly called within
         the entire flow of `BaseExperiment.run`.
         """

--- a/test/test_composite.py
+++ b/test/test_composite.py
@@ -104,7 +104,7 @@ class TestComposite(QiskitExperimentsTestCase):
         )
         expdata = comp_exp.run(FakeBackend())
         self.assertExperimentDone(expdata)
-        # Check out experiment wasnt flattened
+        # Check out experiment wasn't flattened
         self.assertEqual(len(expdata.child_data()), 2)
         self.assertEqual(len(expdata.analysis_results()), 0)
 

--- a/test/test_cross_resonance_hamiltonian.py
+++ b/test/test_cross_resonance_hamiltonian.py
@@ -29,7 +29,7 @@ class SimulatableCRGate(HamiltonianGate):
     """Cross resonance unitary that can be simulated with Aer simulator."""
 
     def __init__(self, width, t_off, wix, wiy, wiz, wzx, wzy, wzz, dt=1e-9):
-        # Note that Qiskit is Little endien, i.e. [q1, q0]
+        # Note that Qiskit is Little endian, i.e. [q1, q0]
         hamiltonian = (
             wix * qi.Operator.from_label("XI") / 2
             + wiy * qi.Operator.from_label("YI") / 2
@@ -65,20 +65,20 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
         )
         expr.backend = backend
 
-        nearlest_16 = 1248
+        nearest_16 = 1248
 
         with pulse.build(default_alignment="left", name="cr") as ref_cr_sched:
             pulse.play(
                 pulse.GaussianSquare(
-                    nearlest_16,
+                    nearest_16,
                     amp=0.1,
                     sigma=64,
                     width=1000,
                 ),
                 pulse.ControlChannel(0),
             )
-            pulse.delay(nearlest_16, pulse.DriveChannel(0))
-            pulse.delay(nearlest_16, pulse.DriveChannel(1))
+            pulse.delay(nearest_16, pulse.DriveChannel(0))
+            pulse.delay(nearest_16, pulse.DriveChannel(1))
 
         cr_gate = cr_hamiltonian.CrossResonanceHamiltonian.CRPulseGate(width=1000)
         expr_circs = expr.circuits()

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -46,7 +46,7 @@ class TestFramework(QiskitExperimentsTestCase):
         self.assertExperimentDone(expdata)
         job_ids = expdata.job_ids
 
-        # Comptue expected number of jobs
+        # Compute expected number of jobs
         if max_experiments is None:
             num_jobs = 1
         else:

--- a/test/test_resonator_spectroscopy.py
+++ b/test/test_resonator_spectroscopy.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Spectroscopy tests for resonator spectroscop experiment."""
+"""Spectroscopy tests for resonator spectroscopy experiment."""
 
 from test.base import QiskitExperimentsTestCase
 import numpy as np


### PR DESCRIPTION
### Summary

There are some spelling mistakes in the docstrings, documentation, and code for the latest commit of Qiskit Experiments. This PR corrects these errors.

### Details and comments

Words were checked against en_GB and en_US, but some mixed usage still exists. This appears to be consistent with the rest of Qiskit documentation, where some en_GB wording exists alongside en_US. There are two _corrections_ which I am not fully confident with, as they may be different words that are context specific. I have highlighted them as comments in this PR and quoted them below.

- `kargs` to `kwargs` which I assumed stood for “keyword arguments”. My understanding is that the standard in Python is to name these `kwargs`.
- `signle` to `signal` instead of `single`? Here I am not sure about which was intended, but `signal` made more sense for me.
