### PR TITLE
Fix failing tests on Python3.7 caused by importlib_metadata v5.0.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,5 @@ qiskit-aer>=0.11.0
 pandas>=1.1.5
 cvxpy>=1.1.15
 pylatexenc
+# Pin `importlib-metadata` because of a bug relating to version 5.0.0. See #931 for more.
+importlib-metadata==4.13.0;python_version<'3.8'


### PR DESCRIPTION
### Summary

The recently released version 5.0.0 of importlib_metadata, which is a required development dependency, is breaking CI tests. This PR pins the version to <5.0.0 for Python versions that need it.

### Details and comments

For details, see #931 and Qiskit/rustworkx#689.

