### PR TITLE
Fix failing tests by pinning matplotlib to <3.6.0 and Qiskit Aer to <0.11.0

### DIFF
--- a/releasenotes/notes/fix-tests-failing-requirements-8b5124a3336d1297.yaml
+++ b/releasenotes/notes/fix-tests-failing-requirements-8b5124a3336d1297.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix failing tests related to Matplotlib 3.6.0 by pinning version to >=3.4 and <3.6.
+  - |
+    Fix failing tests related to Qiskit Aer version 0.11.0 and its namespace change by pinning version to
+    >=0.10.0 and <0.11.

--- a/releasenotes/notes/fix-tests-failing-requirements-8b5124a3336d1297.yaml
+++ b/releasenotes/notes/fix-tests-failing-requirements-8b5124a3336d1297.yaml
@@ -1,7 +1,0 @@
----
-fixes:
-  - |
-    Fix failing tests related to Matplotlib 3.6.0 by pinning version to >=3.4 and <3.6.
-  - |
-    Fix failing tests related to Qiskit Aer version 0.11.0 and its namespace change by pinning version to
-    >=0.10.0 and <0.11.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ sphinx-panels
 nbsphinx
 arxiv
 ddt~=1.4.2
-qiskit-aer>=0.10.0
+qiskit-aer>=0.10.0,<0.11
 pandas>=1.1.5
 cvxpy>=1.1.15
 pylatexenc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ sphinx-panels
 nbsphinx
 arxiv
 ddt~=1.4.2
+# FIXME: Remove maximum version once bugs discussed in #909, #910, #911 have been fixed.
 qiskit-aer>=0.10.0,<0.11
 pandas>=1.1.5
 cvxpy>=1.1.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ scipy>=1.4
 qiskit-terra>=0.21.1
 qiskit-ibmq-provider>=0.16.0
 qiskit-ibm-experiment>=0.2.5
-matplotlib>=3.4
+matplotlib>=3.4,<3.6
 uncertainties
 lmfit

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ scipy>=1.4
 qiskit-terra>=0.21.1
 qiskit-ibmq-provider>=0.16.0
 qiskit-ibm-experiment>=0.2.5
+# FIXME: Remove maximum version once bugs discussed in #909, #910, #911 have been fixed.
 matplotlib>=3.4,<3.6
 uncertainties
 lmfit


### PR DESCRIPTION
### Summary

Recent changes to the latest version of Matplotlib and Qiskit Aer have broken automated tests and CI. This is a quick fix to get CI working again. For part of the discussion, see #909 and #910.

### Details and comments

Matplotlib 3.6.0 deprecates a function, which causes some tests to fail. Qiskit Aer 0.11.0 moves to a separate module/namespace, which breaks lint tests. This PR pins these library versions to get CI working again. Once changes have been merged to fix these issues (like #910), the version limitations introduced here can be removed.

_Pinging relevant people_
@wshanks 
