### PR TITLE
Remove data_sort_key from the LMFIT models

### DIFF
--- a/qiskit_experiments/curve_analysis/__init__.py
+++ b/qiskit_experiments/curve_analysis/__init__.py
@@ -174,17 +174,23 @@ Here is another example how to implement multi-objective optimization task:
         lmfit.models.ExpressionModel(
             expr="amp * exp(-alpha1 * x) + base",
             name="my_experiment1",
-            data_sort_key={"tag": 1},
         ),
         lmfit.models.ExpressionModel(
             expr="amp * exp(-alpha2 * x) + base",
             name="my_experiment2",
-            data_sort_key={"tag": 2},
         ),
     ]
 
-Note that now you need to provide ``data_sort_key`` which is unique argument to
-Qiskit curve analysis. This specifies the metadata of your experiment circuit
+In addition, you need to provide ``data_map`` analysis option, which may look like
+
+.. code-block:: python3
+
+    {
+        "my_experiment1": {"tag": 1},
+        "my_experiment2": {"tag": 2},
+    }
+
+This option specifies the metadata of your experiment circuit
 that is tied to the fit model. If multiple models are provided without this option,
 the curve fitter cannot prepare data to fit.
 In this model, you have four parameters (``amp``, ``alpha1``, ``alpha2``, ``base``)
@@ -203,12 +209,10 @@ By using this model, one can flexibly set up your fit model. Here is another exa
         lmfit.models.ExpressionModel(
             expr="amp * cos(2 * pi * freq * x + phi) + base",
             name="my_experiment1",
-            data_sort_key={"tag": 1},
         ),
         lmfit.models.ExpressionModel(
             expr="amp * sin(2 * pi * freq * x + phi) + base",
             name="my_experiment2",
-            data_sort_key={"tag": 2},
         ),
     ]
 

--- a/qiskit_experiments/curve_analysis/standard_analysis/bloch_trajectory.py
+++ b/qiskit_experiments/curve_analysis/standard_analysis/bloch_trajectory.py
@@ -120,8 +120,7 @@ class BlochTrajectoryAnalysis(curve.CurveAnalysis):
             models.append(
                 lmfit.models.ExpressionModel(
                     expr=eq,
-                    name=f"{axis}",
-                    data_sort_key={"meas_basis": axis},
+                    name=axis,
                 )
             )
 
@@ -144,6 +143,11 @@ class BlochTrajectoryAnalysis(curve.CurveAnalysis):
             xval_unit="s",
             ylim=(-1, 1),
         )
+        default_options.data_map = {
+            "x": {"meas_basis": "x"},
+            "y": {"meas_basis": "y"},
+            "z": {"meas_basis": "z"},
+        }
 
         return default_options
 

--- a/qiskit_experiments/library/characterization/analysis/drag_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/drag_analysis.py
@@ -109,9 +109,9 @@ class DragCalAnalysis(curve.CurveAnalysis):
             List of fit options that are passed to the fitter function.
         """
         # Use the highest-frequency curve to estimate the oscillation frequency.
-        max_rep_model = self._models[-1]
-        max_rep = max_rep_model.opts["data_sort_key"]["nrep"]
-        curve_data = curve_data.get_subset_of(max_rep_model._name)
+        max_rep_model_name = self._models[-1]._name
+        max_rep = self.options.data_map[max_rep_model_name]["nrep"]
+        curve_data = curve_data.get_subset_of(max_rep_model_name)
 
         x_data = curve_data.x
         min_beta, max_beta = min(x_data), max(x_data)
@@ -222,16 +222,18 @@ class DragCalAnalysis(curve.CurveAnalysis):
         self,
         experiment_data: ExperimentData,
     ):
-        super()._initialize(experiment_data)
-
         # Model is initialized at runtime because
         # the experiment option "reps" can be changed before experiment run.
+        data_map = {}
         for nrep in sorted(self.options.reps):
             name = f"nrep={nrep}"
             self._models.append(
                 lmfit.models.ExpressionModel(
                     expr=f"amp * cos(2 * pi * {nrep} * freq * (x - beta)) + base",
                     name=name,
-                    data_sort_key={"nrep": nrep},
                 )
             )
+            data_map[name] = {"nrep": nrep}
+        self._options.data_map = data_map
+
+        super()._initialize(experiment_data)

--- a/qiskit_experiments/library/characterization/analysis/fine_amplitude_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/fine_amplitude_analysis.py
@@ -39,12 +39,10 @@ class FineAmplitudeAnalysis(curve.ErrorAmplificationAnalysis):
                 lmfit.models.ExpressionModel(
                     expr="amp / 2 * (2 * x - 1) + base",
                     name="spam cal.",
-                    data_sort_key={"series": "spam-cal"},
                 ),
                 lmfit.models.ExpressionModel(
                     expr="amp / 2 * cos((d_theta + angle_per_gate) * x - phase_offset) + base",
                     name="fine amp.",
-                    data_sort_key={"series": 1},
                 ),
             ],
         )
@@ -53,4 +51,8 @@ class FineAmplitudeAnalysis(curve.ErrorAmplificationAnalysis):
     def _default_options(cls):
         """Return the default analysis options."""
         default_options = super()._default_options()
+        default_options.data_map = {
+            "spam cal.": {"series": "spam-cal"},
+            "fine amp.": {"series": 1},
+        }
         return default_options

--- a/qiskit_experiments/library/characterization/analysis/ramsey_xy_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/ramsey_xy_analysis.py
@@ -70,12 +70,10 @@ class RamseyXYAnalysis(curve.CurveAnalysis):
                 lmfit.models.ExpressionModel(
                     expr="amp * exp(-x / tau) * cos(2 * pi * freq * x + phase) + base",
                     name="X",
-                    data_sort_key={"series": "X"},
                 ),
                 lmfit.models.ExpressionModel(
                     expr="amp * exp(-x / tau) * sin(2 * pi * freq * x + phase) + base",
                     name="Y",
-                    data_sort_key={"series": "Y"},
                 ),
             ]
         )
@@ -88,6 +86,10 @@ class RamseyXYAnalysis(curve.CurveAnalysis):
         descriptions of analysis options.
         """
         default_options = super()._default_options()
