### PR TITLE
[WIP] Experiment data setting times

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -18,6 +18,7 @@ import copy
 from collections import OrderedDict
 from typing import Sequence, Optional, Tuple, List, Dict, Union
 import warnings
+from datetime import datetime
 
 from qiskit import transpile, QuantumCircuit
 from qiskit.providers import Job, Backend
@@ -52,6 +53,9 @@ class BaseExperiment(ABC, StoreInitArgs):
         Raises:
             QiskitError: if qubits contains duplicates.
         """
+
+        self._creation_datetime = datetime.now()
+
         # Experiment identification metadata
         self._type = experiment_type if experiment_type else type(self).__name__
 
@@ -254,6 +258,7 @@ class BaseExperiment(ABC, StoreInitArgs):
         run_opts = experiment.run_options.__dict__
 
         # Run jobs
+        experiment_data.start_datetime = datetime.now()
         jobs = experiment._run_jobs(transpiled_circuits, **run_opts)
         experiment_data.add_jobs(jobs, timeout=timeout)
 
@@ -265,7 +270,7 @@ class BaseExperiment(ABC, StoreInitArgs):
 
     def _initialize_experiment_data(self) -> ExperimentData:
         """Initialize the return data container for the experiment run"""
-        return ExperimentData(experiment=self)
+        return ExperimentData(experiment=self, creation_datetime=self._creation_datetime)
 
     def _finalize(self):
         """Finalize experiment object before running jobs.

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -346,7 +346,7 @@ class ExperimentData:
             The start datetime of this experiment data.
 
         """
-        return self._db_data.end_datetime
+        return self._db_data.start_datetime
 
     @start_datetime.setter
     def start_datetime(self, new_datetime) -> None:

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -333,6 +333,11 @@ class ExperimentData:
         """
         return self._db_data.creation_datetime
 
+    @creation_datetime.setter
+    def creation_datetime(self, new_datetime) -> None:
+        """Sets the creation datetime for the experiment"""
+        self._db_data.creation_datetime = new_datetime
+
     @property
     def start_datetime(self) -> "datetime":
         """Return the start datetime of this experiment data.
@@ -342,6 +347,11 @@ class ExperimentData:
 
         """
         return self._db_data.end_datetime
+
+    @start_datetime.setter
+    def start_datetime(self, new_datetime) -> None:
+        """Sets the creation datetime for the experiment"""
+        self._db_data.start_datetime = new_datetime
 
     @property
     def updated_datetime(self) -> "datetime":
@@ -353,6 +363,11 @@ class ExperimentData:
         """
         return self._db_data.updated_datetime
 
+    @updated_datetime.setter
+    def updated_datetime(self, new_datetime) -> None:
+        """Sets the creation datetime for the experiment"""
+        self._db_data.updated_datetime = new_datetime
+
     @property
     def end_datetime(self) -> "datetime":
         """Return the end datetime of this experiment data.
@@ -362,6 +377,11 @@ class ExperimentData:
 
         """
         return self._db_data.end_datetime
+
+    @end_datetime.setter
+    def end_datetime(self, new_datetime) -> None:
+        """Sets the creation datetime for the experiment"""
+        self._db_data.end_datetime = new_datetime
 
     @property
     def hub(self) -> str:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR adds code for manually and automatically setting the various time fields in `ExperimentData`: `creation_datetime`, `start_endtime`, `updated_datetime`, `end_datetime`.


### Details and comments
Currently, running a code like
```
from qiskit.providers.fake_provider import FakeBogota
from qiskit_experiments.library.randomized_benchmarking import StandardRB
backend = FakeBogota()
exp = StandardRB(qubits=[0,1], lengths=[10, 20, 30], backend=backend)
data = exp.run().block_for_results()
print("created: ", data.creation_datetime)
print("start: ", data.start_datetime)
print("end: ", data.end_datetime)
```

Results in

```
created:  None
start:  None
end:  None
```

The goal of this PR is to change this, so we have, e.g.
```
created:  2022-09-19 09:41:32.835218
start:  2022-09-19 09:41:33.716068
end:  2022-09-19 09:45:29.581053
```

### Open issues
1. When the datetime is set locally, is should probably use a non-local clock (GMT?).
2. When should `updated_time` be set?
3. What is the optimal way to set `end_time`?
