### PR TITLE
Update CR Hamiltonian Tomography experiment

### DIFF
--- a/qiskit_experiments/library/characterization/cr_hamiltonian.py
+++ b/qiskit_experiments/library/characterization/cr_hamiltonian.py
@@ -236,7 +236,7 @@ class CrossResonanceHamiltonian(BaseExperiment):
         super()._set_backend(backend)
         self._backend_timing = BackendTiming(backend)
 
-    def _get_dt(self):
+    def _get_dt(self) -> float:
         """A helper function to get finite dt.
 
         Returns:

--- a/qiskit_experiments/library/characterization/cr_hamiltonian.py
+++ b/qiskit_experiments/library/characterization/cr_hamiltonian.py
@@ -179,9 +179,10 @@ class CrossResonanceHamiltonian(BaseExperiment):
                 "Length of qubits is not 2. Please provide index for control and target qubit."
             )
 
-        super().__init__(qubits, analysis=CrossResonanceHamiltonianAnalysis(), backend=backend)
-        self._backend_timing = None
         self._gate_cls = cr_gate or self.CRPulseGate
+        self._backend_timing = None
+
+        super().__init__(qubits, analysis=CrossResonanceHamiltonianAnalysis(), backend=backend)
         self.set_experiment_options(durations=durations, **kwargs)
 
         if flat_top_widths is not None:

--- a/qiskit_experiments/library/characterization/cr_hamiltonian.py
+++ b/qiskit_experiments/library/characterization/cr_hamiltonian.py
@@ -329,14 +329,16 @@ class CrossResonanceHamiltonian(BaseExperiment):
             A list of :class:`QuantumCircuit`.
 
         Raises:
-            QiskitError: When the backend is not set with use of pulse gate.
+            QiskitError: When the backend is not set and cr gate is ``CRPulseGate`` type.
         """
         if self._gate_cls is self.CRPulseGate:
             if not self.backend:
                 # Backend is not set, but trying to provide CR gate as a pulse gate.
                 raise QiskitError(
                     "This experiment requires to have backend set to convert durations into samples "
-                    "with backend reported dt value."
+                    "with backend reported dt value and also it requires the channel mapping from "
+                    "the backend to build cross resonance pulse schedule. "
+                    "Please provide valid backend object supporting 2Q pulse gate."
                 )
             return self._pulse_gate_circuits()
         return self._unitary_circuits()

--- a/qiskit_experiments/library/characterization/cr_hamiltonian.py
+++ b/qiskit_experiments/library/characterization/cr_hamiltonian.py
@@ -13,7 +13,7 @@
 Cross resonance Hamiltonian tomography.
 """
 
-from typing import List, Tuple, Iterable, Optional, Type
+from typing import List, Tuple, Sequence, Iterable, Optional, Type
 
 import warnings
 import numpy as np
@@ -21,7 +21,12 @@ from qiskit import pulse, circuit, QuantumCircuit
 from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.exceptions import QiskitError
 from qiskit.providers import Backend
-from qiskit_experiments.framework import BaseExperiment, Options
+from qiskit_experiments.framework import (
+    BaseExperiment,
+    BackendData,
+    BackendTiming,
+    Options,
+)
 from qiskit_experiments.library.characterization.analysis import CrossResonanceHamiltonianAnalysis
 
 
@@ -89,29 +94,27 @@ class CrossResonanceHamiltonian(BaseExperiment):
         excited and ground state, ``P`` will become ``X`` gate or just be omitted, respectively.
         Here ``cr_tone`` is implemented by a single cross resonance tone
         driving the control qubit at the frequency of the target qubit.
-        The pulse envelope is the flat-topped Gaussian implemented by the parametric pulse
+        The pulse envelope might be a flat-topped Gaussian implemented by the parametric pulse
         :py:class:`~qiskit.pulse.library.parametric_pulses.GaussianSquare`.
 
-        This experiment scans the flat-top width of the :py:class:`~qiskit.pulse.library.\
-        parametric_pulses.GaussianSquare` envelope with the fixed rising and falling edges.
-        The total pulse duration is implicitly computed to meet the timing constraints of
-        the target backend. The edge duration is usually computed as
-
-        .. math::
-
-            \tau_{\rm edges} = 2 r \sigma,
-
-        where the :math:`r` is the ratio of the actual edge duration to :math:`\sigma` of
-        the Gaussian rising and falling edges. Note that actual edge duration is not
-        identical to the net duration because of the smaller pulse amplitude of the edges.
-
-        The net edge duration is an extra fitting parameter with initial guess
+        This experiment scans the total duration of the cross resonance pulse
+        including the pulse ramps at both edges. The pulse shape is defined by the
+        :py:class:`~qiskit.pulse.library.parametric_pulses.GaussianSquare`, and
+        an effective length of these Gaussian ramps with :math:`\sigma` can be computed by
 
         .. math::
 
             \tau_{\rm edges}' = \sqrt{2 \pi} \sigma,
 
-        which is derived by assuming a square edges with the full pulse amplitude.
+        which is usually shorter than the actual edge duration of
+
+        .. math::
+
+            \tau_{\rm edges} = 2 r \sigma,
+
+        where the :math:`r` is the ratio of the actual edge duration to :math:`\sigma`.
+        This effect must be considered in the following curve analysis to estimate
+        interaction rates.
 
     # section: analysis_ref
         :py:class:`CrossResonanceHamiltonianAnalysis`
@@ -136,9 +139,10 @@ class CrossResonanceHamiltonian(BaseExperiment):
     def __init__(
         self,
         qubits: Tuple[int, int],
-        flat_top_widths: Iterable[float],
+        flat_top_widths: Optional[Iterable[float]] = None,
         backend: Optional[Backend] = None,
         cr_gate: Optional[Type[circuit.Gate]] = None,
+        durations: Optional[Sequence[int]] = None,
         **kwargs,
     ):
         """Create a new experiment.
