### PR TITLE
Fix performance regression in 3 or more qubits RB

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -38,7 +38,7 @@ from .rb_analysis import RBAnalysis
 LOG = logging.getLogger(__name__)
 
 
-SequenceElementType = Union[Clifford, Integral]
+SequenceElementType = Union[Clifford, Integral, QuantumCircuit]
 
 
 class StandardRB(BaseExperiment, RestlessMixin):
@@ -200,8 +200,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
                 circ.barrier(qubits)
 
             # Compute inverse, compute only the difference from the previous shorter sequence
-            for elem in seq[len(prev_seq) :]:
-                prev_elem = self.__compose_clifford(prev_elem, elem)
+            prev_elem = self.__compose_clifford_seq(prev_elem, seq[len(prev_seq) :])
             prev_seq = seq
             inv = self.__adjoint_clifford(prev_elem)
 
@@ -212,13 +211,14 @@ class StandardRB(BaseExperiment, RestlessMixin):
 
     def __sample_sequence(self, length: int, rng: Generator) -> Sequence[SequenceElementType]:
         # Sample a RB sequence with the given length.
-        # Return integer instead of Clifford object for 1 or 2 qubit case for speed
+        # Return integer instead of Clifford object for 1 or 2 qubits case for speed
         if self.num_qubits == 1:
             return rng.integers(24, size=length)
         if self.num_qubits == 2:
             return rng.integers(11520, size=length)
-
-        return [random_clifford(self.num_qubits, rng) for _ in range(length)]
+        # Return circuit object instead of Clifford object for 3 or more qubits case for speed
+        # TODO: Revisit after terra#7269, #7483, #8585
+        return [random_clifford(self.num_qubits, rng).to_circuit() for _ in range(length)]
 
     def _to_instruction(self, elem: SequenceElementType) -> Instruction:
         # TODO: basis transformation in 1Q (and 2Q) cases for speed
@@ -234,6 +234,21 @@ class StandardRB(BaseExperiment, RestlessMixin):
         if self.num_qubits <= 2:
             return 0
         return Clifford(np.eye(2 * self.num_qubits))