+        default_options.data_map = {
+            "X": {"series": "X"},
+            "Y": {"series": "Y"},
+        }
         default_options.plotter.set_figure_options(
             xlabel="Delay",
             ylabel="Signal (arb. units)",

--- a/qiskit_experiments/library/characterization/analysis/zz_ramsey_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/zz_ramsey_analysis.py
@@ -88,12 +88,10 @@ class ZZRamseyAnalysis(CurveAnalysis):
                 lmfit.models.ExpressionModel(
                     expr="-amp * exp(-x / tau) * cos(2 * pi * (freq - zz / 2) * x + phase) + base",
                     name="0",
-                    data_sort_key={"series": "0"},
                 ),
                 lmfit.models.ExpressionModel(
                     expr="-amp * exp(-x / tau) * cos(2 * pi * (freq + zz / 2) * x + phase) + base",
                     name="1",
-                    data_sort_key={"series": "1"},
                 ),
             ]
         )
@@ -113,6 +111,10 @@ class ZZRamseyAnalysis(CurveAnalysis):
             xval_unit="s",
             ylabel="P(1)",
         )
+        default_options.data_map = {
+            "0": {"series": "0"},
+            "1": {"series": "1"},
+        }
 
         return default_options
 

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
@@ -96,12 +96,10 @@ class InterleavedRBAnalysis(curve.CurveAnalysis):
                 lmfit.models.ExpressionModel(
                     expr="a * alpha ** x + b",
                     name="standard",
-                    data_sort_key={"interleaved": False},
                 ),
                 lmfit.models.ExpressionModel(
                     expr="a * (alpha_c * alpha) ** x + b",
                     name="interleaved",
-                    data_sort_key={"interleaved": True},
                 ),
             ]
         )
@@ -111,6 +109,10 @@ class InterleavedRBAnalysis(curve.CurveAnalysis):
     def _default_options(cls):
         """Default analysis options."""
         default_options = super()._default_options()
+        default_options.data_map = {
+            "standard": {"interleaved": False},
+            "interleaved": {"interleaved": True},
+        }
         default_options.result_parameters = ["alpha", "alpha_c"]
         default_options.average_method = "sample"
         return default_options

--- a/releasenotes/notes/curve-analysis-4bcc10cf3a39a85d.yaml
+++ b/releasenotes/notes/curve-analysis-4bcc10cf3a39a85d.yaml
@@ -6,3 +6,36 @@ features:
     Defaults to `sample` for the RB experiments and `shots_weighted` for the rest of analysis.
     Previously the setup was hardcoded in the ``_format_data`` method of the analysis class,
     and no statistical difference has been introduced with introduction of this option.
+deprecations:
+  - |
+    Providing data_sort_key directly to the LMFIT model to instantiate :class:`CurveAnalysis` 
+    has been deprecated. This option is not officially supported by the LMFIT,
+    and thus curve analysis cannot guarantee this option is properly managed 
+    in all LMFIT model subclasses.
+developer:
+  - |
+    To map experiment result data to a particular LMFIT model in the :class:`CurveAnalysis`,
+    an author must provide the data_map analysis option rather than directly binding data_sort_key
+    with the target LMFIT model. The data_map option is a dictionary keyed on the
+    model name. For example,
+    
+    .. code-block:: python3
+    
+      class MyAnalysis(CurveAnalysis):
+        
+        def __init__(self):
+          super().__init__(
+            models=[
+              lmfit.models.ExpressionModel(expr="x+a0", name="expr1"),
+              lmfit.models.ExpressionModel(expr="x+a1", name="expr2"),
+            ]
+          )
+        
+        @classmethod
+        def _default_options(cls) -> Options:
+          options = super()._default_options()
+          options.data_map = {"expr1": {"tag": "1"}, "expr2": {"tag": "2"}}
+          return options
+      
+    As shown in above, the dictionary had been attached to each LMFIT model 
+    is now moved to the data_map option.

