### PR TITLE
Add IQ plotter class

### DIFF
--- a/qiskit_experiments/visualization/__init__.py
+++ b/qiskit_experiments/visualization/__init__.py
@@ -44,6 +44,7 @@ Plotter Library
 
     BasePlotter
     CurvePlotter
+    IQPlotter
 
 Drawer Library
 ==============
@@ -66,5 +67,5 @@ Plotting Style
 """
 
 from .drawers import BaseDrawer, LegacyCurveCompatDrawer, MplDrawer
-from .plotters import BasePlotter, CurvePlotter
+from .plotters import BasePlotter, CurvePlotter, IQPlotter
 from .style import PlotStyle

--- a/qiskit_experiments/visualization/drawers/base_drawer.py
+++ b/qiskit_experiments/visualization/drawers/base_drawer.py
@@ -13,7 +13,9 @@
 """Drawer abstract class."""
 
 from abc import ABC, abstractmethod
-from typing import Dict, Optional, Sequence, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple, Union
+
+import numpy as np
 
 from qiskit_experiments.framework import Options
 
@@ -420,6 +422,48 @@ class BaseDrawer(ABC):
             description: A string to be drawn inside a report box.
             rel_pos: Relative position of the text-box. If None, the default ``textbox_rel_pos`` from
                 the style is used.
+            options: Valid options for the drawer backend API.
+        """
+
+    @abstractmethod
+    def image(
+        self,
+        data: np.ndarray,
+        extent: Tuple[float, float, float, float],
+        name: Optional[str] = None,
+        label: Optional[str] = None,
+        cmap: Optional[Union[str, Any]] = None,
+        cmap_use_series_colors: bool = False,
+        colorbar: bool = False,
+        **options,
+    ):
+        """Draw scatter points, with optional error-bars.
+
+        Args:
+            data: The two-/three-dimensional data defining an image. If ``data.dims==2``, then the pixel
+                colors are determined by ``cmap`` and ``cmap_use_series_colors``. If ``data.dims==3``,
+                then it is assumed that ``data`` contains either RGB or RGBA data; which requires the
+                third dimension to have length ``3`` or ``4`` respectively. For RGB/A data, the elements
+                of ``data`` must be floats or integers in the range 0-1 and 0-255 respectively. If the
+                data is two-dimensional, there is no limit on the range of the values if they are
+                numerical. ``data`` contain strings, where the element values are series names. This is
+                useful when the image contains classification information. Series-names as values
+                requires setting ``cmap_use_series_colors=True``.
+            extent: A tuple ``(x_min, x_max, y_min, y_max)`` which defines a rectangular region within
+                which the values inside ``data`` should be plotted. The units of ``extent`` are the same
+                as those of the X and Y axes for the axis.
+            name: Name of this image. Used to lookup ``canvas`` and ``label`` in ``series_params``.
+            label: An optional label for the colorbar, if ``colorbar=True``.
+            cmap: Optional colormap for assigning colors to the image values, if ``data`` is not an RGB/A
+                image. ``cmap`` must be a string or object instance which is recognized by the drawer.
+                Defaults to None.
+            cmap_use_series_colors: Whether to assign colors to the image based on the series colors,
+                where the values inside ``data`` are series names. If
+                ``cmap_use_series_colors=True``,``cmap`` is ignored. This only works for two-dimensional
+                images as three-dimensional ``data`` contains RGB/A values. If ``len(data.shape)=3``,
+                ``cmap_use_series_colours`` is ignored. Defaults to False.
+            colorbar: Whether to add a bar showing the color-value mapping for the image. Defaults to
+                False.
             options: Valid options for the drawer backend API.
         """
 

--- a/qiskit_experiments/visualization/drawers/base_drawer.py
+++ b/qiskit_experiments/visualization/drawers/base_drawer.py
@@ -438,7 +438,7 @@ class BaseDrawer(ABC):
         colorbar: bool = False,
         **options,
     ):
-        """Draw scatter points, with optional error-bars.
+        """Draw an image of numerical values, series names, or RGB/A values.
 
         Args:
             data: The two-/three-dimensional data defining an image. If ``data.dims==2``, then the pixel

--- a/qiskit_experiments/visualization/drawers/base_drawer.py
+++ b/qiskit_experiments/visualization/drawers/base_drawer.py
@@ -20,6 +20,7 @@ import numpy as np
 from qiskit_experiments.framework import Options
 
 from ..style import PlotStyle
+from ..utils import ExtentTuple
 
 
 class BaseDrawer(ABC):
