### PR TITLE
Fix bug in tomography conditionals on multiple cregs

### DIFF
--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -172,7 +172,7 @@ class TomographyExperiment(BaseExperiment):
                 name += f"_{prep_element}"
                 metadata["p_idx"] = list(prep_element)
 
-            circ = template.copy()
+            circ = template.copy(name=name)
 
             if prep_element:
                 # Add tomography preparation

--- a/releasenotes/notes/fix-tomography-943-0f2b35964f2cf8ef.yaml
+++ b/releasenotes/notes/fix-tomography-943-0f2b35964f2cf8ef.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixes bug in :class:`~.StateTomography` and :class:`~.ProcessTomography`
+    experiments where if the input circuit contained conditional instructions
+    with multiple classical registers the tomography measurement circuits
+    would contain incorrect conditionals due to a bug in the
+    :meth:`.QuantumCircuit.compose` method.
+
+    See Issue #942 <https://github.com/Qiskit/qiskit-experiments/issues/943>`_
+    for additional details.

--- a/test/library/tomography/test_process_tomography.py
+++ b/test/library/tomography/test_process_tomography.py
@@ -259,7 +259,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         # Check result
         f_threshold = 0.95
 
-        # Check state is density matrix
+        # Check state is a Choi matrix
         state = filter_results(results, "state").value
         self.assertTrue(isinstance(state, qi.Choi), msg="fitted state is not a Choi matrix")
 
@@ -284,7 +284,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         # Check result
         f_threshold = 0.95
 
-        # Check state is density matrix
+        # Check state is a Choi matrix
         state = filter_results(results, "state").value
         self.assertTrue(isinstance(state, qi.Choi), msg="fitted state is not a Choi matrix")
 

--- a/test/library/tomography/test_process_tomography.py
+++ b/test/library/tomography/test_process_tomography.py
@@ -21,7 +21,7 @@ import qiskit.quantum_info as qi
 from qiskit_aer import AerSimulator
 from qiskit_experiments.library import ProcessTomography
 from qiskit_experiments.library.tomography import ProcessTomographyAnalysis
-from .tomo_utils import FITTERS, filter_results, teleport_circuit
+from .tomo_utils import FITTERS, filter_results, teleport_circuit, teleport_bell_circuit
 
 
 @ddt.ddt
@@ -244,15 +244,15 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         target_fid = qi.process_fidelity(state, target, require_tp=False, require_cp=False)
         self.assertAlmostEqual(fid, target_fid, places=6, msg="result fidelity is incorrect")
 
-    def test_qpt_teleport(self):
+    @ddt.data(True, False)
+    def test_qpt_teleport(self, flatten_creg):
         """Test subset state tomography generation"""
-        # NOTE: This test breaks transpiler. I think it is a bug with
-        # conditionals in Terra.
-
         # Teleport qubit 0 -> 2
         backend = AerSimulator(seed_simulator=9000)
-        exp = ProcessTomography(teleport_circuit(), measurement_qubits=[2], preparation_qubits=[0])
-        expdata = exp.run(backend, shots=10000)
+        exp = ProcessTomography(
+            teleport_circuit(flatten_creg), measurement_qubits=[2], preparation_qubits=[0]
+        )
+        expdata = exp.run(backend, shots=1000)
         self.assertExperimentDone(expdata)
         results = expdata.analysis_results()
 
@@ -265,6 +265,37 @@ class TestProcessTomography(QiskitExperimentsTestCase):
 
         # Manually check fidelity
         fid = qi.process_fidelity(state, require_tp=False, require_cp=False)
+        self.assertGreater(fid, f_threshold, msg="fitted state fidelity is low")
+
+    @ddt.data(True, False)
+    def test_qpt_teleport_bell(self, flatten_creg):
+        """Test subset state tomography generation"""
+        # Teleport qubit 0 -> 2
+        backend = AerSimulator(seed_simulator=9000)
+        exp = ProcessTomography(
+            teleport_bell_circuit(flatten_creg),
+            measurement_qubits=[2, 3],
+            preparation_qubits=[0, 3],
+        )
+        expdata = exp.run(backend, shots=1000)
+        self.assertExperimentDone(expdata)
+        results = expdata.analysis_results()
+
+        # Check result
+        f_threshold = 0.95
+
+        # Check state is density matrix
+        state = filter_results(results, "state").value
+        self.assertTrue(isinstance(state, qi.Choi), msg="fitted state is not a Choi matrix")
+
+        # Target circuit
+        target = QuantumCircuit(2)
+        target.h(0)
+        target.cx(0, 1)
+        target = qi.Operator(target)
+
+        # Manually check fidelity
+        fid = qi.process_fidelity(state, target, require_tp=False, require_cp=False)
         self.assertGreater(fid, f_threshold, msg="fitted state fidelity is low")
 
     def test_experiment_config(self):

--- a/test/library/tomography/tomo_utils.py
+++ b/test/library/tomography/tomo_utils.py
@@ -13,7 +13,7 @@
 """
 Common methods for tomography tests
 """
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister
 
 
 FITTERS = [
@@ -32,17 +32,48 @@ def filter_results(analysis_results, name):
     return None
 
 
-def teleport_circuit():
+def teleport_circuit(flatten_creg=True):
     """Teleport qubit 0 to qubit 2"""
-    teleport = QuantumCircuit(3, 2)
+    if flatten_creg:
+        teleport = QuantumCircuit(3, 2)
+        creg = teleport.cregs[0]
+    else:
+        qr = QuantumRegister(3)
+        c0 = ClassicalRegister(1, "c0")
+        c1 = ClassicalRegister(1, "c1")
+        teleport = QuantumCircuit(qr, c0, c1)
+        creg = [c0, c1]
     teleport.h(1)
     teleport.cx(1, 2)
     teleport.cx(0, 1)
     teleport.h(0)
-    teleport.measure(0, 0)
-    teleport.measure(1, 1)
+    teleport.measure(0, creg[0])
+    teleport.measure(1, creg[1])
     # Conditionals
-    creg = teleport.cregs[0]
+    teleport.z(2).c_if(creg[0], 1)
+    teleport.x(2).c_if(creg[1], 1)
+    return teleport
+
+
+def teleport_bell_circuit(flatten_creg=True):
+    """Teleport entangled qubit 0 -> 2"""
+    if flatten_creg:
+        teleport = QuantumCircuit(4, 2)
+        creg = teleport.cregs[0]
+    else:
+        qr = QuantumRegister(4)
+        c0 = ClassicalRegister(1)
+        c1 = ClassicalRegister(1)
+        teleport = QuantumCircuit(qr, c0, c1)
+        creg = [c0, c1]
+    teleport.h(0)
+    teleport.cx(0, 3)
+    teleport.h(1)
+    teleport.cx(1, 2)
+    teleport.cx(0, 1)
+    teleport.h(0)
+    teleport.measure(0, creg[0])
+    teleport.measure(1, creg[1])
     teleport.z(2).c_if(creg[0], 1)
     teleport.x(2).c_if(creg[1], 1)
     return teleport


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #943 

Fixes bug in `StateTomography` and `ProcessTomography` experiments where if the input circuit contained conditional instructions with multiple classical registers the tomography measurement circuits would contain incorrect conditionals due to a bug in the `QuantumCircuit.compose` method.

### Details and comments

This fixes the issue by creating a tomography template circuit containing the same registers as the input circuit with an additional classical register added for tomography measurements, rather than creating a template with a single flat classical register of the required total number of classical bits.
