### PR TITLE
Delegate fit report generation to plotter

### DIFF
--- a/qiskit_experiments/curve_analysis/composite_curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/composite_curve_analysis.py
@@ -19,7 +19,6 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import lmfit
 import numpy as np
-from uncertainties import UFloat
 from uncertainties import unumpy as unp
 
 from qiskit_experiments.framework import (
@@ -39,7 +38,7 @@ from qiskit_experiments.warnings import deprecated_function
 
 from .base_curve_analysis import PARAMS_ENTRY_PREFIX, BaseCurveAnalysis
 from .curve_data import CurveFitResult
-from .utils import analysis_result_to_repr, eval_with_uncertainties
+from .utils import eval_with_uncertainties
 
 
 class CompositeCurveAnalysis(BaseAnalysis):
@@ -280,6 +279,7 @@ class CompositeCurveAnalysis(BaseAnalysis):
         analysis_results = []
 
         fit_dataset = {}
+        red_chi = {}
         for analysis in self._analyses:
             analysis._initialize(experiment_data)
 
@@ -320,6 +320,7 @@ class CompositeCurveAnalysis(BaseAnalysis):
 
             if fit_data.success:
                 quality = analysis._evaluate_quality(fit_data)
+                red_chi[analysis.name] = fit_data.reduced_chisq
             else:
                 quality = "bad"
 
@@ -380,26 +381,18 @@ class CompositeCurveAnalysis(BaseAnalysis):
             fit_dataset[analysis.name] = fit_data
 
         total_quality = self._evaluate_quality(fit_dataset)
+        if red_chi:
+            self.plotter.set_supplementary_data(fit_red_chi=red_chi)
 
         # Create analysis results by combining all fit data
-        analysis_results.extend(
-            self._create_analysis_results(
+        if total_quality == "good":
+            primary_results = self._create_analysis_results(
                 fit_data=fit_dataset, quality=total_quality, **self.options.extra.copy()
             )
-        )
+            analysis_results.extend(primary_results)
+            self.plotter.set_supplementary_data(primary_results=primary_results)
 
         if self.options.plot:
-            # Write fitting report
-            report = ""
-            for res in analysis_results:
-                if isinstance(res.value, (float, UFloat)):
-                    report += f"{analysis_result_to_repr(res)}\n"
-            chisqs = []
-            for group, fit_data in fit_dataset.items():
-                chisqs.append(r"reduced-$\chi^2$ = " + f"{fit_data.reduced_chisq: .4g} ({group})")
-            report += "\n".join(chisqs)
-            self.plotter.set_supplementary_data(report_text=report)
-
             return analysis_results, [self.plotter.figure()]
 
         return analysis_results, []

--- a/qiskit_experiments/curve_analysis/curve_analysis.py
+++ b/qiskit_experiments/curve_analysis/curve_analysis.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Tuple, Union, Optional
 
 import lmfit
 import numpy as np
-from uncertainties import unumpy as unp, UFloat
+from uncertainties import unumpy as unp
 
 from qiskit_experiments.exceptions import AnalysisError
 from qiskit_experiments.framework import ExperimentData, AnalysisResultData, AnalysisConfig
@@ -30,7 +30,7 @@ from qiskit_experiments.warnings import deprecated_function
 from .base_curve_analysis import BaseCurveAnalysis, PARAMS_ENTRY_PREFIX
 from .curve_data import CurveData, FitOptions, CurveFitResult
 from .data_processing import multi_mean_xy_data, data_sort
-from .utils import analysis_result_to_repr, eval_with_uncertainties, convert_lmfit_result
+from .utils import eval_with_uncertainties, convert_lmfit_result
 
 
 class CurveAnalysis(BaseCurveAnalysis):
@@ -507,6 +507,7 @@ class CurveAnalysis(BaseCurveAnalysis):
 
         if fit_data.success:
             quality = self._evaluate_quality(fit_data)
+            self.plotter.set_supplementary_data(fit_red_chi=fit_data.reduced_chisq)
         else:
             quality = "bad"
 
@@ -523,13 +524,12 @@ class CurveAnalysis(BaseCurveAnalysis):
 
         # Create figure and result data
         if fit_data.success:
-
             # Create analysis results
-            analysis_results.extend(
-                self._create_analysis_results(
-                    fit_data=fit_data, quality=quality, **self.options.extra.copy()
-                )
+            primary_results = self._create_analysis_results(
+                fit_data=fit_data, quality=quality, **self.options.extra.copy()
             )
+            analysis_results.extend(primary_results)
+            self.plotter.set_supplementary_data(primary_results=primary_results)
             # calling old extra entry method for backward compatibility
             if hasattr(self, "_extra_database_entry"):
                 warnings.warn(
@@ -572,14 +572,6 @@ class CurveAnalysis(BaseCurveAnalysis):
                                 model._name,
                                 y_interp_err=y_interp_err,
                             )
-
-                # Write fitting report
-                report_description = ""
-                for res in analysis_results:
-                    if isinstance(res.value, (float, UFloat)):
-                        report_description += f"{analysis_result_to_repr(res)}\n"
-                report_description += r"reduced-$\chi^2$ = " + f"{fit_data.reduced_chisq: .4g}"
-                self.plotter.set_supplementary_data(report_text=report_description)
 
         # Add raw data points
         if self.options.return_data_points:

--- a/qiskit_experiments/visualization/plotters/curve_plotter.py
+++ b/qiskit_experiments/visualization/plotters/curve_plotter.py
@@ -12,8 +12,10 @@
 """Plotter for curve-fits, specifically from :class:`CurveAnalysis`."""
 from typing import List
 
-from qiskit_experiments.framework import Options
+from uncertainties import UFloat
 
+from qiskit_experiments.framework import Options
+from qiskit_experiments.curve_analysis.utils import analysis_result_to_repr
 from .base_plotter import BasePlotter
 
 
@@ -64,7 +66,8 @@ class CurvePlotter(BasePlotter):
                 ``textbox_text_size`` style parameters in :class:`PlotStyle`.
         """
         return [
-            "report_text",
+            "primary_results",
+            "fit_red_chi",
         ]
 
     @classmethod
@@ -135,6 +138,42 @@ class CurvePlotter(BasePlotter):
                     )
 
             # Fit report
-            if "report_text" in self.supplementary_data:
-                report_text = self.supplementary_data["report_text"]
-                self.drawer.textbox(report_text)
+            report = self._write_report()
+            if len(report) > 0:
+                self.drawer.textbox(report)
+
+    def _write_report(self) -> str:
+        """Write fit report with supplementary_data.
+
+        Subclass can override this method to customize fit report.
+        By default, this writes important fit parameters and chi-squared value of the
+        fit in the fit report.
+
+        Returns:
+            Fit report.
+        """
+        report = ""
+
+        if "primary_results" in self.supplementary_data:
+            lines = []
+            for outcome in self.supplementary_data["primary_results"]:
+                if isinstance(outcome.value, (float, UFloat)):
+                    lines.append(analysis_result_to_repr(outcome))
+            report += "\n".join(lines)
+
+        if "fit_red_chi" in self.supplementary_data:
+            red_chi = self.supplementary_data["fit_red_chi"]
+            if len(report) > 0:
+                report += "\n\n"
+            if isinstance(red_chi, float):
+                report += f"reduced-chi2 = {red_chi: .4g}"
+            else:
+                # Composite curve analysis reporting multiple chi-sq values.
+                # This is usually given by a dict keyed on fit group name.
+                report += "reduced-chi2 per fit\n"
+                lines = []
+                for mod_name, mod_chi in red_chi.items():
+                    lines.append(f"  * {mod_name}: {mod_chi: .4g}")
+                report += "\n".join(lines)
+
+        return report

--- a/qiskit_experiments/visualization/plotters/curve_plotter.py
+++ b/qiskit_experiments/visualization/plotters/curve_plotter.py
@@ -60,10 +60,18 @@ class CurvePlotter(BasePlotter):
     def expected_supplementary_data_keys(cls) -> List[str]:
         """Returns the expected figures data-keys supported by this plotter.
 
+        This plotter generates a single text box, i.e. fit report, by digesting the
+        provided supplementary data. The style and position of the report is controlled by
+        ``textbox_rel_pos`` and ``textbox_text_size`` style parameters in :class:`PlotStyle`.
+
         Data Keys:
-            report_text: A string containing any fit report information to be drawn in a box.
-                The style and position of the report is controlled by ``textbox_rel_pos`` and
-                ``textbox_text_size`` style parameters in :class:`PlotStyle`.
+            primary_results: A list of :class:`.AnalysisResultData` object to be shown in
+                the fit report window. Typically, these are fit parameter values or
+                secondary quantities computed from multiple fit parameters.
+            fit_red_chi: The best reduced-chi squared value of the fit curves. If
+                the fit consists of multiple sub-fits, this will be a dictionary
+                keyed on the analysis name. Otherwise, this is a single float value
+                of a particular analysis.
         """
         return [
             "primary_results",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR moves the logic to generate curve analysis _fit_report_ to the plotter. This allows curve plotter subclass to customize the fit report. For example, if we design an analysis that generates many analysis data entries, these are all shown in the fit report window and such a long window may overlap with curves. 

Even though user can extract many analysis results from an experiment to save it later in the database, one may want to restrict what to be shown in the analysis report window. This PR gives such a flexibility to experiment authors.

### Details and comments