@@ -146,84 +150,114 @@ class CrossResonanceHamiltonian(BaseExperiment):
         Args:
             qubits: Two-value tuple of qubit indices on which to run tomography.
                 The first index stands for the control qubit.
-            flat_top_widths: The total duration of the square part of cross resonance pulse(s)
-                to scan, in units of dt. The total pulse duration including Gaussian rising and
-                falling edges is implicitly computed with experiment parameters ``sigma`` and
-                ``risefall``.
+            flat_top_widths: Deprecated. The total duration of the square part of
+                cross resonance pulse(s) to scan, in units of dt.
+                The total pulse duration including Gaussian rising and falling edges is
+                implicitly computed with experiment parameters ``sigma`` and ``risefall``.
             backend: Optional, the backend to run the experiment on.
-            cr_gate: Optional, circuit gate instruction of cross resonance pulse.
+            cr_gate: Optional, circuit gate class representing the cross resonance pulse.
+                Providing this object allows us to run this experiment with circuit simulator,
+                and this object might be used for testing, development of analysis protocol,
+                and educational purpose without needing to wait for hardware queueing.
+                Note that this instance must provide matrix representation, such as
+                unitary gate or Hamiltonian gate, and the class is expected to be instantiated
+                with a single parameter ``width`` in units of sec.
+            durations: Optional. The total duration of cross resonance pulse(s) including
+                rising and falling edges. The minimum number should be larger than the
+                total lengths of these ramps. If not provided, default patterns of
+                linear increment will be configured with experiment options.
+                This value should be provided in units of sec.
             kwargs: Pulse parameters. See :meth:`experiment_options` for details.
 
         Raises:
             QiskitError: When ``qubits`` length is not 2.
         """
-        # backend parameters required to run this experiment
-        # random values are populated here but these are immediately updated after backend is set
-        # this is to keep capability of generating circuits just for checking
-        self._dt = 1
-        self._cr_channel = 0
-        self._granularity = 1
-        self._cr_gate = cr_gate
-
         if len(qubits) != 2:
             raise QiskitError(
                 "Length of qubits is not 2. Please provide index for control and target qubit."
             )
 
         super().__init__(qubits, analysis=CrossResonanceHamiltonianAnalysis(), backend=backend)
-        self.set_experiment_options(flat_top_widths=flat_top_widths, **kwargs)
+        self._gate_cls = cr_gate or self.CRPulseGate
+        self.set_experiment_options(durations=durations, **kwargs)
+
+        if flat_top_widths is not None:
+            # TODO remove this in Qiskit Experiments 0.6
+            self.set_experiment_options(flat_top_widths=flat_top_widths)
 
     @classmethod
     def _default_experiment_options(cls) -> Options:
         """Default experiment options.
 
         Experiment Options:
