### PR TITLE
Update test imports for qiskit-aer 0.11

### DIFF
--- a/docs/tutorials/quantum_volume.rst
+++ b/docs/tutorials/quantum_volume.rst
@@ -30,7 +30,7 @@ z_value = 2), and at least 100 trials have been ran.
     from qiskit_experiments.framework import BatchExperiment
     from qiskit_experiments.library import QuantumVolume
     from qiskit import Aer
-    from qiskit.providers.aer import AerSimulator
+    from qiskit_aer import AerSimulator
     
     # For simulation
     from qiskit.providers.fake_provider import FakeSydney

--- a/docs/tutorials/randomized_benchmarking.rst
+++ b/docs/tutorials/randomized_benchmarking.rst
@@ -19,7 +19,7 @@ for an explanation on the RB method, which is based on Ref. [1, 2].
     import qiskit.circuit.library as circuits
     
     # For simulation
-    from qiskit.providers.aer import AerSimulator
+    from qiskit_aer import AerSimulator
     from qiskit.providers.fake_provider import FakeParis
     
     backend = AerSimulator.from_backend(FakeParis())

--- a/docs/tutorials/readout_mitigation.rst
+++ b/docs/tutorials/readout_mitigation.rst
@@ -40,7 +40,7 @@ experiments to generate the corresponding mitigators.
     from qiskit.visualization import plot_histogram
     from qiskit_experiments.library import LocalReadoutError, CorrelatedReadoutError
     # For simulation
