### PR TITLE
Improve custom transpilation for faster 1Q/2Q RB

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
@@ -46,7 +46,7 @@ from .clifford_data import (
 def _transpile_clifford_circuit(
     circuit: QuantumCircuit, physical_qubits: Sequence[int]
 ) -> QuantumCircuit:
-    # Simplified transpile, which only decomposes Clifford circuits and layout qubits
+    # Simplified transpile that only decomposes Clifford circuits and creates the layout.
     return _apply_qubit_layout(_decompose_clifford_ops(circuit), physical_qubits=physical_qubits)
 
 

--- a/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
@@ -43,9 +43,11 @@ from .clifford_data import (
 
 
 # Transpilation utilities
-def _transpile_clifford_circuit(circuit: QuantumCircuit, layout: Sequence[int]) -> QuantumCircuit:
+def _transpile_clifford_circuit(
+    circuit: QuantumCircuit, physical_qubits: Sequence[int]
+) -> QuantumCircuit:
     # Simplified transpile, which only decomposes Clifford circuits and layout qubits
-    return _apply_qubit_layout(_decompose_clifford_ops(circuit), layout=layout)
+    return _apply_qubit_layout(_decompose_clifford_ops(circuit), physical_qubits=physical_qubits)
 
 
 def _decompose_clifford_ops(circuit: QuantumCircuit) -> QuantumCircuit:
@@ -75,13 +77,13 @@ def _decompose_clifford_ops(circuit: QuantumCircuit) -> QuantumCircuit:
     return res
 
 
-def _apply_qubit_layout(circuit: QuantumCircuit, layout: Sequence[int]) -> QuantumCircuit:
+def _apply_qubit_layout(circuit: QuantumCircuit, physical_qubits: Sequence[int]) -> QuantumCircuit:
     # Mapping qubits in circuit to physical qubits (layout)
-    res = QuantumCircuit(1 + max(layout), name=circuit.name, metadata=circuit.metadata)
+    res = QuantumCircuit(1 + max(physical_qubits), name=circuit.name, metadata=circuit.metadata)
     res.add_bits(circuit.clbits)
     for reg in circuit.cregs:
         res.add_register(reg)
-    _circuit_compose(res, circuit, qubits=layout)
+    _circuit_compose(res, circuit, qubits=physical_qubits)
     res._parameter_table = circuit._parameter_table
     return res
 

--- a/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
+++ b/qiskit_experiments/library/randomized_benchmarking/clifford_utils.py
@@ -25,7 +25,7 @@ from numpy.random import Generator, default_rng
 
 from qiskit.circuit import Gate, Instruction
 from qiskit.circuit import QuantumCircuit, QuantumRegister, CircuitInstruction, Qubit
-from qiskit.circuit.library import SdgGate, HGate, SGate
+from qiskit.circuit.library import SdgGate, HGate, SGate, XGate, YGate, ZGate
 from qiskit.compiler import transpile
 from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend
@@ -589,14 +589,14 @@ class CliffordUtils:
         Number of Cliffords == 16."""
         if self._transpiled_cliff_layer[2] != []:
             return
-        pauli = ["i", "x", "y", "z"]
+
+        pauli = ("i", XGate(), YGate(), ZGate())
         for p0, p1 in itertools.product(pauli, pauli):
-            qr = QuantumRegister(2)
-            qc = QuantumCircuit(qr)
+            qc = QuantumCircuit(2)
             if p0 != "i":
-                qc._append(Gate(p0, 1, []), [qr[0]], [])
+                qc.append(p0, [0])
             if p1 != "i":
-                qc._append(Gate(p1, 1, []), [qr[1]], [])
+                qc.append(p1, [1])
 
             transpiled = transpile(
                 qc, optimization_level=1, basis_gates=self.basis_gates, backend=self._backend

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
@@ -111,8 +111,9 @@ class InterleavedRB(StandardRB):
             delay_ops = [interleaved_element]
         elif isinstance(interleaved_element, QuantumCircuit):
             delay_ops = [delay.operation for delay in interleaved_element.get_instructions("delay")]
-        for delay_op in delay_ops:
+        if delay_ops:
             timing = BackendTiming(backend)
+        for delay_op in delay_ops:
             if delay_op.unit != timing.delay_unit:
                 raise QiskitError(
                     f"Interleaved delay for backend {backend} must have time unit {timing.delay_unit}."

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
@@ -66,13 +66,13 @@ class InterleavedRB(StandardRB):
         Args:
             interleaved_element: The element to interleave,
                     given either as a Clifford element, gate, delay or circuit.
-                    Only when the element contains any non-basis gates,
+                    If the element contains any non-basis gates,
                     it will be transpiled with ``transpiled_options`` of this experiment.
                     If it is/contains a delay, its duration and unit must comply with
                     the timing constraints of the ``backend``.
                     (:class:``~qiskit_experiments.framework.backend_timing.BackendTiming`
                     is useful to obtain valid delays.)
-                    Parameterized circuit/instruction is not allowded.
+                    Parameterized circuit/instruction is not allowed.
             qubits: list of physical qubits for the experiment.
             lengths: A list of RB sequences lengths.
             backend: The backend to run the experiment on.

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
@@ -72,11 +72,11 @@ class InterleavedRB(StandardRB):
                     the timing constraints of the ``backend``.
                     (:class:``~qiskit_experiments.framework.backend_timing.BackendTiming`
                     is useful to obtain valid delays.)
+                    Parameterized circuit/instruction is not allowded.
             qubits: list of physical qubits for the experiment.
             lengths: A list of RB sequences lengths.
             backend: The backend to run the experiment on.
-            num_samples: Number of samples to generate for each
-                         sequence length
+            num_samples: Number of samples to generate for each sequence length.
             seed: Optional, seed used to initialize ``numpy.random.default_rng``.
                   when generating circuits. The ``default_rng`` will be initialized
                   with this seed value everytime :meth:`circuits` is called.

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
@@ -198,7 +198,6 @@ class InterleavedRB(StandardRB):
         reference_circuits = self._sequences_to_circuits(reference_sequences)
         for circ, seq in zip(reference_circuits, reference_sequences):
             circ.metadata = {
-                "experiment_type": self._type,
                 "xval": len(seq),
                 "group": "Clifford",
                 "physical_qubits": self.physical_qubits,
@@ -215,7 +214,6 @@ class InterleavedRB(StandardRB):
         interleaved_circuits = self._sequences_to_circuits(interleaved_sequences)
         for circ, seq in zip(interleaved_circuits, reference_sequences):
             circ.metadata = {
-                "experiment_type": self._type,
                 "xval": len(seq),  # set length of the reference sequence
                 "group": "Clifford",
                 "physical_qubits": self.physical_qubits,

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -349,7 +349,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
 
                 common_calibrations = defaultdict(dict)
                 for op_name, qargs in instructions:
-                    inst_prop = self.backend.target[op_name][qargs]
+                    inst_prop = self.backend.target[op_name].get(qargs, None)
                     if inst_prop is None:
                         continue
                     schedule = inst_prop.calibration

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -202,10 +202,15 @@ class StandardRB(BaseExperiment, RestlessMixin):
         if not basis_gates and self.backend:
             if isinstance(self.backend, BackendV2):
                 basis_gates = self.backend.operation_names
+                non_globals = self.backend.target.get_non_global_operation_names(
+                    strict_direction=True
+                )
+                if non_globals:
+                    basis_gates = set(basis_gates) - set(non_globals)
             else:
                 basis_gates = self.backend.configuration().basis_gates
 
-        if basis_gates:
+        if basis_gates is not None:
             basis_gates = tuple(sorted(basis_gates))
 
         return basis_gates

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -213,7 +213,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
     def _sequences_to_circuits(
         self, sequences: List[Sequence[SequenceElementType]]
     ) -> List[QuantumCircuit]:
-        """Convert a RB sequence into circuit and append the inverse to the end.
+        """Convert an RB sequence into circuit and append the inverse to the end.
 
         Returns:
             A list of RB circuits.
@@ -245,7 +245,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
         return circuits
 
     def __sample_sequence(self, length: int, rng: Generator) -> Sequence[SequenceElementType]:
-        # Sample a RB sequence with the given length.
+        # Sample an RB sequence with the given length.
         # Return integer instead of Clifford object for 1 or 2 qubits case for speed
         if self.num_qubits == 1:
             return rng.integers(24, size=length)

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -164,7 +164,6 @@ class StandardRB(BaseExperiment, RestlessMixin):
         # Add metadata for each circuit
         for circ, seq in zip(circuits, sequences):
             circ.metadata = {
-                "experiment_type": self._type,
                 "xval": len(seq),
                 "group": "Clifford",
                 "physical_qubits": self.physical_qubits,

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -192,7 +192,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
 
         return sequences
 
-    def _get_basis_gates(self) -> Optional[Tuple[str]]:
+    def _get_basis_gates(self) -> Optional[Tuple[str, ...]]:
         """Get sorted basis gates to use in basis transformation during circuit generation.
 
         Returns:

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -142,8 +142,8 @@ class StandardRB(BaseExperiment, RestlessMixin):
         return options
 
     def _set_backend(self, backend: Backend):
-        """Set the backend V2 for RB experiments since RB experiments only support BackendV2.
-        If BackendV1 is provided, it is converted to V2 and stored.
+        """Set the backend V2 for RB experiments since RB experiments only support BackendV2
+        except for simulators. If BackendV1 is provided, it is converted to V2 and stored.
         """
         if isinstance(backend, BackendV1) and "simulator" not in backend.name():
             super()._set_backend(BackendV2Converter(backend))

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -322,8 +322,11 @@ class StandardRB(BaseExperiment, RestlessMixin):
                 for circ in self.circuits()
             ]
             # Set custom calibrations provided in backend
-            # TODO: Remove V2 restriction after V2 conversion in _set_backend
-            if self.backend and isinstance(self.backend, BackendV2):
+            if self.backend:
+                # TODO: Remove V2 restriction after V2 conversion in _set_backend
+                if not isinstance(self.backend, BackendV2):
+                    raise NotImplementedError
+
                 # assert self.num_qubits <= 2
                 qargs_patterns = [self.physical_qubits]  # for self.num_qubits == 1
                 if self.num_qubits == 2:

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -12,34 +12,34 @@
 """
 Standard RB Experiment class.
 """
-
 import logging
 from collections import defaultdict
 from numbers import Integral
-from typing import Union, Iterable, Optional, List, Sequence
+from typing import Union, Iterable, Optional, List, Sequence, Tuple
+
 import numpy as np
 from numpy.random import Generator, default_rng
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 
-from qiskit import QuantumCircuit, ClassicalRegister, QiskitError
-from qiskit.circuit import Clbit
-from qiskit.circuit import Instruction
-from qiskit.providers.backend import Backend
-from qiskit.compiler import transpile
-from qiskit.quantum_info import Clifford, random_clifford
-
+from qiskit.circuit import QuantumCircuit, Instruction, Barrier
+from qiskit.exceptions import QiskitError
+from qiskit.providers.backend import Backend, BackendV2
+from qiskit.quantum_info import Clifford
+from qiskit.quantum_info.random import random_clifford
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
 from .clifford_utils import (
     CliffordUtils,
     _clifford_1q_int_to_instruction,
     _clifford_2q_int_to_instruction,
+    _transpile_clifford_circuit,
 )
 from .rb_analysis import RBAnalysis
 
 LOG = logging.getLogger(__name__)
 
-SequenceElementType = Union[Clifford, Integral]
+
+SequenceElementType = Union[Clifford, Integral, QuantumCircuit]
 
 
 class StandardRB(BaseExperiment, RestlessMixin):
@@ -66,9 +66,6 @@ class StandardRB(BaseExperiment, RestlessMixin):
         .. ref_arxiv:: 2 1109.6887
 
     """
-
-    default_basis_gates = {"rz", "sx", "cx"}
-    _clifford_utils = None
 
     def __init__(
         self,
@@ -118,8 +115,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
         )
         self.analysis.set_options(outcome="0" * self.num_qubits)
 
-        # Set fixed options
-        self._full_sampling = full_sampling
+        self._cliff_utils = None  # TODO: cleanup
 
     @classmethod
     def _default_experiment_options(cls) -> Options:
@@ -148,27 +144,23 @@ class StandardRB(BaseExperiment, RestlessMixin):
 
         Returns:
             A list of :class:`QuantumCircuit`.
-
         """
-        self._set_basis_gates()
-        self._initialize_clifford_utils()
-        rng = default_rng(seed=self.experiment_options.seed)
-        circuits = []
-
-        if self.num_qubits in [1, 2]:
-            for _ in range(self.experiment_options.num_samples):
-                rb_circuits = self._build_rb_circuits(self.experiment_options.lengths, rng)
-                circuits += rb_circuits
-        else:
-            for _ in range(self.experiment_options.num_samples):
-                circuits += self._sample_circuits()
-
-        return circuits
-
-    # The following methods are used for RB with more than 2 qubits
-    def _sample_circuits(self):
+        self._cliff_utils = CliffordUtils(
+            self.num_qubits, basis_gates=self._get_basis_gates()
+        )  # TODO: cleanup
+        # Sample random Clifford sequences
         sequences = self._sample_sequences()
-        return self._sequences_to_circuits(sequences)
+        # Convert each sequence into circuit and append the inverse to the end.
+        circuits = self._sequences_to_circuits(sequences)
+        # Add metadata for each circuit
+        for circ, seq in zip(circuits, sequences):
+            circ.metadata = {
+                "experiment_type": self._type,
+                "xval": len(seq),
+                "group": "Clifford",
+                "physical_qubits": self.physical_qubits,
+            }
+        return circuits
 
     def _sample_sequences(self) -> List[Sequence[SequenceElementType]]:
         """Sample RB sequences
@@ -190,14 +182,35 @@ class StandardRB(BaseExperiment, RestlessMixin):
 
         return sequences
 
+    def _get_basis_gates(self) -> Optional[Tuple[str]]:
+        """Get sorted basis gates to use in basis transformation during circuit generation.
+
+        Returns:
+            Sorted basis gate names.
+        """
+        # Basis gates to use in basis transformation during circuit generation for 1Q/2Q cases
+        basis_gates = self.transpile_options.get("basis_gates", None)
+        if not basis_gates and self.backend:
+            if isinstance(self.backend, BackendV2):
+                basis_gates = self.backend.operation_names
+            else:
+                basis_gates = self.backend.configuration().basis_gates
+
+        if basis_gates:
+            basis_gates = tuple(sorted(basis_gates))
+
+        return basis_gates
+
     def _sequences_to_circuits(
         self, sequences: List[Sequence[SequenceElementType]]
     ) -> List[QuantumCircuit]:
-        """Convert an RB sequence into circuit and append the inverse to the end.
+        """Convert a RB sequence into circuit and append the inverse to the end.
 
         Returns:
             A list of RB circuits.
         """
+        basis_gates = self._get_basis_gates()
+        # Circuit generation
         circuits = []
         for i, seq in enumerate(sequences):
             if (
@@ -206,49 +219,43 @@ class StandardRB(BaseExperiment, RestlessMixin):
             ):
                 prev_elem, prev_seq = self.__identity_clifford(), []
 
-            qubits = list(range(self.num_qubits))
             circ = QuantumCircuit(self.num_qubits)
-            circ.barrier(qubits)
+            circ.append(Barrier(self.num_qubits), circ.qubits)
             for elem in seq:
-                circ.append(self._to_instruction(elem), qubits)
-                circ.barrier(qubits)
+                circ.append(self._to_instruction(elem, basis_gates), circ.qubits)
+                circ.append(Barrier(self.num_qubits), circ.qubits)
 
             # Compute inverse, compute only the difference from the previous shorter sequence
-            for elem in seq[len(prev_seq) :]:
-                prev_elem = self.__compose_clifford(prev_elem, elem)
+            prev_elem = self.__compose_clifford_seq(prev_elem, seq[len(prev_seq) :])
             prev_seq = seq
             inv = self.__adjoint_clifford(prev_elem)
 
-            circ.append(self._to_instruction(inv), qubits)
+            circ.append(self._to_instruction(inv, basis_gates), circ.qubits)
             circ.measure_all()  # includes insertion of the barrier before measurement
-            # Add metadata
-            circ.metadata = {
-                "experiment_type": self._type,
-                "xval": len(seq),
-                "group": "Clifford",
-                "physical_qubits": self.physical_qubits,
-            }
             circuits.append(circ)
         return circuits
 
     def __sample_sequence(self, length: int, rng: Generator) -> Sequence[SequenceElementType]:
         # Sample a RB sequence with the given length.
-        # Return integer instead of Clifford object for 1 or 2 qubit case for speed
+        # Return integer instead of Clifford object for 1 or 2 qubits case for speed
         if self.num_qubits == 1:
             return rng.integers(24, size=length)
         if self.num_qubits == 2:
             return rng.integers(11520, size=length)
+        # Return circuit object instead of Clifford object for 3 or more qubits case for speed
+        # TODO: Revisit after terra#7269, #7483, #8585
+        return [random_clifford(self.num_qubits, rng).to_circuit() for _ in range(length)]
 
-        return [random_clifford(self.num_qubits, rng) for _ in range(length)]
-
-    def _to_instruction(self, elem: SequenceElementType) -> Instruction:
-        # TODO: basis transformation in 1Q (and 2Q) cases for speed
+    def _to_instruction(
+        self, elem: SequenceElementType, basis_gates: Optional[Tuple[str]] = None
+    ) -> Instruction:
         # Switching for speed up
         if isinstance(elem, Integral):
             if self.num_qubits == 1:
-                return _clifford_1q_int_to_instruction(elem)
+                return _clifford_1q_int_to_instruction(elem, basis_gates)
             if self.num_qubits == 2:
-                return _clifford_2q_int_to_instruction(elem)
+                return _clifford_2q_int_to_instruction(elem, basis_gates)
+
         return elem.to_instruction()
 
     def __identity_clifford(self) -> SequenceElementType:
@@ -256,234 +263,57 @@ class StandardRB(BaseExperiment, RestlessMixin):
             return 0
         return Clifford(np.eye(2 * self.num_qubits))
 
+    def __compose_clifford_seq(
+        self, org: SequenceElementType, seq: Sequence[SequenceElementType]
+    ) -> SequenceElementType:
+        if self.num_qubits <= 2:
+            new = org
+            for elem in seq:
+                new = self.__compose_clifford(new, elem)
+            return new
+        # 3 or more qubits: compose Clifford from circuits for speed
+        # TODO: Revisit after terra#7269, #7483, #8585
+        circ = QuantumCircuit(self.num_qubits)
+        for elem in seq:
+            circ.compose(elem, inplace=True)
+        return org.compose(Clifford.from_circuit(circ))
+
     def __compose_clifford(
         self, lop: SequenceElementType, rop: SequenceElementType
     ) -> SequenceElementType:
-        # TODO: Speed up 1Q (and 2Q) cases using integer clifford composition
-        # Integer clifford composition is not yet supported
-        if self.num_qubits == 1:
-            if isinstance(lop, Integral):
-                lop = CliffordUtils.clifford_1_qubit(lop)
-            if isinstance(rop, Integral):
-                rop = CliffordUtils.clifford_1_qubit(rop)
-        if self.num_qubits == 2:
-            if isinstance(lop, Integral):
-                lop = CliffordUtils.clifford_2_qubit(lop)
-            if isinstance(rop, Integral):
-                rop = CliffordUtils.clifford_2_qubit(rop)
+        if self.num_qubits <= 2:
+            utils = self._cliff_utils
+            return utils.compose_num_with_clifford(lop, utils.create_cliff_from_num(rop))
+
         return lop.compose(rop)
 
     def __adjoint_clifford(self, op: SequenceElementType) -> SequenceElementType:
-        # TODO: Speed up 1Q and 2Q cases using integer clifford inversion
-        # Integer clifford inversion has not yet supported
-        if isinstance(op, Integral):
-            if self.num_qubits == 1:
-                return CliffordUtils.clifford_1_qubit(op).adjoint()
-            if self.num_qubits == 2:
-                return CliffordUtils.clifford_2_qubit(op).adjoint()
+        if self.num_qubits <= 2:
+            return self._cliff_utils.inverse_cliff(op)
+
+        if isinstance(op, QuantumCircuit):
+            return Clifford.from_circuit(op).adjoint()
+
         return op.adjoint()
-
-    # The following methods are used for RB with 1 or 2 qubits
-    def _build_rb_circuits(self, lengths: List[int], rng: Generator) -> List[QuantumCircuit]:
-        """
-        build_rb_circuits
-        Args:
-                lengths: A list of RB sequence lengths. We create random circuits
-                         where the number of cliffords in each is defined in 'lengths'.
-                rng: Generator object for random number generation.
-                     If None, default_rng will be used.
-
-        Returns:
-                The transpiled RB circuits.
-
-        Additional information:
-            To create the RB circuit, we use a mapping between Cliffords and integers
-            defined in the file clifford_data.py. The operations compose and inverse are much faster
-            when performed on the integers rather than on the Cliffords themselves.
-        """
-        if self._full_sampling:
-            return self._build_rb_circuits_full_sampling(lengths, rng)
-        max_qubit = max(self.physical_qubits) + 1
-        all_rb_circuits = []
-
-        # When full_sampling==False, each circuit is the prefix of the next circuit (without the
-        # inverse Clifford at the end of the circuit. The variable 'circ' will contain
-        # the growing circuit.
-        # When each circuit reaches its length, we copy it to rb_circ, append the inverse,
-        # and add it to the list of circuits.
-        n = self.num_qubits
-        qubits = list(range(n))
-        clbits = list(range(n))
-        circ = QuantumCircuit(max_qubit, n)
-        circ.barrier(qubits)
-        # We transpile the empty circuit to match the backend qubits
-        circ = transpile(
-            circuits=circ,
-            optimization_level=1,
-            basis_gates=self.transpile_options.basis_gates,
-            backend=self._backend,
-        )
-
-        # composed_cliff_num is the number representing the composition of all the Cliffords up to now
-        composed_cliff_num = 0  # 0 is the Clifford that is Id
-        prev_length = 0
-
-        for length in lengths:
-            for i in range(prev_length, length):
-                circ, _, composed_cliff_num = self._add_random_cliff_to_circ(
-                    circ, composed_cliff_num, qubits, rng
-                )
-
-                if i == length - 1:
-                    rb_circ = circ.copy()  # circ is used as the prefix of the next circuit
-                    rb_circ = self._add_inverse_to_circ(rb_circ, composed_cliff_num, qubits, clbits)
-
-                    rb_circ.metadata = {
-                        "experiment_type": "rb",
-                        "xval": length,
-                        "group": "Clifford",
-                        "physical_qubits": self.physical_qubits,
-                    }
-                    all_rb_circuits.append(rb_circ)
-                prev_length = i + 1
-        return all_rb_circuits
-
-    def _build_rb_circuits_full_sampling(
-        self, lengths: List[int], rng: Generator
-    ) -> List[QuantumCircuit]:
-        """
-        _build_rb_circuits_full_sampling
-        Args:
-                lengths: A list of RB sequence lengths. We create random circuits
-                    where the number of cliffords in each is defined in 'lengths'.
-                rng: Generator object for random number generation.
-                    If None, default_rng will be used.
-
-        Returns:
-                The transpiled RB circuits.
-
-        Additional information:
-            This is similar to _build_rb_circuits for the case of full_sampling.
-        """
-        all_rb_circuits = []
-        n = self.num_qubits
-        qubits = list(range(n))
-        clbits = list(range(n))
-        max_qubit = max(self.physical_qubits) + 1
-        for length in lengths:
-            # We define the circuit size here, for the layout that will
-            # be created later
-            rb_circ = QuantumCircuit(max_qubit, n)
-            rb_circ.barrier(qubits)
-            # We transpile the empty circuit to match the backend qubits
-            rb_circ = transpile(
-                circuits=rb_circ,
-                optimization_level=1,
-                basis_gates=self.transpile_options.basis_gates,
-                backend=self._backend,
-            )
-
-            # composed_cliff_num is the number representing the composition of
-            # all the Cliffords up to now
-            composed_cliff_num = 0
-
-            # For full_sampling, we create each circuit independently.
-            for _ in range(length):
-                # choose random clifford
-                rb_circ, _, composed_cliff_num = self._add_random_cliff_to_circ(
-                    rb_circ, composed_cliff_num, qubits, rng
-                )
-
-            rb_circ = self._add_inverse_to_circ(rb_circ, composed_cliff_num, qubits, clbits)
-
-            rb_circ.metadata = {
-                "experiment_type": "rb",
-                "xval": length,
-                "group": "Clifford",
-                "physical_qubits": self.physical_qubits,
-                "interleaved": False,
-            }
-
-            all_rb_circuits.append(rb_circ)
-        return all_rb_circuits
-
-    def _add_random_cliff_to_circ(self, circ, composed_cliff_num, qubits, rng):
-        next_circ = StandardRB._clifford_utils.create_random_clifford(rng)
-        circ, composed_cliff_num = self._add_cliff_to_circ(
-            circ, next_circ, composed_cliff_num, qubits
-        )
-        return circ, next_circ, composed_cliff_num
-
-    def _add_cliff_to_circ(
-        self,
-        circ: QuantumCircuit,
-        next_circ: QuantumCircuit,
-        composed_cliff_num: int,
-        qubits: List[int],
-    ):
-        """Append a Clifford to the end of a circuit. Return both the updated circuit and the updated
-        number representing the circuit"""
-        circ.compose(next_circ, inplace=True)
-        composed_cliff_num = StandardRB._clifford_utils.compose_num_with_clifford(
-            composed_num=composed_cliff_num,
-            qc=next_circ,
-        )
-        circ.barrier(qubits)
-        return circ, composed_cliff_num
-
-    def _add_inverse_to_circ(self, rb_circ, composed_num, qubits, clbits):
-        """Append the inverse of a circuit to the end of the circuit"""
-        inverse_cliff = StandardRB._clifford_utils.inverse_cliff(composed_num)
-        rb_circ.compose(inverse_cliff, inplace=True)
-        rb_circ.measure(qubits, clbits)
-        return rb_circ
-
-    # This method does a quick layout to avoid calling 'transpile()' which is
-    # very costly in performance
-    # We simply copy the circuit to a new circuit where we define the mapping
-    # of the qubit to the single physical qubit that was requested by the user
-    # This is a hack, and would be better if transpile() implemented it.
-    # Something similar is done in ParallelExperiment._combined_circuits
-    def _layout_for_rb(self):
-        transpiled = []
-        qargs_map = (
-            {0: self.physical_qubits[0]}
-            if self.num_qubits == 1
-            else {0: self.physical_qubits[0], 1: self.physical_qubits[1]}
-        )
-        for circ in self.circuits():
-            new_circ = QuantumCircuit(
-                *circ.qregs,
-                name=circ.name,
-                global_phase=circ.global_phase,
-                metadata=circ.metadata.copy(),
-            )
-            clbits = circ.num_clbits
-            if clbits:
-                creg = ClassicalRegister(clbits)
-                new_cargs = [Clbit(creg, i) for i in range(clbits)]
-                new_circ.add_register(creg)
-
-            for inst, qargs, cargs in circ.data:
-                mapped_cargs = [new_cargs[circ.find_bit(clbit).index] for clbit in cargs]
-                mapped_qargs = [circ.qubits[qargs_map[circ.find_bit(i).index]] for i in qargs]
-                new_circ.data.append((inst, mapped_qargs, mapped_cargs))
-                # Add the calibrations
-                for gate, cals in circ.calibrations.items():
-                    for key, sched in cals.items():
-                        new_circ.add_calibration(gate, qubits=key[0], schedule=sched, params=key[1])
-
-            transpiled.append(new_circ)
-        return transpiled
 
     def _transpiled_circuits(self) -> List[QuantumCircuit]:
         """Return a list of experiment circuits, transpiled."""
-        if self.num_qubits in [1, 2]:
-            transpiled = self._layout_for_rb()
+        has_custom_transpile_option = (
+            any(
+                opt not in {"basis_gates", "optimization_level"}
+                for opt in vars(self.transpile_options)
+            )
+            or self.transpile_options.get("optimization_level", 0) != 0
+        )
+        if self.num_qubits <= 2 and not has_custom_transpile_option:
+            transpiled = [
+                _transpile_clifford_circuit(circ, layout=self.physical_qubits)
+                for circ in self.circuits()
+            ]
         else:
             transpiled = super()._transpiled_circuits()
-        if self.analysis.options.get("gate_error_ratio", None) is None:
 
+        if self.analysis.options.get("gate_error_ratio", None) is None:
             # Gate errors are not computed, then counting ops is not necessary.
             return transpiled
 
@@ -503,6 +333,7 @@ class StandardRB(BaseExperiment, RestlessMixin):
                 formatted_key = tuple(sorted(qinds)), inst.name
                 count_ops_result[formatted_key] += 1
             circ.metadata["count_ops"] = tuple(count_ops_result.items())
+
         return transpiled
 
     def _metadata(self):
@@ -514,21 +345,3 @@ class StandardRB(BaseExperiment, RestlessMixin):
                 metadata[run_opt] = getattr(self.run_options, run_opt)
 
         return metadata
-
-    def _initialize_clifford_utils(self):
-        if StandardRB._clifford_utils is None or not (
-            StandardRB._clifford_utils.num_qubits == self.num_qubits
-            and StandardRB._clifford_utils.basis_gates == self.transpile_options.basis_gates
-            and StandardRB._clifford_utils._backend == self._backend
-        ):
-            StandardRB._clifford_utils = CliffordUtils(
-                self.num_qubits, self.transpile_options.basis_gates, backend=self._backend
-            )
-
-    def _set_basis_gates(self):
-        if not hasattr(self.transpile_options, "basis_gates"):
-            if not self.backend is None and self.backend.configuration().basis_gates:
-                self.set_transpile_options(basis_gates=self.backend.configuration().basis_gates)
-            else:
-                basis_gates_option = {"basis_gates": StandardRB.default_basis_gates}
-                self.transpile_options.update_options(**basis_gates_option)

--- a/test/library/randomized_benchmarking/test_randomized_benchmarking.py
+++ b/test/library/randomized_benchmarking/test_randomized_benchmarking.py
@@ -100,8 +100,6 @@ class TestStandardRB(QiskitExperimentsTestCase, RBTestMixin):
             backend=self.backend,
         )
 
-        exp1.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
-        exp2.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
         circs1 = exp1.circuits()
         circs2 = exp2.circuits()
 
@@ -118,7 +116,6 @@ class TestStandardRB(QiskitExperimentsTestCase, RBTestMixin):
             backend=self.backend,
             full_sampling=False,
         )
-        exp1.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
         exp2 = rb.StandardRB(
             qubits=(0,),
             lengths=[10, 20, 30],
@@ -126,7 +123,6 @@ class TestStandardRB(QiskitExperimentsTestCase, RBTestMixin):
             backend=self.backend,
             full_sampling=True,
         )
-        exp2.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
         circs1 = exp1.circuits()
         circs2 = exp2.circuits()
 
@@ -145,7 +141,6 @@ class TestStandardRB(QiskitExperimentsTestCase, RBTestMixin):
             backend=self.backend,
             full_sampling=False,
         )
-        exp1.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
 
         exp2 = rb.StandardRB(
             qubits=(0, 1),
@@ -154,7 +149,6 @@ class TestStandardRB(QiskitExperimentsTestCase, RBTestMixin):
             backend=self.backend,
             full_sampling=True,
         )
-        exp2.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
 
         circs1 = exp1.circuits()
         circs2 = exp2.circuits()

--- a/test/library/randomized_benchmarking/test_randomized_benchmarking.py
+++ b/test/library/randomized_benchmarking/test_randomized_benchmarking.py
@@ -628,8 +628,8 @@ class TestRunStandardRB(RBRunTestCase):
         self.assertExperimentDone(expdata)
 
         # Given CX error is dominant and 1q error can be negligible.
-        # Arbitrary SU(4) can be decomposed with (0, 1, 2, 3) CX gates, the expected
-        # average number of CX gate per Clifford is 1.5.
+        # Arbitrary SU(4) can be decomposed with (0, 1, 2, 3) CZ gates, the expected
+        # average number of CZ gate per Clifford is 1.5.
         # Since this is two qubit RB, the dep-parameter is factored by 3/4.
         epc = expdata.analysis_results("EPC")
 

--- a/test/library/randomized_benchmarking/test_randomized_benchmarking.py
+++ b/test/library/randomized_benchmarking/test_randomized_benchmarking.py
@@ -183,7 +183,7 @@ class TestInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
                 lengths=[1, 2, 3, 5, 8, 13],
             )
 
-    @data([5, "dt"], [3.2e-7, "s"])
+    @data([5, "dt"], [1e-7, "s"], [32, "ns"])
     @unpack
     def test_interleaving_delay_with_invalid_duration(self, duration, unit):
         """Raise if delay with invalid duration is given as interleaved_element"""
@@ -192,6 +192,7 @@ class TestInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
                 interleaved_element=Delay(duration, unit=unit),
                 qubits=[0],
                 lengths=[1, 2, 3],
+                backend=self.backend_with_timing_constraint,
             )
 
     def test_experiment_config(self):
@@ -256,7 +257,7 @@ class TestInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
         """Interleaved RB should not change a given interleaved circuit during RB circuit generation."""
         interleaved_circ = QuantumCircuit(2, name="bell_with_delay")
         interleaved_circ.h(0)
-        interleaved_circ.delay(160, 0)
+        interleaved_circ.delay(1.0e-7, 0, unit="s")
         interleaved_circ.cx(0, 1)
 
         exp = rb.InterleavedRB(
@@ -271,8 +272,10 @@ class TestInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
     def test_interleaving_delay(self):
         """Test delay instruction can be interleaved."""
         # See qiskit-experiments/#727 for details
+        from qiskit_experiments.framework.backend_timing import BackendTiming
+        timing = BackendTiming(self.backend)
         exp = rb.InterleavedRB(
-            interleaved_element=Delay(100),  # TODO: Use BackendTiming
+            interleaved_element=Delay(timing.round_delay(time=1.0e-7)),
             qubits=[0],
             lengths=[1],
             num_samples=1,

--- a/test/library/randomized_benchmarking/test_randomized_benchmarking.py
+++ b/test/library/randomized_benchmarking/test_randomized_benchmarking.py
@@ -11,28 +11,299 @@
 # that they have been altered from the originals.
 
 """Test for randomized benchmarking experiments."""
-
 from test.base import QiskitExperimentsTestCase
 
-import random
-from ddt import ddt, data, unpack
 import numpy as np
+from ddt import ddt, data, unpack
 
 from qiskit.circuit import Delay, QuantumCircuit
 from qiskit.circuit.library import SXGate, CXGate, TGate, CZGate
 from qiskit.exceptions import QiskitError
+from qiskit.providers.fake_provider import FakeManila, FakeWashington
 from qiskit.quantum_info import Operator
 from qiskit_aer import AerSimulator
 from qiskit_aer.noise import NoiseModel, depolarizing_error
-
-from qiskit_experiments.library import randomized_benchmarking as rb
-from qiskit_experiments.library.randomized_benchmarking import CliffordUtils
-from qiskit_experiments.framework.composite import ParallelExperiment
 from qiskit_experiments.database_service.exceptions import ExperimentEntryNotFound
+from qiskit_experiments.framework.composite import ParallelExperiment
+from qiskit_experiments.library import randomized_benchmarking as rb
 
 
-class RBTestCase(QiskitExperimentsTestCase):
-    """Base test case for randomized benchmarking defining a common noise model."""
+class RBTestMixin:
+    """Mixin for RB tests."""
+
+    def assertAllIdentity(self, circuits):
+        """Test if all experiment circuits are identity."""
+        for circ in circuits:
+            num_qubits = circ.num_qubits
+            qc_iden = QuantumCircuit(num_qubits)
+            circ.remove_final_measurements()
+            self.assertTrue(Operator(circ).equiv(Operator(qc_iden)))
+
+
+@ddt
+class TestStandardRB(QiskitExperimentsTestCase, RBTestMixin):
+    """Test for StandardRB without running the experiments."""
+
+    def setUp(self):
+        """Setup the tests."""
+        super().setUp()
+        self.backend = FakeManila()
+
+    # ### Tests for configuration ###
+    @data(
+        {"qubits": [3, 3], "lengths": [1, 3, 5, 7, 9], "num_samples": 1, "seed": 100},
+        {"qubits": [0, 1], "lengths": [1, 3, 5, -7, 9], "num_samples": 1, "seed": 100},
+        {"qubits": [0, 1], "lengths": [1, 3, 5, 7, 9], "num_samples": -4, "seed": 100},
+        {"qubits": [0, 1], "lengths": [1, 3, 5, 7, 9], "num_samples": 0, "seed": 100},
+        {"qubits": [0, 1], "lengths": [1, 5, 5, 5, 9], "num_samples": 2, "seed": 100},
+    )
+    def test_invalid_configuration(self, configs):
+        """Test raise error when creating experiment with invalid configs."""
+        self.assertRaises(QiskitError, rb.StandardRB, **configs)
+
+    def test_experiment_config(self):
+        """Test converting to and from config works"""
+        exp = rb.StandardRB(qubits=(0,), lengths=[10, 20, 30], seed=123)
+        loaded_exp = rb.StandardRB.from_config(exp.config())
+        self.assertNotEqual(exp, loaded_exp)
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
+
+    def test_roundtrip_serializable(self):
+        """Test round trip JSON serialization"""
+        exp = rb.StandardRB(qubits=(0,), lengths=[10, 20, 30], seed=123)
+        self.assertRoundTripSerializable(exp, self.json_equiv)
+
+    def test_analysis_config(self):
+        """ "Test converting analysis to and from config works"""
+        analysis = rb.RBAnalysis()
+        loaded = rb.RBAnalysis.from_config(analysis.config())
+        self.assertNotEqual(analysis, loaded)
+        self.assertEqual(analysis.config(), loaded.config())
+
+    # ### Tests for circuit generation ###
+    def test_return_same_circuit(self):
+        """Test if setting the same seed returns the same circuits."""
+        exp1 = rb.StandardRB(
+            qubits=(0, 1),
+            lengths=[10, 20, 30],
+            seed=123,
+            backend=self.backend,
+        )
+
+        exp2 = rb.StandardRB(
+            qubits=(0, 1),
+            lengths=[10, 20, 30],
+            seed=123,
+            backend=self.backend,
+        )
+
+        exp1.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
+        exp2.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
+        circs1 = exp1.circuits()
+        circs2 = exp2.circuits()
+
+        self.assertEqual(circs1[0].decompose(), circs2[0].decompose())
+        self.assertEqual(circs1[1].decompose(), circs2[1].decompose())
+        self.assertEqual(circs1[2].decompose(), circs2[2].decompose())
+
+    def test_full_sampling_single_qubit(self):
+        """Test if full sampling generates different circuits."""
+        exp1 = rb.StandardRB(
+            qubits=(0,),
+            lengths=[10, 20, 30],
+            seed=123,
+            backend=self.backend,
+            full_sampling=False,
+        )
+        exp1.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
+        exp2 = rb.StandardRB(
+            qubits=(0,),
+            lengths=[10, 20, 30],
+            seed=123,
+            backend=self.backend,
+            full_sampling=True,
+        )
+        exp2.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
+        circs1 = exp1.circuits()
+        circs2 = exp2.circuits()
+
+        self.assertEqual(circs1[0].decompose(), circs2[0].decompose())
+
+        # fully sampled circuits are regenerated while other is just built on top of previous length
+        self.assertNotEqual(circs1[1].decompose(), circs2[1].decompose())
+        self.assertNotEqual(circs1[2].decompose(), circs2[2].decompose())
+
+    def test_full_sampling_2_qubits(self):
+        """Test if full sampling generates different circuits."""
+        exp1 = rb.StandardRB(
+            qubits=(0, 1),
+            lengths=[10, 20, 30],
+            seed=123,
+            backend=self.backend,
+            full_sampling=False,
+        )
+        exp1.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
+
+        exp2 = rb.StandardRB(
+            qubits=(0, 1),
+            lengths=[10, 20, 30],
+            seed=123,
+            backend=self.backend,
+            full_sampling=True,
+        )
+        exp2.set_transpile_options(basis_gates=["rz", "sx", "cx"], optimization_level=1)
+
+        circs1 = exp1.circuits()
+        circs2 = exp2.circuits()
+
+        self.assertEqual(circs1[0].decompose(), circs2[0].decompose())
+
+        # fully sampled circuits are regenerated while other is just built on top of previous length
+        self.assertNotEqual(circs1[1].decompose(), circs2[1].decompose())
+        self.assertNotEqual(circs1[2].decompose(), circs2[2].decompose())
+
+
+@ddt
+class TestInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
+    """Test for InterleavedRB without running the experiments."""
+
+    def setUp(self):
+        """Setup the tests."""
+        super().setUp()
+        self.backend = FakeManila()
+        self.backend_with_timing_constraint = FakeWashington()
+
+    # ### Tests for configuration ###
+    def test_non_clifford_interleaved_element(self):
+        """Verifies trying to run interleaved RB with non Clifford element throws an exception"""
+        with self.assertRaises(QiskitError):
+            rb.InterleavedRB(
+                interleaved_element=TGate(),  # T gate is not Clifford, this should fail
+                qubits=[0],
+                lengths=[1, 2, 3, 5, 8, 13],
+            )
+
+    @data([5, "dt"], [3.2e-7, "s"])
+    @unpack
+    def test_interleaving_delay_with_invalid_duration(self, duration, unit):
+        """Raise if delay with invalid duration is given as interleaved_element"""
+        with self.assertRaises(QiskitError):
+            rb.InterleavedRB(
+                interleaved_element=Delay(duration, unit=unit),
+                qubits=[0],
+                lengths=[1, 2, 3],
+            )
+
+    def test_experiment_config(self):
+        """Test converting to and from config works"""
+        exp = rb.InterleavedRB(
+            interleaved_element=SXGate(),
+            qubits=(0,),
+            lengths=[10, 20, 30],
+            seed=123,
+        )
+        loaded_exp = rb.InterleavedRB.from_config(exp.config())
+        self.assertNotEqual(exp, loaded_exp)
+        self.assertTrue(self.json_equiv(exp, loaded_exp))
+
+    def test_roundtrip_serializable(self):
+        """Test round trip JSON serialization"""
+        exp = rb.InterleavedRB(
+            interleaved_element=SXGate(), qubits=(0,), lengths=[10, 20, 30], seed=123
+        )
+        self.assertRoundTripSerializable(exp, self.json_equiv)
+
+    def test_analysis_config(self):
+        """ "Test converting analysis to and from config works"""
+        analysis = rb.InterleavedRBAnalysis()
+        loaded = rb.InterleavedRBAnalysis.from_config(analysis.config())
+        self.assertNotEqual(analysis, loaded)
+        self.assertEqual(analysis.config(), loaded.config())
+
+    # ### Tests for circuit generation ###
+    @data([SXGate(), [3], 4], [CXGate(), [4, 7], 5])
+    @unpack
+    def test_interleaved_structure(self, interleaved_element, qubits, length):
+        """Verifies that when generating an interleaved circuit, it will be
+        identical to the original circuit up to additions of
+        barrier and interleaved element between any two Cliffords.
+        """
+        exp = rb.InterleavedRB(
+            interleaved_element=interleaved_element, qubits=qubits, lengths=[length], num_samples=1
+        )
+
+        circuits = exp.circuits()
+        c_std = circuits[0]
+        c_int = circuits[1]
+        if c_std.metadata["interleaved"]:
+            c_std, c_int = c_int, c_std
+        num_cliffords = c_std.metadata["xval"]
+        std_idx = 0
+        int_idx = 0
+        for _ in range(num_cliffords):
+            # barrier
+            self.assertEqual(c_std[std_idx][0].name, "barrier")
+            self.assertEqual(c_int[int_idx][0].name, "barrier")
+            # clifford
+            self.assertEqual(c_std[std_idx + 1], c_int[int_idx + 1])
+            # for interleaved circuit: barrier + interleaved element
+            self.assertEqual(c_int[int_idx + 2][0].name, "barrier")
+            self.assertEqual(c_int[int_idx + 3][0].name, interleaved_element.name)
+            std_idx += 2
+            int_idx += 4
+
+    def test_preserve_interleaved_circuit_element(self):
+        """Interleaved RB should not change a given interleaved circuit during RB circuit generation."""
+        interleaved_circ = QuantumCircuit(2, name="bell_with_delay")
+        interleaved_circ.h(0)
+        interleaved_circ.delay(160, 0)
+        interleaved_circ.cx(0, 1)
+
+        exp = rb.InterleavedRB(
+            interleaved_element=interleaved_circ, qubits=[2, 1], lengths=[1], num_samples=1
+        )
+        circuits = exp.circuits()
+        # Get the first interleaved operation in the interleaved RB sequence:
+        # 0: barrier, 1: clifford, 2: barrier, 3: interleaved
+        actual = circuits[1][3].operation
+        self.assertEqual(interleaved_circ.count_ops(), actual.definition.count_ops())
+
+    def test_interleaving_delay(self):
+        """Test delay instruction can be interleaved."""
+        # See qiskit-experiments/#727 for details
+        exp = rb.InterleavedRB(
+            interleaved_element=Delay(100),  # TODO: Use BackendTiming
+            qubits=[0],
+            lengths=[1],
+            num_samples=1,
+            seed=1234,  # This seed gives a 2-gate clifford
+            backend=self.backend,
+        )
+        int_circs = exp.circuits()[1]
+        # barrier, 2-gate clifford, barrier, "delay", barrier, ...
+        self.assertEqual(int_circs.data[3][0].name, "delay")
+        self.assertAllIdentity([int_circs])
+
+    def test_interleaving_circuit_with_delay(self):
+        """Test circuit with delay can be interleaved."""
+        delay_qc = QuantumCircuit(2)
+        delay_qc.delay(160, [0])
+        delay_qc.x(1)
+
+        exp = rb.InterleavedRB(
+            interleaved_element=delay_qc,
+            qubits=[1, 2],
+            lengths=[1],
+            num_samples=1,
+            seed=1234,
+            backend=self.backend,
+        )
+        int_circ = exp.circuits()[1]
+        self.assertAllIdentity([int_circ])
+
+
+class RBRunTestCase(QiskitExperimentsTestCase, RBTestMixin):
+    """Base test case for running RB experiments defining a common noise model."""
 
     def setUp(self):
         """Setup the tests."""
@@ -70,18 +341,9 @@ class RBTestCase(QiskitExperimentsTestCase):
         # Aer simulator
         self.backend = AerSimulator(noise_model=noise_model, seed_simulator=123)
 
-    def assertAllIdentity(self, circuits):
-        """Test if all experiment circuits are identity."""
-        for circ in circuits:
-            num_qubits = circ.num_qubits
-            qc_iden = QuantumCircuit(num_qubits)
-            circ.remove_final_measurements()
-            assert Operator(circ).equiv(Operator(qc_iden))
 
-
-@ddt
-class TestStandardRB(RBTestCase):
-    """Test for standard RB."""
+class TestRunStandardRB(RBRunTestCase):
+    """Test for running StandardRB."""
 
     def test_single_qubit(self):
         """Test single qubit RB."""
@@ -199,134 +461,25 @@ class TestStandardRB(RBTestCase):
         from qiskit.providers.fake_provider import FakeVigoV2
 
         backend = FakeVigoV2()
+        # TODO: this test no longer makes sense (yields small reduced_chisq)
+        #  after fixing how to call fake backend v2 (by adding the next line)
+        # Need to call target before running fake backend v2 to load correct data
+        self.assertLess(backend.target["sx"][(0,)].error, 0.001)
+
         exp = rb.StandardRB(
             qubits=(0,),
-            lengths=[100, 200, 300, 400],
+            lengths=[100, 200, 300],
             seed=123,
             backend=backend,
             num_samples=5,
         )
         exp.set_transpile_options(basis_gates=["x", "sx", "rz"], optimization_level=1)
-        # Simulator seed must be fixed. This can be set via run option with FakeBackend.
-        # pylint: disable=no-member
-        exp.set_run_options(seed_simulator=456)
 
         expdata = exp.run()
         self.assertExperimentDone(expdata)
         overview = expdata.analysis_results(0).value
         # This yields bad fit due to poor data points, but still fit is not completely off.
         self.assertLess(overview.reduced_chisq, 10)
-
-    def test_return_same_circuit(self):
-        """Test if setting the same seed returns the same circuits."""
-        exp1 = rb.StandardRB(
-            qubits=(0, 1),
-            lengths=[10, 20, 30],
-            seed=123,
-            backend=self.backend,
-        )
-
-        exp2 = rb.StandardRB(
-            qubits=(0, 1),
-            lengths=[10, 20, 30],
-            seed=123,
-            backend=self.backend,
-        )
-
-        exp1.set_transpile_options(**self.transpiler_options)
-        exp2.set_transpile_options(**self.transpiler_options)
-        circs1 = exp1.circuits()
-        circs2 = exp2.circuits()
-
-        self.assertEqual(circs1[0].decompose(), circs2[0].decompose())
-        self.assertEqual(circs1[1].decompose(), circs2[1].decompose())
-        self.assertEqual(circs1[2].decompose(), circs2[2].decompose())
-
-    def test_full_sampling_single_qubit(self):
-        """Test if full sampling generates different circuits."""
-        exp1 = rb.StandardRB(
-            qubits=(0,),
-            lengths=[10, 20, 30],
-            seed=123,
-            backend=self.backend,
-            full_sampling=False,
-        )
-        exp1.set_transpile_options(**self.transpiler_options)
-        exp2 = rb.StandardRB(
-            qubits=(0,),
-            lengths=[10, 20, 30],
-            seed=123,
-            backend=self.backend,
-            full_sampling=True,
-        )
-        exp2.set_transpile_options(**self.transpiler_options)
-        circs1 = exp1.circuits()
-        circs2 = exp2.circuits()
-
-        self.assertEqual(circs1[0].decompose(), circs2[0].decompose())
-
-        # fully sampled circuits are regenerated while other is just built on top of previous length
-        self.assertNotEqual(circs1[1].decompose(), circs2[1].decompose())
-        self.assertNotEqual(circs1[2].decompose(), circs2[2].decompose())
-
-    def test_full_sampling_2_qubits(self):
-        """Test if full sampling generates different circuits."""
-        exp1 = rb.StandardRB(
-            qubits=(0, 1),
-            lengths=[10, 20, 30],
-            seed=123,
-            backend=self.backend,
-            full_sampling=False,
-        )
-        exp1.set_transpile_options(**self.transpiler_options)
-
-        exp2 = rb.StandardRB(
-            qubits=(0, 1),
-            lengths=[10, 20, 30],
-            seed=123,
-            backend=self.backend,
-            full_sampling=True,
-        )
-        exp2.set_transpile_options(**self.transpiler_options)
-
-        circs1 = exp1.circuits()
-        circs2 = exp2.circuits()
-
-        self.assertEqual(circs1[0].decompose(), circs2[0].decompose())
-
-        # fully sampled circuits are regenerated while other is just built on top of previous length
-        self.assertNotEqual(circs1[1].decompose(), circs2[1].decompose())
-        self.assertNotEqual(circs1[2].decompose(), circs2[2].decompose())
-
-    @data(
-        {"qubits": [3, 3], "lengths": [1, 3, 5, 7, 9], "num_samples": 1, "seed": 100},
-        {"qubits": [0, 1], "lengths": [1, 3, 5, -7, 9], "num_samples": 1, "seed": 100},
-        {"qubits": [0, 1], "lengths": [1, 3, 5, 7, 9], "num_samples": -4, "seed": 100},
-        {"qubits": [0, 1], "lengths": [1, 3, 5, 7, 9], "num_samples": 0, "seed": 100},
-        {"qubits": [0, 1], "lengths": [1, 5, 5, 5, 9], "num_samples": 2, "seed": 100},
-    )
-    def test_invalid_configuration(self, configs):
-        """Test raise error when creating experiment with invalid configs."""
-        self.assertRaises(QiskitError, rb.StandardRB, **configs)
-
-    def test_experiment_config(self):
-        """Test converting to and from config works"""
-        exp = rb.StandardRB(qubits=(0,), lengths=[10, 20, 30], seed=123)
-        loaded_exp = rb.StandardRB.from_config(exp.config())
-        self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
-
-    def test_roundtrip_serializable(self):
-        """Test round trip JSON serialization"""
-        exp = rb.StandardRB(qubits=(0,), lengths=[10, 20, 30], seed=123)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
-
-    def test_analysis_config(self):
-        """ "Test converting analysis to and from config works"""
-        analysis = rb.RBAnalysis()
-        loaded = rb.RBAnalysis.from_config(analysis.config())
-        self.assertNotEqual(analysis, loaded)
-        self.assertEqual(analysis.config(), loaded.config())
 
     def test_expdata_serialization(self):
         """Test serializing experiment data works."""
@@ -414,86 +567,28 @@ class TestStandardRB(RBTestCase):
         self.assertAlmostEqual(epc.value.n, epc_expected, delta=0.5 * epc_expected)
 
 
-@ddt
-class TestInterleavedRB(RBTestCase):
-    """Test for interleaved RB."""
-
-    @data([SXGate(), [3], 4], [CXGate(), [4, 7], 5])
-    @unpack
-    def test_interleaved_structure(self, interleaved_element, qubits, length):
-        """Verifies that when generating an interleaved circuit, it will be
-        identical to the original circuit up to additions of
-        barrier and interleaved element between any two Cliffords.
-        """
-        full_sampling = [True, False]
-        for val in full_sampling:
-            exp = rb.InterleavedRB(
-                interleaved_element=interleaved_element,
-                qubits=qubits,
-                lengths=[length],
-                num_samples=1,
-                full_sampling=val,
-            )
-            exp.set_transpile_options(**self.transpiler_options)
-            circuits = exp.circuits()
-            c_std = circuits[0]
-            c_int = circuits[1]
-            if c_std.metadata["interleaved"]:
-                c_std, c_int = c_int, c_std
-            num_cliffords = c_std.metadata["xval"]
-            std_idx = 0
-            int_idx = 0
-            for _ in range(num_cliffords):
-                # barrier
-                self.assertEqual(c_std[std_idx][0].name, "barrier")
-                self.assertEqual(c_int[int_idx][0].name, "barrier")
-                # clifford
-                std_idx += 1
-                int_idx += 1
-                while c_std[std_idx][0].name != "barrier":
-                    self.assertEqual(c_std[std_idx], c_int[int_idx])
-                    std_idx += 1
-                    int_idx += 1
-                # for interleaved circuit: barrier + interleaved element
-                self.assertEqual(c_int[int_idx][0].name, "barrier")
-                int_idx += 1
-                self.assertEqual(c_int[int_idx][0].name, interleaved_element.name)
-                int_idx += 1
+class TestRunInterleavedRB(RBRunTestCase):
+    """Test for running InterleavedRB."""
 
     def test_single_qubit(self):
-        """Test single qubit IRB, once with an interleaved gate, once with an interleaved
-        Clifford circuit.
-        """
-        interleaved_gate = SXGate()
-        random.seed(123)
-        num = random.randint(0, 23)
-        interleaved_clifford = CliffordUtils.clifford_1_qubit_circuit(num)
-        # The circuit created for interleaved_clifford is:
-        # qc = QuantumCircuit(1)
-        # qc.rz(np.pi/2, 0)
-        # qc.sx(0)
-        # qc.rz(np.pi/2, 0)
-        # Since there is a single sx per interleaved_element,
-        # therefore epc_expected is the same as for when interleaved_element = SXGate()
-        for interleaved_element in [interleaved_gate, interleaved_clifford]:
-            exp = rb.InterleavedRB(
-                interleaved_element=interleaved_element,
-                qubits=(0,),
-                lengths=list(range(1, 300, 30)),
-                seed=123,
-                backend=self.backend,
-            )
-            exp.set_transpile_options(**self.transpiler_options)
+        """Test single qubit IRB."""
+        exp = rb.InterleavedRB(
+            interleaved_element=SXGate(),
+            qubits=(0,),
+            lengths=list(range(1, 300, 30)),
+            seed=123,
+            backend=self.backend,
+        )
+        exp.set_transpile_options(**self.transpiler_options)
+        self.assertAllIdentity(exp.circuits())
 
-            self.assertAllIdentity(exp.circuits())
+        expdata = exp.run()
+        self.assertExperimentDone(expdata)
 
-            expdata = exp.run()
-            self.assertExperimentDone(expdata)
-
-            # Since this is interleaved, we can directly compare values, i.e. n_gpc = 1
-            epc = expdata.analysis_results("EPC")
-            epc_expected = 1 / 2 * self.p1q
-            self.assertAlmostEqual(epc.value.n, epc_expected, delta=0.1 * epc_expected)
+        # Since this is interleaved, we can directly compare values, i.e. n_gpc = 1
+        epc = expdata.analysis_results("EPC")
+        epc_expected = 1 / 2 * self.p1q
+        self.assertAlmostEqual(epc.value.n, epc_expected, delta=0.1 * epc_expected)
 
     def test_two_qubit(self):
         """Test two qubit IRB."""
@@ -525,7 +620,7 @@ class TestInterleavedRB(RBTestCase):
             interleaved_element=CZGate(),
             qubits=(0, 1),
             lengths=list(range(1, 30, 3)),
-            seed=123,
+            seed=1234,
             backend=self.backend,
         )
         exp.set_transpile_options(**transpiler_options)
@@ -538,85 +633,6 @@ class TestInterleavedRB(RBTestCase):
         epc = expdata.analysis_results("EPC")
         epc_expected = 3 / 4 * self.pcz
         self.assertAlmostEqual(epc.value.n, epc_expected, delta=0.1 * epc_expected)
-
-    def test_non_clifford_interleaved_element(self):
-        """Verifies trying to run interleaved RB with non Clifford element throws an exception"""
-        qubits = [0]
-        lengths = [1, 4, 6, 9, 13, 16]
-        interleaved_element = TGate()  # T gate is not Clifford, this should fail
-        self.assertRaises(
-            QiskitError,
-            rb.InterleavedRB,
-            interleaved_element=interleaved_element,
-            qubits=qubits,
-            lengths=lengths,
-        )
-
-    def test_interleaving_delay(self):
-        """Test delay instruction can be interleaved."""
-        # See qiskit-experiments/#727 for details
-        interleaved_element = Delay(10, unit="us")
-        exp = rb.InterleavedRB(
-            interleaved_element,
-            qubits=[0],
-            lengths=[1],
-            num_samples=1,
-            seed=1234,  # This seed gives a 2-gate clifford
-        )
-        exp.set_transpile_options(**self.transpiler_options)
-
-        int_circs = exp.circuits()[1]
-
-        # barrier, 2-gate clifford, barrier, "delay", barrier, ...
-        self.assertEqual(int_circs.data[4][0].name, interleaved_element.name)
-
-        # Transpiled delay duration is represented in seconds, so must convert from us
-        self.assertEqual(int_circs.data[4][0].unit, "s")
-        self.assertAlmostEqual(int_circs.data[4][0].params[0], interleaved_element.params[0] * 1e-6)
-        self.assertAllIdentity([int_circs])
-
-    def test_interleaving_circuit_with_delay(self):
-        """Test circuit with delay can be interleaved."""
-        delay_qc = QuantumCircuit(2)
-        delay_qc.delay(10, [0], unit="us")
-        delay_qc.x(1)
-
-        exp = rb.InterleavedRB(
-            interleaved_element=delay_qc,
-            qubits=[1, 2],
-            lengths=[1],
-            seed=123,
-            num_samples=1,
-        )
-        exp.set_transpile_options(**self.transpiler_options)
-        int_circ = exp.circuits()[1]
-        self.assertAllIdentity([int_circ])
-
-    def test_experiment_config(self):
-        """Test converting to and from config works"""
-        exp = rb.InterleavedRB(
-            interleaved_element=SXGate(),
-            qubits=(0,),
-            lengths=[10, 20, 30],
-            seed=123,
-        )
-        loaded_exp = rb.InterleavedRB.from_config(exp.config())
-        self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
-
-    def test_roundtrip_serializable(self):
-        """Test round trip JSON serialization"""
-        exp = rb.InterleavedRB(
-            interleaved_element=SXGate(), qubits=(0,), lengths=[10, 20, 30], seed=123
-        )
-        self.assertRoundTripSerializable(exp, self.json_equiv)
-
-    def test_analysis_config(self):
-        """ "Test converting analysis to and from config works"""
-        analysis = rb.InterleavedRBAnalysis()
-        loaded = rb.InterleavedRBAnalysis.from_config(analysis.config())
-        self.assertNotEqual(analysis, loaded)
-        self.assertEqual(analysis.config(), loaded.config())
 
     def test_expdata_serialization(self):
         """Test serializing experiment data works."""

--- a/test/library/randomized_benchmarking/test_randomized_benchmarking.py
+++ b/test/library/randomized_benchmarking/test_randomized_benchmarking.py
@@ -167,7 +167,9 @@ class TestStandardRB(QiskitExperimentsTestCase, RBTestMixin):
         my_inst_map = InstructionScheduleMap()
         my_inst_map.add(SXGate(), qubits, my_sched)
 
-        exp = rb.StandardRB(qubits=qubits, lengths=[3], num_samples=4, backend=self.backend)
+        exp = rb.StandardRB(
+            qubits=qubits, lengths=[3], num_samples=4, backend=self.backend, seed=123
+        )
         exp.set_transpile_options(inst_map=my_inst_map)
         transpiled = exp._transpiled_circuits()
         for qc in transpiled:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR is a follow-up of #892 for further performance improvement with several clean-ups suggested in the review of PR 892.


### Details and comments
The drastic performance improvement in 1Q/2Q RB (PR 892) was mostly come from two ideas:
1. Custom transpilation (mapping circuits to physical qubits without using `transpile`)
2. Integer-based Clifford operations (especially sparse lookup table with triplet decomposition for 2Q Clifford circuits)

PR 892 implements more than those two (including some not contributing to the performance improvement) and they make difficult to track what really improved the performance and seem overly reduce maintainability of the code.

This PR cleans up the implementation of Standard/InterleavedRB without performance regression and add further optimization in the implementation of (1) custom transpilation with following several suggestions given in PR 892. For insetances,
- Change back to the simple code structure introduced at #898
- Change back to return wrapped Clifford circuits (not unwrapped ones), such a change (wrapped -> unwrapped) should be discussed as [an independent issue](https://github.com/Qiskit/qiskit-experiments/issues/930)
- Move `StandardRB._layout_for_rb` to `clifford_utils._transpile_clifford_circuit` and add further optimization. 
(See also [the original draft PR](https://github.com/Qiskit/qiskit-experiments/pull/906/files) to roughly understand which code blocks are essentially changed for above updates)
- Fix a bug that ignores user calibrations in custom transpilation of 1Q/2Q RB circuits

Other features added in this PR includes:
- Add the same fix as in #905
- Improve validation of interleave_element
- Restructure tests

This PR achieves further speed-up (1.2x for 1Q StandardRB, 1.1x for 2Q StandardRB, 3.4x for 1Q InterleavedRB, 1.6x for 2Q InterleavedRB) measured by [this benchmark](https://gist.github.com/itoko/f078218ea6458f32d1c0f9be827f614f).
This PR will be followed by one more PR that cleans up `clifford_utils`, which is left with minimal updates in this PR.
