### PR TITLE
Compress docs artifacts in CI docs job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,12 @@ jobs:
           sudo apt-get install -y pandoc graphviz
       - name: Build Docs
         run: tox -edocs
+      - name: Compress Artifacts
+        run: |
+          mkdir artifacts
+          tar -Jcvf html_docs.tar.xz docs/_build/html
+          mv html_docs.tar.xz artifacts/.
       - uses: actions/upload-artifact@v2
         with:
           name: html_docs
-          path: docs/_build/html
+          path: artifacts


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The CI job that builds and tests docs builds for proposed PRs also uploads the built docs artifacts to GHA's artifact store. However, the built docs can end up being quite sizeable, despite being easily compressible. The upload action does do basic zip compression but it isn't very efficient and still ends up with a larget file to download. This commit adds a step to the CI job that builds the docs on all proposed PRs to manually compress the docs artifacts into an xz compressed tarball which should save a lot of bandwidth and wait times when downloading the artifacts from CI.

### Details and comments