+
+    def __compose_clifford_seq(
+        self, org: SequenceElementType, seq: Sequence[SequenceElementType]
+    ) -> SequenceElementType:
+        if self.num_qubits <= 2:
+            new = org
+            for elem in seq:
+                new = self.__compose_clifford(new, elem)
+            return new
+        # 3 or more qubits: compose Clifford from circuits for speed
+        # TODO: Revisit after terra#7269, #7483, #8585
+        circ = QuantumCircuit(self.num_qubits)
+        for elem in seq:
+            circ.compose(elem, inplace=True)
+        return org.compose(Clifford.from_circuit(circ))
 
     def __compose_clifford(
         self, lop: SequenceElementType, rop: SequenceElementType
@@ -260,6 +275,8 @@ class StandardRB(BaseExperiment, RestlessMixin):
                 return CliffordUtils.clifford_1_qubit(op).adjoint()
             if self.num_qubits == 2:
                 return CliffordUtils.clifford_2_qubit(op).adjoint()
+        if isinstance(op, QuantumCircuit):
+            return Clifford.from_circuit(op).adjoint()
         return op.adjoint()
 
     def _transpiled_circuits(self) -> List[QuantumCircuit]:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix the performance regression of RB for 3 or more qubits Cliffords, which was introduced in the recent refactoring of RB module #898


### Details and comments
Change back to avoid using slow `Clifford.compose` as much as possible and use faster `QuantumCircuit.compose` and `Clifford.from_circuit` instead for 3 or more qubits Cliffords, that was the technique used in the original code before #898 but missed to be included in #898.

As shown in the table below, this PR recovers the original performance. ([Code to measure the performance of 3Q RB](https://gist.github.com/itoko/bf08ef3b65da00abbf8f343a8931ce23))
```
[after-this-PR]
    full_sampling          backend  max_length  num_samples                    method    seconds  num_runs
0           False      fake_manila          20            3             time_circuits   1.661291         1
1           False      fake_manila          20            3  time_transpiled_circuits   4.292393         1
2           False      fake_manila          20            6             time_circuits   3.375736         1
3           False      fake_manila          20            6  time_transpiled_circuits   7.549929         1
4           False      fake_manila          40            3             time_circuits   2.772556         1
5           False      fake_manila          40            3  time_transpiled_circuits   6.404932         1
6           False      fake_manila          40            6             time_circuits   5.390166         1
7           False      fake_manila          40            6  time_transpiled_circuits  12.694415         1
8           False      fake_mumbai          20            3             time_circuits   1.630835         1
9           False      fake_mumbai          20            3  time_transpiled_circuits   5.511165         1
10          False      fake_mumbai          20            6             time_circuits   3.343967         1
11          False      fake_mumbai          20            6  time_transpiled_circuits  10.307006         1
12          False      fake_mumbai          40            3             time_circuits   2.551411         1
13          False      fake_mumbai          40            3  time_transpiled_circuits   8.743302         1
14          False      fake_mumbai          40            6             time_circuits   5.347619         1
15          False      fake_mumbai          40            6  time_transpiled_circuits  17.490494         1
16          False  fake_washington          20            3             time_circuits   1.590835         1
17          False  fake_washington          20            3  time_transpiled_circuits  15.676607         1
18          False  fake_washington          20            6             time_circuits   3.243143         1
19          False  fake_washington          20            6  time_transpiled_circuits  23.216102         1
20          False  fake_washington          40            3             time_circuits   2.629359         1
21          False  fake_washington          40            3  time_transpiled_circuits  20.105627         1
22          False  fake_washington          40            6             time_circuits   5.276347         1
23          False  fake_washington          40            6  time_transpiled_circuits  41.768356         1

[main]
    full_sampling          backend  max_length  num_samples                    method    seconds  num_runs
0           False      fake_manila          20            3             time_circuits   6.361049         1
1           False      fake_manila          20            3  time_transpiled_circuits   9.400935         1
2           False      fake_manila          20            6             time_circuits  13.168127         1
3           False      fake_manila          20            6  time_transpiled_circuits  17.275917         1
4           False      fake_manila          40            3             time_circuits  10.803795         1
5           False      fake_manila          40            3  time_transpiled_circuits  14.360775         1
6           False      fake_manila          40            6             time_circuits  21.231920         1
7           False      fake_manila          40            6  time_transpiled_circuits  32.218625         1
8           False      fake_mumbai          20            3             time_circuits   6.478630         1
9           False      fake_mumbai          20            3  time_transpiled_circuits  10.717985         1
10          False      fake_mumbai          20            6             time_circuits  12.797258         1
11          False      fake_mumbai          20            6  time_transpiled_circuits  20.825657         1
12          False      fake_mumbai          40            3             time_circuits  11.569653         1
13          False      fake_mumbai          40            3  time_transpiled_circuits  18.167764         1
14          False      fake_mumbai          40            6             time_circuits  23.377687         1
15          False      fake_mumbai          40            6  time_transpiled_circuits  35.131031         1
16          False  fake_washington          20            3             time_circuits   5.729617         1
17          False  fake_washington          20            3  time_transpiled_circuits  21.061335         1
18          False  fake_washington          20            6             time_circuits  11.404692         1
19          False  fake_washington          20            6  time_transpiled_circuits  33.093630         1
20          False  fake_washington          40            3             time_circuits  10.356137         1
21          False  fake_washington          40            3  time_transpiled_circuits  32.811150         1
22          False  fake_washington          40            6             time_circuits  24.519854         1
23          False  fake_washington          40            6  time_transpiled_circuits  65.782916         1

[before-898]
    full_sampling          backend  max_length  num_samples                    method    seconds  num_runs
0           False      fake_manila          20            3             time_circuits   1.239760         1
1           False      fake_manila          20            3  time_transpiled_circuits   4.570645         1
2           False      fake_manila          20            6             time_circuits   2.490214         1
3           False      fake_manila          20            6  time_transpiled_circuits   8.229670         1
4           False      fake_manila          40            3             time_circuits   2.401180         1
5           False      fake_manila          40            3  time_transpiled_circuits   7.136153         1
6           False      fake_manila          40            6             time_circuits   4.711962         1
7           False      fake_manila          40            6  time_transpiled_circuits  13.858979         1
8           False      fake_mumbai          20            3             time_circuits   1.182070         1
9           False      fake_mumbai          20            3  time_transpiled_circuits   5.678319         1
10          False      fake_mumbai          20            6             time_circuits   2.271423         1
11          False      fake_mumbai          20            6  time_transpiled_circuits  10.940199         1
12          False      fake_mumbai          40            3             time_circuits   2.332980         1
13          False      fake_mumbai          40            3  time_transpiled_circuits   9.905238         1
14          False      fake_mumbai          40            6             time_circuits   4.764303         1
15          False      fake_mumbai          40            6  time_transpiled_circuits  19.541976         1
16          False  fake_washington          20            3             time_circuits   1.219157         1
17          False  fake_washington          20            3  time_transpiled_circuits  16.669695         1
18          False  fake_washington          20            6             time_circuits   2.551022         1
19          False  fake_washington          20            6  time_transpiled_circuits  25.928957         1
20          False  fake_washington          40            3             time_circuits   2.294674         1
21          False  fake_washington          40            3  time_transpiled_circuits  21.894724         1
22          False  fake_washington          40            6             time_circuits   4.168826         1
23          False  fake_washington          40            6  time_transpiled_circuits  44.483864         1
```