-            flat_top_widths (np.ndarray): The total duration of the square part of
-                cross resonance pulse(s) to scan, in units of dt. This can start from zero and
-                take positive real values representing the durations.
-                Pulse edge effect is considered as an offset to the durations.
+            durations (np.ndarray): The total duration of the cross resonance pulse(s) to scan,
+                in units of sec. Values should be longer than pulse ramps.
+            durations_min (int): The minimum default pulse durations.
+            durations_max (int): The maximum default pulse durations.
+            durations_num (int): The number of default durations. Experiment automatically
+                creates durations of linear increment along with ``durations_min`` and
+                ``durations_max`` when user doesn't explicitly provide ``durations``.
             amp (complex): Amplitude of the cross resonance tone.
             amp_t (complex): Amplitude of the cancellation or rotary drive on target qubit.
             sigma (float): Sigma of Gaussian rise and fall edges, in units of dt.
             risefall (float): Ratio of edge durations to sigma.
         """
         options = super()._default_experiment_options()
-        options.flat_top_widths = None
-        options.amp = 0.2
+        options.flat_top_widths = None  # to be removed
+        options.durations = None
+        options.durations_min = 60e-9
+        options.durations_max = 1200e-9
+        options.durations_num = 48
+        options.amp = 0.5
         options.amp_t = 0.0
         options.sigma = 64
         options.risefall = 2
 
         return options
 
-    def _set_backend(self, backend: Backend):
-        super()._set_backend(backend)
-
-        if self._cr_gate is None:
-            # This falls into CRPulseGate which requires pulse schedule
-
-            # Extract control channel index
-            cr_channels = self._backend_data.control_channel(self.physical_qubits)
-            if cr_channels is not None:
-                self._cr_channel = cr_channels[0].index
-            else:
-                warnings.warn(
-                    f"{self._backend_data.name} doesn't provide cr channel mapping. "
-                    "Cannot find proper channel index to play the cross resonance pulse.",
-                    UserWarning,
-                )
-
-            # Extract pulse granularity
-            self._granularity = self._backend_data.granularity
-
-        # Extract time resolution, this is anyways required for xvalue conversion
-        self._dt = self._backend_data.dt
-        if self._dt is None:
+    def set_experiment_options(self, **fields):
+        if "flat_top_widths" in fields:
+            # TODO remove this in Qiskit Experiments 0.6
             warnings.warn(
-                f"{self._backend_data.name} doesn't provide system time resolution dt. "
-                "Cannot estimate Hamiltonian coefficients in SI units.",
-                UserWarning,
+                "'flat_top_widths' argument has been deprecated and will be removed. "
+                "Use 'durations' instead. New variable includes pulse ramps, "
+                "and it cannot include zero in the sequence. "
+                "This argument will be dropped with this warning in Qiskit Experiments 0.6.",
+                DeprecationWarning,
             )
+        super().set_experiment_options(**fields)
+
+    def _get_width(self, duration: ParameterValueType) -> ParameterValueType:
+        """A helper function to get flat top width.
+
+        Args:
+            duration: Cross resonance pulse duration in units of sec.
+
+        Returns:
+            A flat top widths of cross resonacne pulse in units of sec.
+        """
+        timing = BackendTiming(self.backend)
+        backend_dt = timing.dt or 1
+        sigma_sec = self.experiment_options.sigma * backend_dt
+
+        return duration - 2 * sigma_sec * self.experiment_options.risefall
+
+    def _get_durations(self) -> np.ndarray:
+        """Return cross resonance pulse durations in units of sec."""
+        opt = self.experiment_options
+
+        if opt.flat_top_widths is not None:
+            # TODO Remove this in Qiskit Experiments 0.6
+            timing = BackendTiming(self.backend)
+            backend_dt = timing.dt or 1
+            widths = np.asarray(opt.flat_top_widths, dtype=float)
+
+            return backend_dt * (widths + 2 * opt.sigma * opt.risefall)
+
+        if opt.durations is None:
+            return np.linspace(opt.durations_min, opt.durations_max, opt.durations_num)
+
+        return np.asarray(opt.durations, dtype=float)
 
     def _build_cr_circuit(self, pulse_gate: circuit.Gate) -> QuantumCircuit:
         """Single tone cross resonance.
@@ -239,49 +273,47 @@ class CrossResonanceHamiltonian(BaseExperiment):
 
         return cr_circuit
 
-    def _build_cr_schedule(self, flat_top_width: float) -> pulse.ScheduleBlock:
+    def _build_default_schedule(self) -> pulse.ScheduleBlock:
         """GaussianSquared cross resonance pulse.
-
-        Args:
-            flat_top_width: Total length of flat top part of the pulse in units of dt.
 
         Returns:
             A schedule definition for the cross resonance pulse to measure.
         """
         opt = self.experiment_options
+        duration = circuit.Parameter("duration")
 
-        # Compute valid integer duration
-        duration = flat_top_width + 2 * opt.sigma * opt.risefall
-        valid_duration = int(self._granularity * np.floor(duration / self._granularity))
+        backend_data = BackendData(self.backend)
+        cr_drive = backend_data.control_channel(self.physical_qubits)[0]
+        c_drive = backend_data.drive_channel(self.physical_qubits[0])
+        t_drive = backend_data.drive_channel(self.physical_qubits[1])
 
         with pulse.build(default_alignment="left", name="cr") as cross_resonance:
-
             # add cross resonance tone
             pulse.play(
                 pulse.GaussianSquare(
-                    duration=valid_duration,
+                    duration=duration,
                     amp=opt.amp,
                     sigma=opt.sigma,
-                    width=flat_top_width,
+                    risefall_sigma_ratio=opt.risefall,
                 ),
-                pulse.ControlChannel(self._cr_channel),
+                cr_drive,
             )
             # add cancellation tone
             if not np.isclose(opt.amp_t, 0.0):
                 pulse.play(
                     pulse.GaussianSquare(
-                        duration=valid_duration,
+                        duration=duration,
                         amp=opt.amp_t,
                         sigma=opt.sigma,
-                        width=flat_top_width,
+                        risefall_sigma_ratio=opt.risefall,
                     ),
-                    pulse.DriveChannel(self.physical_qubits[1]),
+                    t_drive,
                 )
             else:
