### PR TITLE
Remove restriction to tox<4 from CI

### DIFF
--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Deps
-        run: python -m pip install -U 'tox<4' setuptools virtualenv wheel
+        run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Run Tests
         run: tox -epy38 -- -n test/database_service/test_experiment_data_integration.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel 'tox<4'
+        pip install -U virtualenv setuptools wheel tox
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel 'tox<4'
+        pip install -U virtualenv setuptools wheel tox
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U 'tox<4' setuptools virtualenv wheel
+        run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests
         run: tox -e py
         if: runner.os != 'macOS'
@@ -67,7 +67,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install Deps
-        run: python -m pip install -U 'tox<4'
+        run: python -m pip install -U tox
       - name: Run lint
         run: tox -elint
   docs:
@@ -92,7 +92,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install Deps
         run: |
-          python -m pip install -U 'tox<4'
+          python -m pip install -U tox
           sudo apt-get install -y pandoc graphviz
       - name: Build Docs
         run: tox -edocs

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,11 @@ deps =
   git+https://github.com/Qiskit/qiskit-ibmq-provider
   git+https://github.com/jupyter/jupyter-sphinx
   -r{toxinidir}/requirements-dev.txt
-passenv = OMP_NUM_THREADS QISKIT_PARALLEL RAYON_NUM_THREADS QISKIT_IBM_*
+passenv =
+  OMP_NUM_THREADS
+  QISKIT_PARALLEL
+  RAYON_NUM_THREADS
+  QISKIT_IBM_*
 commands = stestr run {posargs}
 
 [testenv:lint]


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR allows the CI to use tox 4.0

### Details and comments

#988 restricted tox to version 3. #990 modifies tox.ini in a way that should be compatible with tox 4. After #990, this PR could be merged. Also, tox 4.0 was a fairly major change, and there have been 5 patch releases already in the day since it was released. It's possible a patch release could make this PR work even without #990.

This reverts commit 36d2eaca54783ba368dc519b1aa37dbca638435c.