-    from qiskit.providers.aer import AerSimulator
+    from qiskit_aer import AerSimulator
     from qiskit.providers.fake_provider import FakeParis
 
     from qiskit.result.mitigation.utils import (

--- a/docs/tutorials/state_tomography.rst
+++ b/docs/tutorials/state_tomography.rst
@@ -8,7 +8,7 @@ Quantum State Tomography
     from qiskit_experiments.library import StateTomography
     
     # For simulation
-    from qiskit.providers.aer import AerSimulator
+    from qiskit_aer import AerSimulator
     from qiskit.providers.fake_provider import FakeParis
     
     # Noisy simulator backend

--- a/docs/tutorials/t1.rst
+++ b/docs/tutorials/t1.rst
@@ -38,8 +38,8 @@ for qubit 0.
 
     # A T1 simulator
     from qiskit.providers.fake_provider import FakeVigo
-    from qiskit.providers.aer import AerSimulator
-    from qiskit.providers.aer.noise import NoiseModel
+    from qiskit_aer import AerSimulator
+    from qiskit_aer.noise import NoiseModel
 
     # A kerneled data simulator
     from qiskit_experiments.test.mock_iq_backend import MockIQBackend

--- a/docs/tutorials/t2ramsey_characterization.rst
+++ b/docs/tutorials/t2ramsey_characterization.rst
@@ -65,8 +65,8 @@ pure T1/T2 relaxation noise model.
 
     # A T1 simulator
     from qiskit.providers.fake_provider import FakeVigo
-    from qiskit.providers.aer import AerSimulator
-    from qiskit.providers.aer.noise import NoiseModel
+    from qiskit_aer import AerSimulator
+    from qiskit_aer.noise import NoiseModel
     
     # Create a pure relaxation noise model for AerSimulator
     noise_model = NoiseModel.from_backend(

--- a/docs/tutorials/tphi_characterization.rst
+++ b/docs/tutorials/tphi_characterization.rst
@@ -23,8 +23,8 @@ we compute the results for :math:`T_\varphi.`
 
     # An Aer simulator
     from qiskit.providers.fake_provider import FakeVigo
-    from qiskit.providers.aer import AerSimulator
-    from qiskit.providers.aer.noise import NoiseModel
+    from qiskit_aer import AerSimulator
+    from qiskit_aer.noise import NoiseModel
     
     # Create a pure relaxation noise model for AerSimulator
     noise_model = NoiseModel.from_backend(

--- a/qiskit_experiments/library/quantum_volume/qv_experiment.py
+++ b/qiskit_experiments/library/quantum_volume/qv_experiment.py
@@ -53,7 +53,7 @@ class QuantumVolume(BaseExperiment):
         :math:`d` qubits, which contain :math:`d` layers, where each layer consists of random 2-qubit
         unitary gates from :math:`SU(4)`, followed by a random permutation on the :math:`d` qubits.
         Then these circuits run on the quantum backend and on an ideal simulator (either
-        :class:`~qiskit.providers.aer.AerSimulator` or :class:`~qiskit.quantum_info.Statevector`).
+        :class:`~qiskit_aer.AerSimulator` or :class:`~qiskit.quantum_info.Statevector`).
 
         A depth :math:`d` QV circuit is successful if it has 'mean heavy-output probability' > 2/3 with
         confidence level > 0.977 (corresponding to z_value = 2), and at least 100 trials have been ran.

--- a/qiskit_experiments/test/mock_iq_helpers.py
+++ b/qiskit_experiments/test/mock_iq_helpers.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.exceptions import QiskitError
-from qiskit.providers.aer import AerSimulator
+from qiskit_aer import AerSimulator
 from qiskit_experiments.framework import BaseExperiment
 
 # Define an IQ point typing class.

--- a/qiskit_experiments/test/noisy_delay_aer_simulator.py
+++ b/qiskit_experiments/test/noisy_delay_aer_simulator.py
@@ -16,10 +16,12 @@ Temporary backend to be used to apply T2 and T1 noise.
 from typing import List
 
 from qiskit import QuantumCircuit
+from qiskit.circuit import Delay
+
+from qiskit_aer import AerSimulator
 from qiskit_aer.jobs.aerjob import AerJob
 from qiskit_aer.noise.passes import RelaxationNoisePass
-from qiskit.circuit import Delay
-from qiskit_aer import AerSimulator
+
 from qiskit_experiments.framework import BackendData
 
 

--- a/qiskit_experiments/test/noisy_delay_aer_simulator.py
+++ b/qiskit_experiments/test/noisy_delay_aer_simulator.py
@@ -16,10 +16,10 @@ Temporary backend to be used to apply T2 and T1 noise.
 from typing import List
 
 from qiskit import QuantumCircuit
-from qiskit_aer import AerSimulator
 from qiskit_aer.jobs.aerjob import AerJob
 from qiskit_aer.noise.passes import RelaxationNoisePass
 from qiskit.circuit import Delay
+from qiskit_aer import AerSimulator
 from qiskit_experiments.framework import BackendData
 
 

--- a/qiskit_experiments/test/noisy_delay_aer_simulator.py
+++ b/qiskit_experiments/test/noisy_delay_aer_simulator.py
@@ -16,9 +16,9 @@ Temporary backend to be used to apply T2 and T1 noise.
 from typing import List
 
 from qiskit import QuantumCircuit
-from qiskit.providers.aer import AerSimulator
-from qiskit.providers.aer.jobs.aerjob import AerJob
-from qiskit.providers.aer.noise.passes import RelaxationNoisePass
+from qiskit_aer import AerSimulator
+from qiskit_aer.jobs.aerjob import AerJob
+from qiskit_aer.noise.passes import RelaxationNoisePass
 from qiskit.circuit import Delay
 from qiskit_experiments.framework import BackendData
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,8 +12,7 @@ sphinx-panels
 nbsphinx
 arxiv
 ddt~=1.4.2
-# FIXME: Remove maximum version once bugs discussed in #909, #910, #911 have been fixed.
-qiskit-aer>=0.10.0,<0.11
+qiskit-aer>=0.11.0
 pandas>=1.1.5
 cvxpy>=1.1.15
 pylatexenc

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -20,8 +20,9 @@ from test.base import QiskitExperimentsTestCase
 from ddt import ddt, data
 
 from qiskit import QuantumCircuit, Aer
-from qiskit_aer import noise
 from qiskit.result import Result
+
+from qiskit_aer import noise
 
 from qiskit_ibm_experiment import IBMExperimentService
 

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -20,7 +20,7 @@ from test.base import QiskitExperimentsTestCase
 from ddt import ddt, data
 
 from qiskit import QuantumCircuit, Aer
-from qiskit.providers.aer import noise
+from qiskit_aer import noise
 from qiskit.result import Result
 
 from qiskit_ibm_experiment import IBMExperimentService

--- a/test/library/characterization/test_cross_resonance_hamiltonian.py
+++ b/test/library/characterization/test_cross_resonance_hamiltonian.py
@@ -21,7 +21,7 @@ from ddt import ddt, data, unpack
 from qiskit import QuantumCircuit, pulse, quantum_info as qi
 from qiskit.providers.fake_provider import FakeBogotaV2
 from qiskit.extensions.hamiltonian_gate import HamiltonianGate
-from qiskit.providers.aer import AerSimulator
+from qiskit_aer import AerSimulator
 from qiskit_experiments.library.characterization import cr_hamiltonian
 from qiskit_experiments.framework import BackendData
 

--- a/test/library/quantum_volume/qv_generate_data.py
+++ b/test/library/quantum_volume/qv_generate_data.py
@@ -16,13 +16,13 @@ Code for generating data for the Quantum Volume experiment for testing.
 import os
 import sys
 import json
-from qiskit.providers.aer import AerSimulator
-from qiskit.providers.aer.noise import NoiseModel
-from qiskit.providers.aer.noise.errors.standard_errors import (
+from qiskit_aer import AerSimulator
+from qiskit_aer.noise import NoiseModel
+from qiskit_aer.noise.errors.standard_errors import (
     depolarizing_error,
     thermal_relaxation_error,
 )
-from qiskit.providers.aer.noise.errors import readout_error
+from qiskit_aer.noise.errors import readout_error
 from qiskit_experiments.library import QuantumVolume
 from qiskit_experiments.framework import ExperimentEncoder
 

--- a/test/library/randomized_benchmarking/test_randomized_benchmarking.py
+++ b/test/library/randomized_benchmarking/test_randomized_benchmarking.py
@@ -19,8 +19,8 @@ from ddt import ddt, data, unpack
 from qiskit.circuit import Delay, QuantumCircuit
 from qiskit.circuit.library import SXGate, CXGate, TGate, XGate
 from qiskit.exceptions import QiskitError
-from qiskit.providers.aer import AerSimulator
-from qiskit.providers.aer.noise import NoiseModel, depolarizing_error
+from qiskit_aer import AerSimulator
+from qiskit_aer.noise import NoiseModel, depolarizing_error
 from qiskit.quantum_info import Clifford
 
 from qiskit_experiments.library import randomized_benchmarking as rb

--- a/test/library/randomized_benchmarking/test_randomized_benchmarking.py
+++ b/test/library/randomized_benchmarking/test_randomized_benchmarking.py
@@ -19,9 +19,9 @@ from ddt import ddt, data, unpack
 from qiskit.circuit import Delay, QuantumCircuit
 from qiskit.circuit.library import SXGate, CXGate, TGate, XGate
 from qiskit.exceptions import QiskitError
+from qiskit.quantum_info import Clifford
 from qiskit_aer import AerSimulator
 from qiskit_aer.noise import NoiseModel, depolarizing_error
-from qiskit.quantum_info import Clifford
 
 from qiskit_experiments.library import randomized_benchmarking as rb
 from qiskit_experiments.database_service.exceptions import ExperimentEntryNotFound

--- a/test/library/tomography/test_composite_tomography.py
+++ b/test/library/tomography/test_composite_tomography.py
@@ -16,7 +16,7 @@ Composite StateTomography and ProcessTomography experiment tests
 from test.base import QiskitExperimentsTestCase
 from qiskit import QuantumCircuit
 import qiskit.quantum_info as qi
-from qiskit.providers.aer import AerSimulator
+from qiskit_aer import AerSimulator
 from qiskit_experiments.framework import BatchExperiment, ParallelExperiment
 from qiskit_experiments.library import StateTomography, ProcessTomography
 from .tomo_utils import filter_results

--- a/test/library/tomography/test_process_tomography.py
+++ b/test/library/tomography/test_process_tomography.py
@@ -18,7 +18,7 @@ import ddt
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import XGate, CXGate
 import qiskit.quantum_info as qi
-from qiskit.providers.aer import AerSimulator
+from qiskit_aer import AerSimulator
 from qiskit_experiments.library import ProcessTomography
 from qiskit_experiments.library.tomography import ProcessTomographyAnalysis
 from .tomo_utils import FITTERS, filter_results, teleport_circuit

--- a/test/library/tomography/test_state_tomography.py
+++ b/test/library/tomography/test_state_tomography.py
@@ -18,7 +18,7 @@ import ddt
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import XGate
 import qiskit.quantum_info as qi
-from qiskit.providers.aer import AerSimulator
+from qiskit_aer import AerSimulator
 from qiskit_experiments.library import StateTomography
 from qiskit_experiments.library.tomography import StateTomographyAnalysis
 from .tomo_utils import FITTERS, filter_results, teleport_circuit


### PR DESCRIPTION
### Summary

qiskit-aer moved from a namespace package at `qiskit.providers.aer` to its own package `qiskit_aer` with version 0.11. Tests in qiskit-experiments importing from the old path fail with qiskit-aer 0.11. This PR updates those imports.

Closes #912

### Details and comments

This is a follow up to #911.

For the aer change, see See https://github.com/Qiskit/qiskit-aer/pull/1526.

@conradhaupt and I were running into this, but I can't add him as a reviewer.