-                pulse.delay(valid_duration, pulse.DriveChannel(self.physical_qubits[1]))
+                pulse.delay(duration, t_drive)
 
             # place holder for empty drive channels. this is necessary due to known pulse gate bug.
-            pulse.delay(valid_duration, pulse.DriveChannel(self.physical_qubits[0]))
+            pulse.delay(duration, c_drive)
 
         return cross_resonance
 
@@ -292,67 +324,153 @@ class CrossResonanceHamiltonian(BaseExperiment):
             A list of :class:`QuantumCircuit`.
 
         Raises:
-            AttributeError: When the backend doesn't report the time resolution of waveforms.
+            QiskitError: When the backend is not set with use of pulse gate.
         """
-        opt = self.experiment_options
+        if issubclass(self._gate_cls, self.CRPulseGate):
+            if not self.backend:
+                # Backend is not set, but trying to provide CR gate as a pulse gate.
+                raise QiskitError(
+                    "This experiment requires to have backend set to convert durations into samples "
+                    "with backend reported dt value."
+                )
+            return self._pulse_gate_circuits()
+        return self._unitary_circuits()
 
-        expr_circs = []
-        for flat_top_width in opt.flat_top_widths:
-            if self._cr_gate is None:
-                # default pulse gate execution
-                cr_schedule = self._build_cr_schedule(flat_top_width)
-                cr_gate = self.CRPulseGate(flat_top_width)
-            else:
-                cr_schedule = None
-                cr_gate = self._cr_gate(flat_top_width)
+    def _pulse_gate_circuits(self):
+        """Protocol to create circuits with pulse gate.
 
