### PR TITLE
Fix outdated python version strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,34 +106,33 @@ an isolated virtualenv for running tests. This means it does not pollute your sy
 python when running. Additionally, the environment that tox sets up matches the CI
 environment more closely and it runs the tests in parallel (resulting in much faster
 execution). To run tests on all installed supported python versions and lint/style
-checks you can simply run `tox`. Or if you just want to run the tests once run for a
-specific python version: `tox -epy37` (or replace py37 with the python version you want
-to use, py35 or py36).
+checks you can simply run `tox`. Or if you just want to run the tests once for a
+specific python version such as 3.10: `tox -epy310`.
 
 If you just want to run a subset of tests you can pass a selection regex to the test
 runner. For example, if you want to run all tests that have "dag" in the test id you can
-run: `tox -epy37 -- dag`. You can pass arguments directly to the test runner after the
+run: `tox -- dag`. You can pass arguments directly to the test runner after the
 bare `--`. To see all the options on test selection you can refer to the stestr manual:
 https://stestr.readthedocs.io/en/stable/MANUAL.html#test-selection
 
 If you want to run a single test module, test class, or individual test method you can
 do this faster with the `-n`/`--no-discover` option. For example, to run a module:
 ```
-tox -epy37 -- -n test.python.test_examples
+tox -- -n test.python.test_examples
 ```
 Or to run the same module by path:
 
 ```
-tox -epy37 -- -n test/python/test_examples.py
+tox -- -n test/python/test_examples.py
 ```
 To run a class:
 
 ```
-tox -epy37 -- -n test.python.test_examples.TestPythonExamples
+tox -- -n test.python.test_examples.TestPythonExamples
 ```
 To run a method:
 ```
-tox -epy37 -- -n test.python.test_examples.TestPythonExamples.test_all_examples
+tox -- -n test.python.test_examples.TestPythonExamples.test_all_examples
 ```
 
 #### STDOUT/STDERR and logging capture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@ requires = ["setuptools", "wheel"]
 
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38', 'py39', 'py310']

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py39,py38,py37,py36,lint
+envlist = py310,py39,py38,py37,lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Python 3.6 support was already dropped, but some files haven't been updated. Now the supported Python versions should be 3.7-3.10 everywhere.