### PR TITLE
Restrict tox to less than version 4

### DIFF
--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Deps
-        run: python -m pip install -U tox setuptools virtualenv wheel
+        run: python -m pip install -U 'tox<4' setuptools virtualenv wheel
       - name: Run Tests
         run: tox -epy38 -- -n test/database_service/test_experiment_data_integration.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
+        pip install -U virtualenv setuptools wheel 'tox<4'
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
+        pip install -U virtualenv setuptools wheel 'tox<4'
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U tox setuptools virtualenv wheel
+        run: python -m pip install -U 'tox<4' setuptools virtualenv wheel
       - name: Install and Run Tests
         run: tox -e py
         if: runner.os != 'macOS'
@@ -67,7 +67,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install Deps
-        run: python -m pip install -U tox
+        run: python -m pip install -U 'tox<4'
       - name: Run lint
         run: tox -elint
   docs:
@@ -92,7 +92,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install Deps
         run: |
-          python -m pip install -U tox
+          python -m pip install -U 'tox<4'
           sudo apt-get install -y pandoc graphviz
       - name: Build Docs
         run: tox -edocs


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Restrict tox to version 3

### Details and comments

tox 4.0 was just released and CI jobs stopped working. Until those issues are dealt with we can just restrict to tox 3.