--- a/test/curve_analysis/test_baseclass.py
+++ b/test/curve_analysis/test_baseclass.py
@@ -119,17 +119,19 @@ class TestCurveAnalysis(CurveAnalysisTestCase):
                 ExpressionModel(
                     expr="par0 * x + par1",
                     name="s1",
-                    data_sort_key={"series": 1},
                 ),
                 ExpressionModel(
                     expr="par2 * x + par3",
                     name="s2",
-                    data_sort_key={"series": 2},
                 ),
             ]
         )
         analysis.set_options(
             data_processor=DataProcessor("counts", [Probability("1")]),
+            data_map={
+                "s1": {"series": 1},
+                "s2": {"series": 2},
+            },
         )
 
         curve_data = analysis._run_data_processing(
@@ -235,17 +237,19 @@ class TestCurveAnalysis(CurveAnalysisTestCase):
                 ExpressionModel(
                     expr="amp * cos(2 * pi * freq * x + phi) + base",
                     name="m1",
-                    data_sort_key={"series": "cos"},
                 ),
                 ExpressionModel(
                     expr="amp * sin(2 * pi * freq * x + phi) + base",
                     name="m2",
-                    data_sort_key={"series": "sin"},
                 ),
             ]
         )
         analysis.set_options(
             data_processor=DataProcessor(input_key="counts", data_actions=[Probability("1")]),
+            data_map={
+                "m1": {"series": "cos"},
+                "m2": {"series": "sin"},
+            },
             p0={"amp": 0.5, "freq": 2.1, "phi": 0.3, "base": 0.1},
             result_parameters=["amp", "freq", "phi", "base"],
             plot=False,
@@ -472,17 +476,21 @@ class TestCurveAnalysis(CurveAnalysisTestCase):
                 models=[
                     ExpressionModel(
                         expr="amp * cos(2 * pi * freq * x) + b",
-                        data_sort_key={"type": "cos"},
+                        name="m1",
                     ),
                     ExpressionModel(
                         expr="amp * sin(2 * pi * freq * x) + b",
-                        data_sort_key={"type": "sin"},
+                        name="m2",
                     ),
                 ],
                 name=group_name,
             )
             analysis.set_options(
                 filter_data={"setup": setup},
+                data_map={
+                    "m1": {"type": "cos"},
+                    "m2": {"type": "sin"},
+                },
                 result_parameters=["amp"],
                 data_processor=DataProcessor(input_key="counts", data_actions=[Probability("1")]),
             )
@@ -809,3 +817,34 @@ class TestBackwardCompatibility(QiskitExperimentsTestCase):
 
         # Still works.
         self.assertListEqual(instance.parameters, ["par0"])
+
+    def test_lmfit_model_with_data_sort_key(self):
+        """Test providing LMFIT model with legacy 'data_sort_key' option."""
+
+        class _DeprecatedAnalysis(CurveAnalysis):
+            def __init__(self):
+                super().__init__(
+                    models=[
+                        ExpressionModel(
+                            expr="x + a",
+                            name="experiment1",
+                            data_sort_key={"tag": 1},
+                        ),
+                        ExpressionModel(
+                            expr="x + b",
+                            name="experiment2",
+                            data_sort_key={"tag": 2},
+                        ),
+                    ]
+                )
+
+        instance = _DeprecatedAnalysis()
+        experiment_data = ExperimentData()
+
+        with self.assertWarns(DeprecationWarning):
+            instance._initialize(experiment_data)
+
+        self.assertDictEqual(
+            instance.options.data_map,
+            {"experiment1": {"tag": 1}, "experiment2": {"tag": 2}},
+        )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR moves `data_sort_key` in the LMFIT model in the curve analysis to the curve analysis options.

Fix #927 

### Details and comments

The `data_sort_key` is an option which is necessary for the curve analysis to filter the experiment data. This option had been tied to each LMFIT model by injecting the filter keywords to the fit options of the LMFIT model. However, such usage is not officially supported by the LMFIT, and this could break curve analysis.

With this PR, the `data_sort_key` is moved to the curve analysis options, rather than binding it with LMFIT model. This gives us more robust framework at the slight expense of coding overhead of default options.