@@ -429,7 +430,7 @@ class BaseDrawer(ABC):
     def image(
         self,
         data: np.ndarray,
-        extent: Tuple[float, float, float, float],
+        extent: Optional[ExtentTuple] = None,
         name: Optional[str] = None,
         label: Optional[str] = None,
         cmap: Optional[Union[str, Any]] = None,
@@ -446,22 +447,22 @@ class BaseDrawer(ABC):
                 third dimension to have length ``3`` or ``4`` respectively. For RGB/A data, the elements
                 of ``data`` must be floats or integers in the range 0-1 and 0-255 respectively. If the
                 data is two-dimensional, there is no limit on the range of the values if they are
-                numerical. ``data`` contain strings, where the element values are series names. This is
-                useful when the image contains classification information. Series-names as values
-                requires setting ``cmap_use_series_colors=True``.
-            extent: A tuple ``(x_min, x_max, y_min, y_max)`` which defines a rectangular region within
-                which the values inside ``data`` should be plotted. The units of ``extent`` are the same
-                as those of the X and Y axes for the axis.
+                numerical. If ``cmap_use_series_colors=True``, then ``data`` contains series names; which
+                can be strings or numerical values, as long as they are appropriate series-names.
+            extent: An optional tuple ``(x_min, x_max, y_min, y_max)`` which defines a rectangular region
+                within which the values inside ``data`` should be plotted. The units of ``extent`` are
+                the same as those of the X and Y axes for the axis. If None, the extent of the image is
+                taken as ``(0, data.shape[0], 0, data.shape[1])``. Default is None.
             name: Name of this image. Used to lookup ``canvas`` and ``label`` in ``series_params``.
             label: An optional label for the colorbar, if ``colorbar=True``.
             cmap: Optional colormap for assigning colors to the image values, if ``data`` is not an RGB/A
                 image. ``cmap`` must be a string or object instance which is recognized by the drawer.
                 Defaults to None.
-            cmap_use_series_colors: Whether to assign colors to the image based on the series colors,
+            cmap_use_series_colors: Whether to assign colors to the image based on series colors,
                 where the values inside ``data`` are series names. If
                 ``cmap_use_series_colors=True``,``cmap`` is ignored. This only works for two-dimensional
-                images as three-dimensional ``data`` contains RGB/A values. If ``len(data.shape)=3``,
-                ``cmap_use_series_colours`` is ignored. Defaults to False.
+                images as three-dimensional ``data`` contains explicit colors as RGB/A values. If
+                ``len(data.shape)=3``, ``cmap_use_series_colours`` is ignored. Defaults to False.
             colorbar: Whether to add a bar showing the color-value mapping for the image. Defaults to
                 False.
             options: Valid options for the drawer backend API.

--- a/qiskit_experiments/visualization/drawers/legacy_curve_compat_drawer.py
+++ b/qiskit_experiments/visualization/drawers/legacy_curve_compat_drawer.py
@@ -13,7 +13,9 @@
 """Compatibility wrapper for legacy BaseCurveDrawer."""
 
 import warnings
-from typing import Optional, Sequence, Tuple
+from typing import Any, Optional, Sequence, Tuple, Union
+
+import numpy as np
 
 from qiskit_experiments.curve_analysis.visualization import BaseCurveDrawer
 from qiskit_experiments.warnings import deprecated_class
@@ -165,6 +167,20 @@ class LegacyCurveCompatDrawer(BaseDrawer):
         """
 
         self._curve_drawer.draw_fit_report(description, **options)
+
+    # pylint: disable=unused-argument
+    def image(
+        self,
+        data: np.ndarray,
+        extent: Tuple[float, float, float, float],
+        name: Optional[str] = None,
+        label: Optional[str] = None,
+        cmap: Optional[Union[str, Any]] = None,
+        cmap_use_series_colors: bool = False,
+        colorbar: bool = False,
+        **options,
+    ):
+        warnings.warn(f"{self.__class__.__name__}.image is not supported.")
 
     @property
     def figure(self):

--- a/qiskit_experiments/visualization/drawers/legacy_curve_compat_drawer.py
+++ b/qiskit_experiments/visualization/drawers/legacy_curve_compat_drawer.py
@@ -20,6 +20,7 @@ import numpy as np
 from qiskit_experiments.curve_analysis.visualization import BaseCurveDrawer
 from qiskit_experiments.warnings import deprecated_class
 
+from ..utils import ExtentTuple
 from .base_drawer import BaseDrawer
 
 
@@ -172,7 +173,7 @@ class LegacyCurveCompatDrawer(BaseDrawer):
     def image(
         self,
         data: np.ndarray,
-        extent: Tuple[float, float, float, float],
+        extent: Optional[ExtentTuple] = None,
         name: Optional[str] = None,
         label: Optional[str] = None,
         cmap: Optional[Union[str, Any]] = None,

--- a/qiskit_experiments/visualization/drawers/mpl_drawer.py
+++ b/qiskit_experiments/visualization/drawers/mpl_drawer.py
@@ -458,6 +458,38 @@ class MplDrawer(BaseDrawer):
         text_box_handler.set_bbox(bbox_props)
 
     def _series_names_to_cmap(self, series_names: List[str]) -> Tuple[Colormap, Dict[str, float]]:
+        """Create a :class:`Colormap` instance of series colours.
+
+        This method creates a :class:`Colormap` instance that can be used to plot an image of series
+        classifications: i.e., a 2D array of series names. The returned Colormap positions the series
+        colours, from :meth:`_get_default_color`, along the range :math:`0` to :math:`1`. The returned
+        dictionary contains mappings from series names (str) to floats which are used to "sample" from
+        the Colormap.
+
+        Example:
+            .. code-block:: python
+
+                # 2D array of classification strings, where each value is a series name.
+                data_classification = np.array(..., dtype=str)
+
+                # Get Colormap and its key.
+                series_names = [...]
+                cmap,cmap_map = self._series_names_to_cmap(series_names)
+
+                # Convert classified data into float data.
+                data_float = np.vectorize(lambda x: cmap(cmap_map[x]))(data_classification)
+
+                # Plot float data with Colormap.
+                plt.imshow(data_float, cmap=cmap, ...)
+
+        Args:
+            series_names: List of series names.
+
+        Returns:
+            tuple: a tuple ``(cmap, map)`` where ``cmap`` is a Matplotlib Colormap instance and ``map``
+                is a dictionary that maps series names (keys) to floats that identify the series names'
+                colours in ``cmap``.
+        """
         # Remove duplicates from series_names, just in-case. Use dict.fromkeys to preserve order and
         # remove duplicates.
         unique_series_names = list(dict.fromkeys(series_names))

--- a/qiskit_experiments/visualization/drawers/mpl_drawer.py
+++ b/qiskit_experiments/visualization/drawers/mpl_drawer.py
@@ -26,6 +26,7 @@ from qiskit.utils import detach_prefix
 
 from qiskit_experiments.framework.matplotlib import get_non_gui_ax
 
+from ..utils import ExtentTuple
 from .base_drawer import BaseDrawer
 
 
@@ -484,7 +485,7 @@ class MplDrawer(BaseDrawer):
     def image(
         self,
         data: np.ndarray,
-        extent: Tuple[float, float, float, float],
+        extent: Optional[ExtentTuple] = None,
         name: Optional[str] = None,
         label: Optional[str] = None,
         cmap: Optional[Union[str, Any]] = None,

--- a/qiskit_experiments/visualization/plotters/__init__.py
+++ b/qiskit_experiments/visualization/plotters/__init__.py
@@ -13,3 +13,4 @@
 
 from .base_plotter import BasePlotter
 from .curve_plotter import CurvePlotter
+from .iq_plotter import IQPlotter

--- a/qiskit_experiments/visualization/plotters/iq_plotter.py
+++ b/qiskit_experiments/visualization/plotters/iq_plotter.py
@@ -86,8 +86,13 @@ class IQPlotter(BasePlotter):
         """Returns the expected figures data-keys supported by this plotter.
 
         Data Keys:
-            discriminator: A trained discriminator used to classify IQ points. Must be a subclass of
-                :class:`BaseDiscriminator`.
+            discriminator: A trained discriminator that classifies IQ points. If provided, the
+                predictions of the discriminator will be sampled to generate a background image,
+                indicating the regions for each predicted outcome. The predictions are assumed to be
+                series names (str). The generated image allows viewers to see how well the discriminator
+                classifies the provided series data. Must be a subclass of :class:`BaseDiscriminator`.
+                See :attr:`options` for ways to control the generation of the discriminator prediction
+                image.
         """
         return [
             "discriminator",

--- a/qiskit_experiments/visualization/utils.py
+++ b/qiskit_experiments/visualization/utils.py
@@ -1,0 +1,246 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Utilities for visualization."""
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+from qiskit.exceptions import QiskitError
+
+ExtentTuple = Tuple[float, float, float, float]
+
+
+class DataExtentCalculator:
+    """A class to handle computing the extent of two-dimensional data.
+
+    This class makes computing the extent of two-dimensional data easier, especially for adding images
+    to plots where the extent of the axes (i.e., axis limits) are not known prior to figure generation.
+    An instance of this class can be used to compute an extent tuple which is larger than the registered
+    data, and thus has a margin that can exceed the axis-limits or be used as the axis limits without
+    cropping additional data-points from a figure. An extent tuple ``(x_min, x_max, y_min, y_max)``
+    contains the minimum and maximum values for the X and Y dimensions.
+
+    Data is registered with a :class:`DataExtentCalculator` so that the computed extent covers all
+    values in the data array. The extent tuple is computed as follows:
+        1. The maximum and minimum values for input data is stored whenever new data arrays are
+           registered. This is the data-extent: the minimum-area bounding box that contains all
+           registered data.
+        2. The data-extent is enlarged/shrunk by scaling its width and height by :attr:`multiplier`.
+        3. If :attr:`aspect_ratio` is not ``None``, the scaled extent tuple is extended in one of the
+           dimensions so that the output extent tuple is larger and the target aspect ratio is achieved.
+    """
+
+    def __init__(self, multiplier: float = 1.0, aspect_ratio: Optional[float] = 1.0):
+        """Create an extent calculator.
+
+        Args:
+            multiplier: The factor by which to scale the extent of the data when computing the output
+                extent tuple. Defaults to 1.0,
+            aspect_ratio: An optional target aspect ratio for the output extent tuple. If None, the
+                extent tuple is not extended to achieve a given aspect ratio. Defaults to None.
+        """
+        self._multiplier = multiplier
+        self._aspect_ratio = aspect_ratio
+        self._data_extent = np.asarray([[np.inf, -np.inf], [np.inf, -np.inf]])
+
+    @property
+    def multiplier(self) -> float:
+        """The multiplier by which to scale the data-extent.
+
+        Returns:
+            float: The multiplier for the computed extent.
+        """
+        return self._multiplier
+
+    @property
+    def aspect_ratio(self) -> Optional[float]:
+        """The target aspect ratio.
+
+        If None, the :class:`DataExtentCalculator` instance will not modify the computed extent tuple to
+        achieve a given aspect ratio; instead only scale by :attr:`multiplier`.
+
+        Returns:
+            Optional[float]: The target aspect ratio of the computed extent tuple.
+        """
+        return self._aspect_ratio
+
+    def register_data(self, data: Union[List, np.ndarray], dim: Optional[int] = None):
+        r"""Register data to modify the resulting extent tuple.
+
+        Args:
+            data: Array or list of data values to use when calculating the extent tuple. If a list is
+                given, it is converted into an array using :meth:`numpy.asarray`. If the array has the
+                shape ``(m, 2)``, then there are ``m`` values in two dimensions (being the second
+                dimension of ``data``). If the array has the shape ``(m,)`` or ``(m, 1)``, then ``dim``
+                must be set to the index of the dimension for which this data is associated.
+            dim: Optional dimension index if a one-dimensional array is provided (i.e., `X=0` and `Y=1`).
+                If None, then ``data`` must have the shape ``(m, 2)``. Defaults to None.
+
+        Raises:
+            QiskitError: if the data is not two-dimensional and ``dim`` is not set.
+            QiskitError: if the data does not contain one-dimensional values when ``dim`` is set.
+            QiskitError: if ``dim`` is not an index for two-dimensions: i.e.,
+                :math:`0\leq{}\text{dim}<2`.
+        """
+        data = np.asarray(data)
+        if dim is None and (len(data.shape) != 2 or (len(data.shape) == 2 and data.shape[1] != 2)):
+            raise QiskitError(
+                "Data must contain two-dimensional values. Expected shape `(m,2)` but got "
+                f"{data.shape} instead."
+            )
+        if dim is not None and (
+            len(data.shape) > 2 or (len(data.shape) == 2 and data.shape[1] != 1)
+        ):
+            raise QiskitError(
+                "Data must contain one-dimensional values if `dim` is set. Expected shape of `(m,1)` "
+                f"or `(m,)` but got {data.shape} instead."
+            )
+        if dim is not None and dim >= 2:
+            raise QiskitError(
+                f"Dim must be a two-dimensional dimension index (0<=dim<2), got {dim} instead."
+            )
+
+        if dim is not None:
+            _data_extent = [
+                min(np.min(data), self._data_extent[dim, 0]),
+                max(np.max(data), self._data_extent[dim, 1]),
+            ]
+            self._data_extent[dim] = _data_extent
+        else:
+            for i_dim in range(2):
+                _data_extent = [
+                    min(np.min(data[..., i_dim]), self._data_extent[i_dim, 0]),
+                    max(np.max(data[..., i_dim]), self._data_extent[i_dim, 1]),
+                ]
+                self._data_extent[i_dim, :] = _data_extent
+
+    @classmethod
+    def _range(cls, extent: np.ndarray) -> np.ndarray:
+        """Compute the range of the extent array.
+
+        Args:
+            extent: The extent array for the range.
+
+        Returns:
+            np.ndarray: the array ``[x_range, y_range]`` where ``x_range`` and ``y_range`` are the ranges
+                for their respective dimensions.
+        """
+        return np.diff(
+            extent,
+            axis=1,
+        ).flatten()
+
+    @classmethod
+    def _midpoint(cls, extent: np.ndarray) -> np.ndarray:
+        """Compute the midpoint of the extent array.
+
+        Args:
+            extent: The extent array for the midpoint.
+
+        Returns:
+            np.ndarray: the array ``[x, y]`` where ``x`` and ``y`` are the midpoints for their respective
+                dimensions.
+        """
+        return np.mean(
+            extent,
+            axis=1,
+        )
+
+    @classmethod
+    def _extent_from_range_midpoint(
+        cls, extent_range: np.ndarray, midpoint: np.ndarray
+    ) -> np.ndarray:
+        """Compute an extent array from range and midpoint arrays.
+
+        Args:
+            extent_range: The extent range to use.
+            midpoint: The midpoint of the extent.
+
+        Returns:
+            np.ndarray: an extent array with range and midpoint corresponding to ``extent_range`` and
+                ``midpoint``.
+        """
+        radii = extent_range.flatten() / 2
+        new_extent = np.zeros((2, 2))
+        new_extent[:, 0] = midpoint - radii
+        new_extent[:, 1] = midpoint + radii
+        return new_extent
+
+    @classmethod
+    def _extent_with_aspect_ratio(
+        cls, extent: np.ndarray, target_aspect_ratio: Optional[float]
+    ) -> np.ndarray:
+        """Expand ``extent`` to have an aspect ratio defined by ``target_aspect_ratio``.
+
+        This method extends ``extent`` along one of the two dimensions so that its aspect ratio is equal
+        to ``target_aspect_ratio``. This is done by computing the ratio of the actual and target aspect
+        ratios, computing the dimension along which to extend ``extent``, and recomputing the extent
+        array based on scaled ranges to achieve the target aspect ratio. If the target ratio is ``None``,
+        nothing is done. If extended, the region defined by the output array is always larger than the
+        input array.
+
+        Args:
+            extent: The extent array to expand.
+            target_aspect_ratio: Optional target aspect ratio, being :math:`\text{width}/\text{height}`
+            for the extent array. If None, ``extent`` is not extended. Defaults to None.
+
+        Returns:
+            np.ndarray: ``extent``, extended to have an aspect ratio defined by ``target_aspect_ratio``.
+        """
+        if target_aspect_ratio is None:
+            return extent
+
+        # Compute ratio coefficient
+        _range = cls._range(extent)
+        ratio = _range[0] / _range[1]
+        ratio_coefficient = target_aspect_ratio / ratio
+
+        _new_range = _range
+        # Handle three cases of aspect ratios
+        if ratio_coefficient == 1.0:
+            return extent
+        elif ratio_coefficient < 1:
+            _new_range[1] = (1 / ratio_coefficient) * _range[1]
+        else:
+            _new_range[0] = ratio_coefficient * _range[0]
+
+        return cls._extent_from_range_midpoint(_new_range, cls._midpoint(extent))
+
+    @classmethod
+    def _scaled_extent(cls, extent: np.ndarray, multiplier: float) -> np.ndarray:
+        _range = cls._range(extent)
+        midpoint = cls._midpoint(extent)
+        new_range = multiplier * _range
+        return cls._extent_from_range_midpoint(new_range, midpoint)
+
+    def extent(self) -> ExtentTuple:
+        """An extent array for the registered data, multiplier, and aspect ratio.
+
+        Raises:
+            QiskitError: if the resulting extent tuple is not finite. This can occur if no data was
+                registered before calling :meth:`extent`.
+
+        Returns:
+            tuple: the extent tuple for the registered data, scaled by ``multiplier``, and then extended
+                to achieve the set aspect ratio.
+        """
+        if not np.all(np.isfinite(self._data_extent)):
+            is_infinite = np.argwhere(np.invert(np.isfinite(self._data_extent)))
+            raise QiskitError(
+                "Encountered non-finite extent. The following dimensions have non-finite "
+                f"values: {is_infinite}."
+            )
+
+        return tuple(
+            self._extent_with_aspect_ratio(
+                self._scaled_extent(self._data_extent, self._multiplier), self._aspect_ratio
+            ).flatten()
+        )

--- a/releasenotes/notes/add-iq-plotter-45d4fe133cf8f108.yaml
+++ b/releasenotes/notes/add-iq-plotter-45d4fe133cf8f108.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Added a new IQ plotting class for plotting IQ/level-1 data (individual 
+    shots and their average) and a discriminator that classifies the data into
+    states.
+  - |
+    Added a new `image()` method to `BaseDrawer` and `MplDrawer` to plot
+    two-dimensional images on a figure canvas.

--- a/test/visualization/mock_drawer.py
+++ b/test/visualization/mock_drawer.py
@@ -13,7 +13,7 @@
 Mock drawer for testing.
 """
 
-from typing import Optional, Sequence, Tuple
+from typing import Any, Optional, Sequence, Tuple, Union
 
 from qiskit_experiments.visualization import BaseDrawer, PlotStyle
 
@@ -104,6 +104,20 @@ class MockDrawer(BaseDrawer):
         self,
         description: str,
         rel_pos: Optional[Tuple[float, float]] = None,
+        **options,
+    ):
+        """Does nothing."""
+        pass
+
+    def image(
+        self,
+        data: "numpy.ndarray",
+        extent: Tuple[float, float, float, float],
+        name: Optional[str] = None,
+        label: Optional[str] = None,
+        cmap: Optional[Union[str, Any]] = None,
+        cmap_use_series_colors: bool = False,
+        colorbar: bool = False,
         **options,
     ):
         """Does nothing."""

--- a/test/visualization/mock_drawer.py
+++ b/test/visualization/mock_drawer.py
@@ -16,6 +16,7 @@ Mock drawer for testing.
 from typing import Any, Optional, Sequence, Tuple, Union
 
 from qiskit_experiments.visualization import BaseDrawer, PlotStyle
+from qiskit_experiments.visualization.utils import ExtentTuple
 
 
 class MockDrawer(BaseDrawer):
@@ -112,7 +113,7 @@ class MockDrawer(BaseDrawer):
     def image(
         self,
         data: "numpy.ndarray",
-        extent: Tuple[float, float, float, float],
+        extent: Optional[ExtentTuple] = None,
         name: Optional[str] = None,
         label: Optional[str] = None,
         cmap: Optional[Union[str, Any]] = None,

--- a/test/visualization/test_iq_plotter.py
+++ b/test/visualization/test_iq_plotter.py
@@ -1,0 +1,119 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Test IQ plotter.
+"""
+
+from test.base import QiskitExperimentsTestCase
+from typing import Any, Dict, List, Tuple
+
+import ddt
+import numpy as np
+
+from qiskit_experiments.data_processing.discriminator import BaseDiscriminator
+from qiskit_experiments.visualization import IQPlotter, MplDrawer
+
+
+class MockDiscriminator(BaseDiscriminator):
+    """A mock discriminator for testing."""
+
+    def __init__(self, is_trained: bool = False):
+        """Create a MockDiscriminator instance.
+
+        Args:
+            is_trained: Whether the discriminator is trained or not. Defaults to False.
+        """
+        super().__init__()
+        self._is_trained = is_trained
+        self.predict_was_called = False
+        """Whether :meth:`predict` was called at least once."""
+
+    def predict(self, data: List):
+        """Returns dummy predictions where everything has the label ``0``."""
+        self.predict_was_called = True
+        if isinstance(data, list):
+            return [0] * len(data)
+        return [0] * data.shape[0]
+
+    def config(self) -> Dict[str, Any]:
+        return {
+            "predict_was_called": self.predict_was_called,
+            "is_trained": self._is_trained,
+        }
+
+    def is_trained(self) -> bool:
+        return self._is_trained
+
+
+@ddt.ddt
+class TestIQPlotter(QiskitExperimentsTestCase):
+    """Test IQPlotter"""
+
+    @classmethod
+    def _dummy_data(
+        cls,
+        is_trained: bool = True,
+        n_series: int = 3,
+    ) -> Tuple[List, List, BaseDiscriminator]:
+        """Create dummy data for the tests.
+
+        Args:
+            is_trained: Whether the discriminator should be trained or not. Defaults to True.
+            n_series: The number of series to generate dummy data for. Defaults to 3.
+
+        Returns:
+            tuple: the tuple ``(points, names, discrim)`` where ``points`` is a list of NumPy arrays of
+                IQ points, ``names`` is a list of series names (one for each NumPy array), and
+                ``discrim`` is a :class:`MockDiscriminator` instance.
+        """
+        points = []
+        labels = []
+        for i in range(n_series):
+            points.append(np.random.rand(128, 2))
+            labels.append(f"{i}")
+        mock_discrim = MockDiscriminator(is_trained)
+        return points, labels, mock_discrim
+
+    @ddt.data(True, False)
+    def test_discriminator_trained(self, is_trained: bool):
+        """Test that the discriminator is only sampled if it is trained.
+
+        Args:
+            is_trained: Whether the mock discriminator should be trained or not.
+        """
+        plotter = IQPlotter(MplDrawer())
+        points, labels, discrim = self._dummy_data(is_trained)
+
+        # Add dummy data
+        for series_points, series_name in zip(points, labels):
+            plotter.set_series_data(series_name, points=series_points)
+
+        # Add un-trained discriminator
+        plotter.set_supplementary_data(discriminator=discrim)
+
+        # Call figure() to generate discriminator image, if possible.
+        plotter.figure()
+
+        # Assert that MockDiscriminator.predict() was/wasn't called, depending on whether it was trained
+        # or not.
+        self.assertEqual(is_trained, discrim.predict_was_called)
+
+    def test_end_to_end(self):
+        """Test end-to-end functionality of IQPlotter."""
+        plotter = IQPlotter(MplDrawer())
+        points, labels, discrim = self._dummy_data(is_trained=True)
+        for points, series_name in zip(points, labels):
+            centroid = np.mean(points, axis=0)
+            plotter.set_series_data(series_name, points=points, centroid=centroid)
+        plotter.set_supplementary_data(discriminator=discrim)
+
+        plotter.figure()

--- a/test/visualization/test_utils.py
+++ b/test/visualization/test_utils.py
@@ -1,0 +1,108 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Test visualization utilities.
+"""
+
+import itertools as it
+from test.base import QiskitExperimentsTestCase
+from typing import List, Tuple
+
+import numpy as np
+from ddt import data, ddt
+from qiskit.exceptions import QiskitError
+
+from qiskit_experiments.visualization.utils import DataExtentCalculator
+
+
+@ddt
+class TestDataExtentCalculator(QiskitExperimentsTestCase):
+    """Test DataExtentCalculator"""
+
+    @classmethod
+    def _dummy_data(
+        cls,
+        extent: Tuple[float, float, float, float] = (-1, 1, -5, 0),
+        n_data: int = 5,
+        n_points: int = 16,
+    ) -> List[np.ndarray]:
+        # Create a list of bin edges by which to divide the target extent
+        bin_edges = [
+            np.histogram_bin_edges(extent[0:2], bins=n_data).tolist(),
+            np.histogram_bin_edges(extent[2:], bins=n_data).tolist(),
+        ]
+
+        # Iterate over pairs of adjacent bin edges, which define the maximum and minimum for the region.
+        # This is done by zipping over shifted subarrays of bin_edges as follows:
+        #      [[a], [b], [c], [d], [e], [f]], g]
+        #  [a, [[b], [c], [d], [e], [f], [g]]
+        # The result is a list of pairs representing a moving window of size 2.
+        # TODO: Replace this with numpy.[...].sliding_window_view when Qiskit requires numpy>=0.20.0
+        dummy_data = []
+        for (x_min, x_max), (y_min, y_max) in it.product(
+            *tuple(list(zip(b[0:-1], b[1:])) for b in bin_edges)
+        ):
+            _dummy_data = np.asarray(
+                [
+                    np.linspace(x_min, x_max, n_points),
+                    np.linspace(y_min, y_max, n_points),
+                ]
+            )
+            dummy_data.append(_dummy_data.swapaxes(-1, -2))
+        return dummy_data
+
+    @data(*list(it.product([1.0, 1.1, 2.0], [None, 1.0, np.sqrt(2)])))
+    def test_end_to_end(self, args):
+        """Test end-to-end functionality.
+
+        Results that are asserted include the range of the final extent tuple and its midpoint.
+        """
+        # Test args
+        multiplier, aspect_ratio = args[0], args[1]
+
+        # Problem inputs
+        extent = (-1, 1, -5, 1)
+
+        n_data = 6
+        dummy_data = self._dummy_data(extent, n_data=n_data)
+        ext_calc = DataExtentCalculator(multiplier=multiplier, aspect_ratio=aspect_ratio)
+        # Add data as 2D and 1D arrays to test both methods
+        for d in dummy_data[0 : int(n_data / 2)]:
+            ext_calc.register_data(d)
+        for d in dummy_data[int(n_data / 2) :]:
+            for i_dim in range(2):
+                ext_calc.register_data(d[:, i_dim], dim=i_dim)
+
+        # Check extent
+        actual_extent = ext_calc.extent()
+
+        # Check that range was scaled. Given we also have an aspect ratio, we may have a range that is
+        # larger than the original scaled by the multiplier. At the minimum, the range should be exactly
+        # equal to the original scaled by the multiplier
+        expected_range = multiplier * np.diff(np.asarray(extent).reshape((2, 2)), axis=1).flatten()
+        actual_range = np.diff(np.reshape(actual_extent, (2, 2)), axis=1).flatten()
+        for act, exp in zip(actual_range, expected_range):
+            self.assertTrue(act >= exp)
+
+        # Check that the midpoints are the same.
+        expected_midpoint = np.mean(np.reshape(extent, (2, 2)), axis=1).flatten()
+        actual_midpoint = np.mean(np.reshape(actual_extent, (2, 2)), axis=1).flatten()
+        np.testing.assert_almost_equal(
+            actual_midpoint,
+            expected_midpoint,
+        )
+
+    def test_no_data_error(self):
+        """Test that a QiskitError is raised if no data was set."""
+        ext_calc = DataExtentCalculator()
+        with self.assertRaises(QiskitError):
+            ext_calc.extent()


### PR DESCRIPTION
### Summary

The recent addition of the visualization module for Qiskit Experiments introduced plotters to the code-base (#902). This PR adds a new plotter subclass for plotting IQ data, typically acquired from experiments with level-1 results or during state-discrimination training (#936).

### Details and comments

This PR adds a new `IQPlotter` class to plot IQ data for multiple prepared states and a discriminator which classifies the IQ points into state labels. The plotter takes in points and centroid data for different prepared states and creates a scatter plot with their values. Modifications were made to `BaseDrawer` and `MplDrawer` to add functionality to draw an image on a canvas,  (i.e., equivalent to `plt.imshow`).

#### Usage of `IQPlotter`.

Below you can see a figure generated using `IQPlotter` for mock qutrit readout. The code used to generate this figure is given at the end of the PR description. The plotting class supports plotting individual points and centroids for multiple states, where states are different series. It also supports plotting the predictions of a trained discriminator over a region of the IQ space. This is done by sampling the discriminators `predict()` method for different IQ positions. The discriminator is passed as supplementary data to the plotter.

![image](https://user-images.githubusercontent.com/6696704/196426836-f52d0cb2-5b18-41ab-b7a4-0247b36edc69.png)

#### New `BaseDrawer.image()` method.

To allow plotters to draw images onto a canvas, `BaseDrawer` and `MplDrawer` had to be updated with new functionality. `BaseDrawer.image()` takes in a two-dimensional NumPy array of numerical values or strings, or a three-dimensional NumPy array of RGB/RGBA data. If two-dimensional numerical data is provided, the drawer will assign colours to the values based on the `cmap` parameter. `image()` also supports plotting images of classification labels, where the values in `data` are series names (str). Setting `cmap_use_series_colors=True` will tell the drawer to use the series colours (from other graphics already drawn on the canvas) as the colours for the image. This is used by `IQPlotter` to plot a discriminators predictions and match the colours to IQ points and centroids.

`image()` also has an `extent` parameter which defines the region for the image in the units of the X and Y axes. `IQPlotter` uses a helper class `DataExtentCalculator` to assist with precomputing the extent of the plotting data, so that the discriminator can be sampled to generate the prediction image.

#### Example code to generate the example figure.

```python
import numpy as np
from qiskit_experiments.data_processing import SkLDA
from qiskit_experiments.visualization import IQPlotter, MplDrawer, PlotStyle
from sklearn.discriminant_analysis import LinearDiscriminantAnalysis

# Generate dummy qutrit data.
centers = [(-1, 1), (1, 1), (0.8, 2.5)]
widths = [0.3] * 3
states = [0, 1, 2]
n_shots = 8096

points, series_names = [], []
for cent, width, label in zip(centers, widths, states):
    p = np.zeros((n_shots, 2))
    for i in range(2):
        p[:, i] = np.random.normal(cent[i], width, (n_shots,))
    points.append(p)
    series_names.append(label)
centroids = [np.mean(x, axis=0) for x in points]

# Create and train linear discriminator
lda = LinearDiscriminantAnalysis()
sklda = SkLDA(lda)
sklda.fit(
    np.concatenate(points),
    np.asarray([[f"{l}"] * n_shots for l in series_names]).flatten().transpose(),
)

# Create IQPlotter and generate figure.
plotter = IQPlotter(MplDrawer())
plotter.set_options(
    discriminator_max_resolution=64,
    style=PlotStyle(figsize=(6, 4), legend_loc=None),
)
plotter.set_figure_options(
    series_params={
        "0": {"label": "$|0\\rangle$"},
        "1": {"label": "$|1\\rangle$"},
        "2": {"label": "$|2\\rangle$"},
    },
)
for p, c, n in zip(points, centroids, series_names):
    _name = f"{n}"
    plotter.set_series_data(_name, points=p, centroid=c)
plotter.set_supplementary_data(discriminator=sklda)
fig = plotter.figure()
```