### PR TITLE
Fix simulator seed

### DIFF
--- a/test/randomized_benchmarking/test_randomized_benchmarking.py
+++ b/test/randomized_benchmarking/test_randomized_benchmarking.py
@@ -180,6 +180,8 @@ class TestStandardRB(RBTestCase):
             num_samples=5,
         )
         exp.set_transpile_options(basis_gates=["x", "sx", "rz"], optimization_level=1)
+        # Simulator seed must be fixed. This can be set via run option with FakeBackend.
+        exp.set_run_options(seed_simulator=456)
         expdata = exp.run()
         self.assertExperimentDone(expdata)
 

--- a/test/randomized_benchmarking/test_randomized_benchmarking.py
+++ b/test/randomized_benchmarking/test_randomized_benchmarking.py
@@ -181,6 +181,7 @@ class TestStandardRB(RBTestCase):
         )
         exp.set_transpile_options(basis_gates=["x", "sx", "rz"], optimization_level=1)
         # Simulator seed must be fixed. This can be set via run option with FakeBackend.
+        # pylint: disable=no-member
         exp.set_run_options(seed_simulator=456)
         expdata = exp.run()
         self.assertExperimentDone(expdata)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR updates `test_poor_experiment_result` unittest with the fixed simulator seed. This test sometimes (randomly) fails because of the random change of simulated outcomes. When we use a fake backend for test, we must provide `simulator_seed` option to run options.

### Details and comments