-            for control_state in (0, 1):
-                for meas_basis in ("x", "y", "z"):
-                    tomo_circ = QuantumCircuit(2, 1)
+        Pulse gate has backend timing constraints and duration should be in units of dt.
+        This method calls :meth:`_build_default_schedule` to generate actual schedule.
+        We assume backend has been set in this method call.
+        """
+        timing = BackendTiming(self.backend)
+        schedule = self._build_default_schedule()
 
-                    if control_state:
-                        tomo_circ.x(0)
+        # Assume this parameter is in units of dt, because this controls pulse samples.
+        param_duration = next(iter(schedule.get_parameters("duration")))
 
-                    tomo_circ.compose(
-                        other=self._build_cr_circuit(cr_gate),
-                        qubits=[0, 1],
-                        inplace=True,
-                    )
+        # Gate duration will be shown in sec, which is more intuitive.
+        cr_gate = self._gate_cls(width=self._get_width(timing.dt * param_duration))
 
-                    if meas_basis == "x":
-                        tomo_circ.h(1)
-                    elif meas_basis == "y":
-                        tomo_circ.sdg(1)
-                        tomo_circ.h(1)
-                    tomo_circ.measure(1, 0)
+        # Create parameterized circuits with calibration.
+        tmp_circs = []
+        for control_state in (0, 1):
+            for meas_basis in ("x", "y", "z"):
+                tmp_qc = QuantumCircuit(2, 1)
+                if control_state:
+                    tmp_qc.x(0)
+                tmp_qc.compose(
+                    other=self._build_cr_circuit(cr_gate),
+                    qubits=[0, 1],
+                    inplace=True,
+                )
+                if meas_basis == "y":
+                    tmp_qc.sdg(1)
+                if meas_basis in ("x", "y"):
+                    tmp_qc.h(1)
+                tmp_qc.measure(1, 0)
+                tmp_qc.metadata = {
+                    "control_state": control_state,
+                    "meas_basis": meas_basis,
+                }
+                tmp_qc.add_calibration(cr_gate, self.physical_qubits, schedule)
+                tmp_circs.append(tmp_qc)
 
-                    tomo_circ.metadata = {
-                        "experiment_type": self.experiment_type,
-                        "qubits": self.physical_qubits,
-                        "xval": flat_top_width * self._dt,  # in units of sec
-                        "control_state": control_state,
-                        "meas_basis": meas_basis,
-                    }
-                    if isinstance(cr_gate, self.CRPulseGate):
-                        # Attach calibration if this is bare pulse gate
-                        tomo_circ.add_calibration(
-                            gate=cr_gate,
-                            qubits=self.physical_qubits,
-                            schedule=cr_schedule,
-                        )
+        circs = []
+        for duration in self._get_durations():
+            # Need to round pulse to satisfy hardware timing constraints.
+            # Convert into samples for assignment and validation.
+            valid_duration_dt = timing.round_pulse(time=duration)
 
-                    expr_circs.append(tomo_circ)
-        return expr_circs
+            # Convert into sec to pass xval to analysis.
+            # Analysis expects xval of flat top widths in units of sec.
+            flat_top_width_sec = self._get_width(timing.dt * valid_duration_dt)
+            if flat_top_width_sec < 0:
+                raise ValueError(
+                    f"Input duration={duration} is less than pulse ramps lengths, resulting in "
+                    f"a negative flat top length of {flat_top_width_sec} sec. "
+                    f"This cross resonance schedule is invalid."
+                )
+
+            for circ in tmp_circs:
+                # Assign duration in dt to create pulse schedule.
+                assigned_circ = circ.assign_parameters(
+                    {param_duration: valid_duration_dt},
+                    inplace=False,
+                )
+                assigned_circ.metadata["xval"] = self.num_pulses * flat_top_width_sec
+                circs.append(assigned_circ)
+
+        return circs
+
+    def _unitary_circuits(self):
+        """Protocol to create circuits with unitary gate.
+
+        Unitary gate has no timing constraints and accepts duration in sec.
+        Basically, this method doesn't require backend apart from conversion of
+        sigma in samples into sec.
+        """
+        # Assume this parameter is in units of sec.
+        param_duration = circuit.Parameter("duration")
+
+        # Gate duration will be shown in sec, which is more intuitive.
+        cr_gate = self._gate_cls(width=self._get_width(param_duration))
+
+        # Create parameterized circuits without calibration.
+        tmp_circs = []
+        for control_state in (0, 1):
+            for meas_basis in ("x", "y", "z"):
+                tmp_qc = QuantumCircuit(2, 1)
+                if control_state:
+                    tmp_qc.x(0)
+                tmp_qc.compose(
+                    other=self._build_cr_circuit(cr_gate),
+                    qubits=[0, 1],
+                    inplace=True,
+                )
+                if meas_basis == "y":
+                    tmp_qc.sdg(1)
+                if meas_basis in ("x", "y"):
+                    tmp_qc.h(1)
+                tmp_qc.measure(1, 0)
+                tmp_qc.metadata = {
+                    "control_state": control_state,
+                    "meas_basis": meas_basis,
+                }
+                tmp_circs.append(tmp_qc)
+
+        circs = []
+        for duration in self._get_durations():
+            flat_top_width_sec = self._get_width(duration)
+            if flat_top_width_sec < 0:
+                raise ValueError(
+                    f"Input duration={duration} is less than pulse ramps lengths, resulting in "
+                    f"a negative flat top length of {flat_top_width_sec} sec. "
+                    f"This cross resonance schedule is invalid."
+                )
+
+            for circ in tmp_circs:
+                # Assign duration in sec since this is unitary gate.
+                assigned_circ = circ.assign_parameters(
+                    {param_duration: duration},
+                    inplace=False,
+                )
+                assigned_circ.metadata["xval"] = self.num_pulses * flat_top_width_sec
+                circs.append(assigned_circ)
+
+        return circs
 
     def _finalize(self):
         """Set analysis option for initial guess that depends on experiment option values."""
         edge_duration = np.sqrt(2 * np.pi) * self.experiment_options.sigma * self.num_pulses
+        timing = BackendTiming(self.backend)
+        backend_dt = timing.dt or 1
 
         for analysis in self.analysis.analyses():
             init_guess = analysis.options.p0.copy()
             if "t_off" in init_guess:
                 continue
-            init_guess["t_off"] = edge_duration * self._dt
+            init_guess["t_off"] = backend_dt * edge_duration
             analysis.set_options(p0=init_guess)
 
     def _metadata(self):

--- a/qiskit_experiments/library/characterization/cr_hamiltonian.py
+++ b/qiskit_experiments/library/characterization/cr_hamiltonian.py
@@ -326,7 +326,7 @@ class CrossResonanceHamiltonian(BaseExperiment):
         Raises:
             QiskitError: When the backend is not set with use of pulse gate.
         """
