### PR TITLE
`iq_cluster_centers` and `iq_cluster_width` are not optional

### DIFF
--- a/qiskit_experiments/test/mock_iq_backend.py
+++ b/qiskit_experiments/test/mock_iq_backend.py
@@ -12,7 +12,7 @@
 
 """A mock IQ backend for testing."""
 from abc import abstractmethod
-from typing import Sequence, List, Tuple, Dict, Union, Any, Optional
+from typing import Sequence, List, Tuple, Dict, Union, Any
 import numpy as np
 
 from qiskit import QuantumCircuit
@@ -310,8 +310,8 @@ class MockIQBackend(FakeOpenPulse2Q):
         prob: List[float],
         shots: int,
         circ_qubits: Sequence[int],
-        iq_cluster_centers: Optional[List[Tuple[IQPoint, IQPoint]]],
-        iq_cluster_width: Optional[List[float]],
+        iq_cluster_centers: List[Tuple[IQPoint, IQPoint]],
+        iq_cluster_width: List[float],
         phase: float = 0.0,
     ) -> List[List[List[Union[float, complex]]]]:
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`iq_cluster_centers` and `iq_cluster_width` in the `_draw_iq_shots` method should not have the `Optional` type hint as per https://docs.python.org/3/library/typing.html#typing.Optional  They won't work with `None` as their value.
