### PR TITLE
Setting new service in `ExperimentData` without raising exception

### DIFF
--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1981,17 +1981,19 @@ class ExperimentData:
             self.add_child_data(data)
         self._db_data.metadata["child_data_ids"] = self._child_data.keys()
 
-    def _set_service(self, service: IBMExperimentService) -> None:
+    def _set_service(self, service: IBMExperimentService, replace: bool = None) -> None:
         """Set the service to be used for storing experiment data,
            to this experiment itself and its descendants.
 
         Args:
             service: Service to be used.
+            replace: Should an existing service be replaced?
+            If not, and a current service exists, exception is raised
 
         Raises:
-            ExperimentDataError: If an experiment service is already being used.
+            ExperimentDataError: If an experiment service is already being used and `replace==False`.
         """
-        if self._service:
+        if self._service and not replace:
             raise ExperimentDataError("An experiment service is already being used.")
         self._service = service
         for result in self._analysis_results.values():


### PR DESCRIPTION
… unless this option is explicitly prevented

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR changes the way `ExperimentData._set_service` method works: If a service already exists, the method raises an exception only if a new parameter, `replace`, is `False`. By default this parameter is `True`.


### Details and comments
This change is the result of several different cases in `qiskit-monitoring` where crashes occurred because of the current behavior, while nothing was gained by it.