-        if issubclass(self._gate_cls, self.CRPulseGate):
+        if self._gate_cls is self.CRPulseGate:
             if not self.backend:
                 # Backend is not set, but trying to provide CR gate as a pulse gate.
                 raise QiskitError(

--- a/releasenotes/notes/update-cr-hamtomo-with-duration-380da3452045cd0c.yaml
+++ b/releasenotes/notes/update-cr-hamtomo-with-duration-380da3452045cd0c.yaml
@@ -5,7 +5,7 @@ features:
     ``durations`` with default values. Note that values should be provided in
     units of sec rather than samples, and must include pulse ramps at edges.
     Default values with linear increment are generated according to new experiment options,
-    ``durations_min``, ``durations_max`, and ``durations_num``, when the durations
+    ``min_duration``, ``max_duration`, and ``num_durations``, when the durations
     is not explicitly provided. Default value is chosen by assuming a
     typical ZX rate around 1 MHz in recent IBM Quantum backends.
     User can update these option values as well as providing full ``durations``

--- a/releasenotes/notes/update-cr-hamtomo-with-duration-380da3452045cd0c.yaml
+++ b/releasenotes/notes/update-cr-hamtomo-with-duration-380da3452045cd0c.yaml
@@ -6,8 +6,8 @@ features:
     units of sec rather than samples, and must include pulse ramps at edges.
     Default values with linear increment are generated according to new experiment options,
     ``min_duration``, ``max_duration`, and ``num_durations``, when the durations
-    is not explicitly provided. Default value is chosen by assuming a
-    typical ZX rate around 1 MHz in recent IBM Quantum backends.
+    is not explicitly provided. The default values are chosen by assuming a
+    ZX rate of around 1 MHz which is typical for IBM Quantum backends.
     User can update these option values as well as providing full ``durations``
     to tailor experiment setting to their device.
     Total durations should be carefully chosen not to overflow the waveform memory

--- a/releasenotes/notes/update-cr-hamtomo-with-duration-380da3452045cd0c.yaml
+++ b/releasenotes/notes/update-cr-hamtomo-with-duration-380da3452045cd0c.yaml
@@ -1,0 +1,30 @@
+---
+features:
+  - |
+    :class:`.CrossResonanceHamiltonian` experiment and its subclass now accept
+    ``durations`` with default values. Note that values should be provided in
+    units of sec rather than samples, and must include pulse ramps at edges.
+    Default values with linear increment are generated according to new experiment options,
+    ``durations_min``, ``durations_max`, and ``durations_num``, when the durations
+    is not explicitly provided. Default value is chosen by assuming a
+    typical ZX rate around 1 MHz in recent IBM Quantum backends.
+    User can update these option values as well as providing full ``durations``
+    to tailor experiment setting to their device.
+    Total durations should be carefully chosen not to overflow the waveform memory
+    when the experiment is run on a real hardware. With this update, 
+    the minimum example code to run this experiment might be
+    
+    .. code-block:: python
+    
+      from qiskit_experiments.library.characterization import CrossResonanceHamiltonian
+      
+      expr = CrossResonanceHamiltonian(qubits=(0, 1), amp=0.3, backend=backend)
+      exp_data = expr.run()
+    
+    where the durations to scan are implicitly set by experiment options.
+
+deprecations:
+  - |
+    The ``flat_top_widths`` argument and experiment option of 
+    :class:`.CrossResonanceHamiltonian` experiment and its subclass 
+    have been deprecated and will be removed in Qiskit Experiments 0.6.

--- a/releasenotes/notes/update-cr-hamtomo-with-duration-380da3452045cd0c.yaml
+++ b/releasenotes/notes/update-cr-hamtomo-with-duration-380da3452045cd0c.yaml
@@ -22,9 +22,13 @@ features:
       exp_data = expr.run()
     
     where the durations to scan are implicitly set by experiment options.
-
 deprecations:
   - |
     The ``flat_top_widths`` argument and experiment option of 
     :class:`.CrossResonanceHamiltonian` experiment and its subclass 
     have been deprecated and will be removed in Qiskit Experiments 0.6.
+fixes:
+  - |
+    There has been a bug in the :class:`.EchoedCrossResonanceHamiltonian` experiment 
+    in which the Hamiltonian coefficients were overestimated by a factor of 2.
+    This bug has been fixed.

--- a/test/library/characterization/test_cross_resonance_hamiltonian.py
+++ b/test/library/characterization/test_cross_resonance_hamiltonian.py
@@ -15,7 +15,6 @@
 """Spectroscopy tests."""
 from test.base import QiskitExperimentsTestCase
 
-import functools
 import numpy as np
 from ddt import ddt, data, unpack
 from qiskit import QuantumCircuit, pulse, quantum_info as qi
@@ -23,23 +22,6 @@ from qiskit.providers.fake_provider import FakeBogotaV2
 from qiskit.extensions.hamiltonian_gate import HamiltonianGate
 from qiskit_aer import AerSimulator
 from qiskit_experiments.library.characterization import cr_hamiltonian
-from qiskit_experiments.framework import BackendData
-
-
-class SimulatableCRGate(HamiltonianGate):
-    """Cross resonance unitary that can be simulated with Aer simulator."""
-
-    def __init__(self, width, t_off, wix, wiy, wiz, wzx, wzy, wzz, dt=1e-9):
-        # Note that Qiskit is Little endian, i.e. [q1, q0]
-        hamiltonian = (
-            wix * qi.Operator.from_label("XI") / 2
-            + wiy * qi.Operator.from_label("YI") / 2
-            + wiz * qi.Operator.from_label("ZI") / 2
-            + wzx * qi.Operator.from_label("XZ") / 2
-            + wzy * qi.Operator.from_label("YZ") / 2
-            + wzz * qi.Operator.from_label("ZZ") / 2
-        )
-        super().__init__(data=hamiltonian, time=(t_off + width) * dt)
 
 
 @ddt
@@ -50,31 +32,31 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
         """Test generated circuits."""
         backend = FakeBogotaV2()
 
-        expr = cr_hamiltonian.CrossResonanceHamiltonian(
-            qubits=(0, 1),
-            flat_top_widths=[1000],
-            amp=0.1,
-            sigma=64,
-            risefall=2,
-        )
+        with self.assertWarns(DeprecationWarning):
+            expr = cr_hamiltonian.CrossResonanceHamiltonian(
+                qubits=(0, 1),
+                flat_top_widths=[1000],
+                amp=0.1,
+                sigma=64,
+                risefall=2,
+            )
         expr.backend = backend
-
-        duration = 1256
 
         with pulse.build(default_alignment="left", name="cr") as ref_cr_sched:
             pulse.play(
                 pulse.GaussianSquare(
-                    duration,
+                    duration=1256,
                     amp=0.1,
                     sigma=64,
                     width=1000,
                 ),
                 pulse.ControlChannel(0),
             )
-            pulse.delay(duration, pulse.DriveChannel(0))
-            pulse.delay(duration, pulse.DriveChannel(1))
+            pulse.delay(1256, pulse.DriveChannel(0))
+            pulse.delay(1256, pulse.DriveChannel(1))
 
-        cr_gate = cr_hamiltonian.CrossResonanceHamiltonian.CRPulseGate(width=1000)
+        width_sec = 1000 * backend.dt
+        cr_gate = cr_hamiltonian.CrossResonanceHamiltonian.CRPulseGate(width=width_sec)
         expr_circs = expr.circuits()
 
         x0_circ = QuantumCircuit(2, 1)
@@ -118,36 +100,25 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
 
     def test_circuit_generation_no_backend(self):
         """User can check experiment circuit without setting backend."""
-        expr = cr_hamiltonian.CrossResonanceHamiltonian(
-            qubits=(0, 1),
-            flat_top_widths=[1000],
-            amp=0.1,
-            sigma=64,
-            risefall=2,
-        )
+
+        class FakeCRGate(HamiltonianGate):
+            """Hamiltonian Gate for simulation."""
+
+            def __init__(self, width):
+                super().__init__(data=np.eye(4), time=width)
+
+        with self.assertWarns(DeprecationWarning):
+            expr = cr_hamiltonian.CrossResonanceHamiltonian(
+                qubits=(0, 1),
+                flat_top_widths=[1000],
+                cr_gate=FakeCRGate,
+                amp=0.1,
+                sigma=64,
+                risefall=2,
+            )
 
         # Not raise an error
         expr.circuits()
-
-    def test_instance_with_backend_without_cr_gate(self):
-        """Calling set backend method without setting cr gate."""
-        backend = FakeBogotaV2()
-
-        # not raise an error
-        exp = cr_hamiltonian.CrossResonanceHamiltonian(
-            qubits=(0, 1),
-            flat_top_widths=[1000],
-            backend=backend,
-        )
-        backend_data = BackendData(backend)
-        ref_dt = backend_data.dt
-        self.assertEqual(exp._dt, ref_dt)
-
-        # These properties are set when cr_gate is not provided
-        ref_cr_channel = backend_data.control_channel((0, 1))[0].index
-        self.assertEqual(exp._cr_channel, ref_cr_channel)
-        ref_granularity = backend_data.granularity
-        self.assertEqual(exp._granularity, ref_granularity)
 
     @data(
         [1e6, 2e6, 1e3, -3e6, -2e6, 1e4],
@@ -159,33 +130,38 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
     @unpack
     def test_integration(self, ix, iy, iz, zx, zy, zz):
         """Integration test for Hamiltonian tomography."""
-        backend = AerSimulator(seed_simulator=123, shots=2000)
-        backend._configuration.dt = 1e-9
         delta = 3e4
 
-        sigma = 20
-        t_off = np.sqrt(2 * np.pi) * sigma
+        dt = 0.222e-9
+        sigma = 64
 
-        # Hack: transpiler calls qiskit.parallel but local object cannot be picked
-        cr_gate = functools.partial(
-            SimulatableCRGate,
-            t_off=t_off,
-            wix=2 * np.pi * ix,
-            wiy=2 * np.pi * iy,
-            wiz=2 * np.pi * iz,
-            wzx=2 * np.pi * zx,
-            wzy=2 * np.pi * zy,
-            wzz=2 * np.pi * zz,
-            dt=1e-9,
+        backend = AerSimulator(seed_simulator=123, shots=2000)
+        backend._configuration.dt = dt
+
+        # Note that Qiskit is Little endian, i.e. [q1, q0]
+        hamiltonian = (
+            2
+            * np.pi
+            * (
+                ix * qi.Operator.from_label("XI") / 2
+                + iy * qi.Operator.from_label("YI") / 2
+                + iz * qi.Operator.from_label("ZI") / 2
+                + zx * qi.Operator.from_label("XZ") / 2
+                + zy * qi.Operator.from_label("YZ") / 2
+                + zz * qi.Operator.from_label("ZZ") / 2
+            )
         )
 
-        durations = np.linspace(0, 700, 50)
+        class SimulatableCRGate(HamiltonianGate):
+            """Hamiltonian Gate for simulation."""
+
+            def __init__(self, width):
+                super().__init__(data=hamiltonian, time=np.sqrt(2 * np.pi) * sigma * dt + width)
+
         expr = cr_hamiltonian.CrossResonanceHamiltonian(
             qubits=(0, 1),
-            flat_top_widths=durations,
             sigma=sigma,
-            risefall=2,
-            cr_gate=cr_gate,
+            cr_gate=SimulatableCRGate,
         )
         expr.backend = backend
 
@@ -207,11 +183,64 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
         self.assertAlmostEqual(exp_data.analysis_results("omega_zy").value.n, zy, delta=delta)
         self.assertAlmostEqual(exp_data.analysis_results("omega_zz").value.n, zz, delta=delta)
 
+    def test_integration_backward_compat(self):
+        """Integration test for Hamiltonian tomography with implicitly setting flat_top_widths."""
+        ix, iy, iz, zx, zy, zz = 1e6, 2e6, 1e3, -3e6, -2e6, 1e4
+
+        delta = 3e4
+
+        dt = 0.222e-9
+        sigma = 64
+
+        backend = AerSimulator(seed_simulator=123, shots=2000)
+        backend._configuration.dt = dt
+
+        # Note that Qiskit is Little endian, i.e. [q1, q0]
+        hamiltonian = (
+            2
+            * np.pi
+            * (
+                ix * qi.Operator.from_label("XI") / 2
+                + iy * qi.Operator.from_label("YI") / 2
+                + iz * qi.Operator.from_label("ZI") / 2
+                + zx * qi.Operator.from_label("XZ") / 2
+                + zy * qi.Operator.from_label("YZ") / 2
+                + zz * qi.Operator.from_label("ZZ") / 2
+            )
+        )
+
+        class SimulatableCRGate(HamiltonianGate):
+            """Hamiltonian Gate for simulation."""
+
+            def __init__(self, width):
+                super().__init__(data=hamiltonian, time=np.sqrt(2 * np.pi) * sigma * dt + width)
+
+        with self.assertWarns(DeprecationWarning):
+            expr = cr_hamiltonian.CrossResonanceHamiltonian(
+                (0, 1),
+                np.linspace(0, 700, 50),
+                sigma=sigma,
+                cr_gate=SimulatableCRGate,
+            )
+        expr.backend = backend
+
+        exp_data = expr.run()
+        self.assertExperimentDone(exp_data, timeout=1000)
+
+        self.assertEqual(exp_data.analysis_results(0).quality, "good")
+
+        self.assertAlmostEqual(exp_data.analysis_results("omega_ix").value.n, ix, delta=delta)
+        self.assertAlmostEqual(exp_data.analysis_results("omega_iy").value.n, iy, delta=delta)
+        self.assertAlmostEqual(exp_data.analysis_results("omega_iz").value.n, iz, delta=delta)
+        self.assertAlmostEqual(exp_data.analysis_results("omega_zx").value.n, zx, delta=delta)
+        self.assertAlmostEqual(exp_data.analysis_results("omega_zy").value.n, zy, delta=delta)
+        self.assertAlmostEqual(exp_data.analysis_results("omega_zz").value.n, zz, delta=delta)
+
     def test_experiment_config(self):
         """Test converting to and from config works"""
         exp = cr_hamiltonian.CrossResonanceHamiltonian(
             qubits=[0, 1],
-            flat_top_widths=[1000],
+            durations=[1000],
             amp=0.1,
             sigma=64,
             risefall=2,
@@ -224,7 +253,7 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
         """Test round trip JSON serialization"""
         exp = cr_hamiltonian.CrossResonanceHamiltonian(
             qubits=[0, 1],
-            flat_top_widths=[1000],
+            durations=[1000],
             amp=0.1,
             sigma=64,
             risefall=2,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR updates `CrossResonanceHamiltonian` experiment. Now this experiment and subclass take ``duration`` instead of ``flat_top_widths``. This experiment is used for two qubit gate calibration, but usually CR pulse instance in the calibration is defined with ``raise_fall_sigma_ratio`` rather than ``width``, thus removing width parameter from this experiment will easily fit the experiment into calibrations.


### Details and comments

This experiment provides default durations by assuming 1 MHz ZX rate of typical IBM backends. This allows user to run experiment without being annoyed by choosing pulse durations. Note that now durations is provided in units of sec, because providing it in samples makes default value sensitive to backend dt (i.e. with different dt, default value no longer makes sense).