### PR TITLE
Fix broken tests using deprecated matplotlib function from 3.6.0 (closes #909)

### DIFF
--- a/qiskit_experiments/curve_analysis/visualization/mpl_drawer.py
+++ b/qiskit_experiments/curve_analysis/visualization/mpl_drawer.py
@@ -191,12 +191,21 @@ class MplCurveDrawer(BaseCurveDrawer):
 
             # Auto-scale all axes to the first sub axis
             if ax_type == "x":
-                all_axes[0].get_shared_x_axes().join(*all_axes)
+                # get_shared_y_axes() is immutable from matplotlib>=3.6.0. Must use Axis.sharey()
+                # instead, but this can only be called once per axis. Here we call sharey  on all axes in
+                # a chain, which should have the same effect.
+                if len(all_axes) > 1:
+                    for ax1, ax2 in zip(all_axes[1:],all_axes[0:-1]):
+                        ax1.sharex(ax2)
                 all_axes[0].set_xlim(lim)
             else:
-                all_axes[0].get_shared_y_axes().join(*all_axes)
+                # get_shared_y_axes() is immutable from matplotlib>=3.6.0. Must use Axis.sharey()
+                # instead, but this can only be called once per axis. Here we call sharey  on all axes in
+                # a chain, which should have the same effect.
+                if len(all_axes) > 1:
+                    for ax1, ax2 in zip(all_axes[1:],all_axes[0:-1]):
+                        ax1.sharey(ax2)
                 all_axes[0].set_ylim(lim)
-
         # Add title
         if self.options.figure_title is not None:
             self._axis.set_title(

--- a/qiskit_experiments/curve_analysis/visualization/mpl_drawer.py
+++ b/qiskit_experiments/curve_analysis/visualization/mpl_drawer.py
@@ -195,7 +195,7 @@ class MplCurveDrawer(BaseCurveDrawer):
                 # instead, but this can only be called once per axis. Here we call sharey  on all axes in
                 # a chain, which should have the same effect.
                 if len(all_axes) > 1:
-                    for ax1, ax2 in zip(all_axes[1:],all_axes[0:-1]):
+                    for ax1, ax2 in zip(all_axes[1:], all_axes[0:-1]):
                         ax1.sharex(ax2)
                 all_axes[0].set_xlim(lim)
             else:
@@ -203,7 +203,7 @@ class MplCurveDrawer(BaseCurveDrawer):
                 # instead, but this can only be called once per axis. Here we call sharey  on all axes in
                 # a chain, which should have the same effect.
                 if len(all_axes) > 1:
-                    for ax1, ax2 in zip(all_axes[1:],all_axes[0:-1]):
+                    for ax1, ax2 in zip(all_axes[1:], all_axes[0:-1]):
                         ax1.sharey(ax2)
                 all_axes[0].set_ylim(lim)
         # Add title

--- a/releasenotes/notes/fix-matplotlib-3.6.0-failing-test-5a747f61a9c357b4.yaml
+++ b/releasenotes/notes/fix-matplotlib-3.6.0-failing-test-5a747f61a9c357b4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix a bug where :class:`CurveAnalysis` tests would fail with matplotlib 3.6.0 owing to a deprecated
+    function call used in :class:`MplCurveDrawer`. The new :class:`MplCurveDrawer` no-longer uses the
+    deprecated function.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ scipy>=1.4
 qiskit-terra>=0.21.1
 qiskit-ibmq-provider>=0.16.0
 qiskit-ibm-experiment>=0.2.5
-# FIXME: Remove maximum version once bugs discussed in #909, #910, #911 have been fixed.
-matplotlib>=3.4,<3.6
+matplotlib>=3.4
 uncertainties
 lmfit


### PR DESCRIPTION
### Summary

Matplotlib 3.6.0 deprecates `join()` for `Grouper`, which is returned by `get_shared_{x,y}_axes()`. This means a deprecation warning is raised by `MplCurveDrawer`, which causes some tests to fail. See #909 for more.

### Details and comments

This PR fixes #909 as described in the issue. I have confirmed the tests pass locally on my machine (macOS Intel, Python 3.9).


_Pinging relevant people_
@wshanks @nkanazawa1989 