### PR TITLE
Update tox config to avoid sdist for tox 4.x.x compat

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 2.1
+minversion = 3.3.0
 envlist = py310,py39,py38,py37,lint
 isolated_build = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.1
 envlist = py310,py39,py38,py37,lint
-skipsdist = True
+isolated_build = true
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the tox configuration to remove the sdist configuration flag which avoids the intermediate sdist creation as part of tox building the package under test in it's venv. It is replaced by the isolated_build option which configures tox to use a PEP 518/PEP 517 mechanism for building experiments. This mirrors the default behavior in tox 4.0.0. By making this change the tox.ini should be compatible with both tox 3.x.y and 4.x.y.

### Details and comments