### PR TITLE
Update tomography kwargs

### DIFF
--- a/qiskit_experiments/library/tomography/qpt_experiment.py
+++ b/qiskit_experiments/library/tomography/qpt_experiment.py
@@ -16,10 +16,11 @@ Quantum Process Tomography experiment
 from typing import Union, Optional, Iterable, List, Tuple, Sequence
 import numpy as np
 from qiskit.circuit import QuantumCircuit, Instruction
+from qiskit.providers.backend import Backend
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.quantum_info import Choi, Operator, Statevector, DensityMatrix, partial_trace
 from qiskit_experiments.exceptions import QiskitError
-from .tomography_experiment import TomographyExperiment
+from .tomography_experiment import TomographyExperiment, TomographyAnalysis, BaseAnalysis
 from .qpt_analysis import ProcessTomographyAnalysis
 from . import basis
 
@@ -52,12 +53,17 @@ class ProcessTomography(TomographyExperiment):
     def __init__(
         self,
         circuit: Union[QuantumCircuit, Instruction, BaseOperator],
+        backend: Optional[Backend] = None,
+        physical_qubits: Optional[Sequence[int]] = None,
         measurement_basis: basis.MeasurementBasis = basis.PauliMeasurementBasis(),
+        measurement_indices: Optional[Sequence[int]] = None,
         measurement_qubits: Optional[Sequence[int]] = None,
         preparation_basis: basis.PreparationBasis = basis.PauliPreparationBasis(),
+        preparation_indices: Optional[Sequence[int]] = None,
         preparation_qubits: Optional[Sequence[int]] = None,
         basis_indices: Optional[Iterable[Tuple[List[int], List[int]]]] = None,
         qubits: Optional[Sequence[int]] = None,
+        analysis: Optional[BaseAnalysis] = None,
     ):
         """Initialize a quantum process tomography experiment.
 
@@ -66,14 +72,14 @@ class ProcessTomography(TomographyExperiment):
                 it must be a class that can be appended to a quantum circuit.
             measurement_basis: Tomography basis for measurements. If not specified the
                 default basis is the :class:`~basis.PauliMeasurementBasis`.
-            measurement_qubits: Optional, the qubits to be measured. These should refer
-                to the logical qubits in the state circuit. If None all qubits
-                in the state circuit will be measured.
+            measurement_indices: Optional, the physical_qubit indices to be measured.
+                If None all circuit physical qubits will be measured.
+            measurement_qubits: DEPREACTED, equivalent to measurement_indices.
             preparation_basis: Tomography basis for measurements. If not specified the
-                        default basis is the :class:`~basis.PauliPreparationBasis`.
-            preparation_qubits: Optional, the qubits to be prepared. These should refer
-                to the logical qubits in the process circuit. If None all qubits
-                in the process circuit will be prepared.
+                default basis is the :class:`~basis.PauliPreparationBasis`.
+            preparation_indices: Optional, the physical_qubits indices to be prepared.
+                If None all circuit physical qubits will be prepared.
+            preparation_qubits: DEPREACTED, equivalent to preparation_indices.
             basis_indices: Optional, a list of basis indices for generating partial
                 tomography measurement data. Each item should be given as a pair of
                 lists of preparation and measurement basis configurations
@@ -81,21 +87,28 @@ class ProcessTomography(TomographyExperiment):
                 preparation basis index, and ``m[i]`` is the measurement basis index
                 for qubit-i. If not specified full tomography for all indices of the
                 preparation and measurement bases will be performed.
-            qubits: Optional, the physical qubits for the initial state circuit.
+            qubits: DEPRECATED, the physical qubits for the initial state circuit.
+            analysis: Optional, a custom analysis class to use. If None the default
+                :class:`~.ProcessTomographyAnalysis` will be used.
         """
         super().__init__(
             circuit,
+            backend=backend,
+            physical_qubits=physical_qubits,
             measurement_basis=measurement_basis,
+            measurement_indices=measurement_indices,
             measurement_qubits=measurement_qubits,
             preparation_basis=preparation_basis,
+            preparation_indices=preparation_indices,
             preparation_qubits=preparation_qubits,
             basis_indices=basis_indices,
             qubits=qubits,
-            analysis=ProcessTomographyAnalysis(),
+            analysis=analysis or ProcessTomographyAnalysis(),
         )
 
         # Set target quantum channel
-        self.analysis.set_options(target=self._target_quantum_channel())
+        if isinstance(self.analysis, TomographyAnalysis):
+            self.analysis.set_options(target=self._target_quantum_channel())
 
     def _target_quantum_channel(self) -> Union[Choi, Operator]:
         """Return the process tomography target"""
@@ -116,8 +129,8 @@ class ProcessTomography(TomographyExperiment):
             return None
 
         total_qubits = self._circuit.num_qubits
-        num_meas = total_qubits if self._meas_qubits is None else len(self._meas_qubits)
-        num_prep = total_qubits if self._prep_qubits is None else len(self._prep_qubits)
+        num_meas = total_qubits if self._meas_indices is None else len(self._meas_indices)
+        num_prep = total_qubits if self._prep_indices is None else len(self._prep_indices)
 
         # If all qubits are prepared or measurement we are done
         if num_meas == total_qubits and num_prep == total_qubits:

--- a/qiskit_experiments/library/tomography/qpt_experiment.py
+++ b/qiskit_experiments/library/tomography/qpt_experiment.py
@@ -63,7 +63,7 @@ class ProcessTomography(TomographyExperiment):
         preparation_qubits: Optional[Sequence[int]] = None,
         basis_indices: Optional[Iterable[Tuple[List[int], List[int]]]] = None,
         qubits: Optional[Sequence[int]] = None,
-        analysis: Optional[Union[BaseAnalysis, None]] = "default",
+        analysis: Union[BaseAnalysis, None, str] = "default",
     ):
         """Initialize a quantum process tomography experiment.
 
@@ -75,12 +75,12 @@ class ProcessTomography(TomographyExperiment):
                 If None this will be qubits [0, N) for an N-qubit circuit.
             measurement_basis: Tomography basis for measurements. If not specified the
                 default basis is the :class:`~basis.PauliMeasurementBasis`.
-            measurement_indices: Optional, the physical_qubit indices to be measured.
+            measurement_indices: Optional, the `physical_qubits` indices to be measured.
                 If None all circuit physical qubits will be measured.
             measurement_qubits: DEPRECATED, equivalent to measurement_indices.
             preparation_basis: Tomography basis for measurements. If not specified the
                 default basis is the :class:`~basis.PauliPreparationBasis`.
-            preparation_indices: Optional, the physical_qubits indices to be prepared.
+            preparation_indices: Optional, the `physical_qubits` indices to be prepared.
                 If None all circuit physical qubits will be prepared.
             preparation_qubits: DEPRECATED, equivalent to preparation_indices.
             basis_indices: Optional, a list of basis indices for generating partial
@@ -136,8 +136,8 @@ class ProcessTomography(TomographyExperiment):
             return None
 
         total_qubits = self._circuit.num_qubits
-        num_meas = total_qubits if self._meas_indices is None else len(self._meas_indices)
-        num_prep = total_qubits if self._prep_indices is None else len(self._prep_indices)
+        num_meas = total_qubits if not self._meas_indices else len(self._meas_indices)
+        num_prep = total_qubits if not self._prep_indices else len(self._prep_indices)
 
         # If all qubits are prepared or measurement we are done
         if num_meas == total_qubits and num_prep == total_qubits:

--- a/qiskit_experiments/library/tomography/qpt_experiment.py
+++ b/qiskit_experiments/library/tomography/qpt_experiment.py
@@ -74,12 +74,12 @@ class ProcessTomography(TomographyExperiment):
                 default basis is the :class:`~basis.PauliMeasurementBasis`.
             measurement_indices: Optional, the physical_qubit indices to be measured.
                 If None all circuit physical qubits will be measured.
-            measurement_qubits: DEPREACTED, equivalent to measurement_indices.
+            measurement_qubits: DEPRECATED, equivalent to measurement_indices.
             preparation_basis: Tomography basis for measurements. If not specified the
                 default basis is the :class:`~basis.PauliPreparationBasis`.
             preparation_indices: Optional, the physical_qubits indices to be prepared.
                 If None all circuit physical qubits will be prepared.
-            preparation_qubits: DEPREACTED, equivalent to preparation_indices.
+            preparation_qubits: DEPRECATED, equivalent to preparation_indices.
             basis_indices: Optional, a list of basis indices for generating partial
                 tomography measurement data. Each item should be given as a pair of
                 lists of preparation and measurement basis configurations

--- a/qiskit_experiments/library/tomography/qpt_experiment.py
+++ b/qiskit_experiments/library/tomography/qpt_experiment.py
@@ -63,13 +63,16 @@ class ProcessTomography(TomographyExperiment):
         preparation_qubits: Optional[Sequence[int]] = None,
         basis_indices: Optional[Iterable[Tuple[List[int], List[int]]]] = None,
         qubits: Optional[Sequence[int]] = None,
-        analysis: Optional[BaseAnalysis] = None,
+        analysis: Optional[Union[BaseAnalysis, None]] = "default",
     ):
         """Initialize a quantum process tomography experiment.
 
         Args:
             circuit: the quantum process circuit. If not a quantum circuit
                 it must be a class that can be appended to a quantum circuit.
+            backend: The backend to run the experiment on.
+            physical_qubits: Optional, the physical qubits for the initial state circuit.
+                If None this will be qubits [0, N) for an N-qubit circuit.
             measurement_basis: Tomography basis for measurements. If not specified the
                 default basis is the :class:`~basis.PauliMeasurementBasis`.
             measurement_indices: Optional, the physical_qubit indices to be measured.
@@ -88,9 +91,13 @@ class ProcessTomography(TomographyExperiment):
                 for qubit-i. If not specified full tomography for all indices of the
                 preparation and measurement bases will be performed.
             qubits: DEPRECATED, the physical qubits for the initial state circuit.
-            analysis: Optional, a custom analysis class to use. If None the default
-                :class:`~.ProcessTomographyAnalysis` will be used.
+            analysis: Optional, a custom analysis instance to use. If ``"default"``
+                :class:`~.ProcessTomographyAnalysis` will be used. If None no analysis
+                instance will be set.
         """
+        if analysis == "default":
+            analysis = ProcessTomographyAnalysis()
+
         super().__init__(
             circuit,
             backend=backend,
@@ -103,7 +110,7 @@ class ProcessTomography(TomographyExperiment):
             preparation_qubits=preparation_qubits,
             basis_indices=basis_indices,
             qubits=qubits,
-            analysis=analysis or ProcessTomographyAnalysis(),
+            analysis=analysis,
         )
 
         # Set target quantum channel

--- a/qiskit_experiments/library/tomography/qst_experiment.py
+++ b/qiskit_experiments/library/tomography/qst_experiment.py
@@ -58,7 +58,7 @@ class StateTomography(TomographyExperiment):
         measurement_qubits: Optional[Sequence[int]] = None,
         basis_indices: Optional[Iterable[List[int]]] = None,
         qubits: Optional[Sequence[int]] = None,
-        analysis: Optional[BaseAnalysis] = None,
+        analysis: Optional[Union[BaseAnalysis, None]] = "default",
     ):
         """Initialize a quantum process tomography experiment.
 
@@ -79,8 +79,9 @@ class StateTomography(TomographyExperiment):
                 is the measurement basis index for qubit-i. If not specified full
                 tomography for all indices of the measurement basis will be performed.
             qubits: DEPRECATED, the physical qubits for the initial state circuit.
-            analysis: Optional, a custom analysis class to use. If None the default
-                :class:`~.StateTomographyAnalysis` will be used.
+            analysis: Optional, a custom analysis instance to use. If ``"default"``
+                :class:`~.StateTomographyAnalysis` will be used. If None no analysis
+                instance will be set.
         """
         if isinstance(circuit, Statevector):
             # Convert to circuit using initialize instruction
@@ -92,6 +93,9 @@ class StateTomography(TomographyExperiment):
             # Add trivial preparation indices for base class
             basis_indices = [([], i) for i in basis_indices]
 
+        if analysis == "default":
+            analysis = StateTomographyAnalysis()
+
         super().__init__(
             circuit,
             backend=backend,
@@ -101,7 +105,7 @@ class StateTomography(TomographyExperiment):
             measurement_qubits=measurement_qubits,
             basis_indices=basis_indices,
             qubits=qubits,
-            analysis=analysis or StateTomographyAnalysis(),
+            analysis=analysis,
         )
 
         # Set target quantum state

--- a/qiskit_experiments/library/tomography/qst_experiment.py
+++ b/qiskit_experiments/library/tomography/qst_experiment.py
@@ -72,7 +72,7 @@ class StateTomography(TomographyExperiment):
                 default basis is the :class:`~basis.PauliMeasurementBasis`.
             measurement_indices: Optional, the physical_qubit indices to be measured.
                 If None all circuit physical qubits will be measured.
-            measurement_qubits: DEPREACTED, equivalent to measurement_indices.
+            measurement_qubits: DEPRECATED, equivalent to measurement_indices.
             basis_indices: Optional, a list of basis indices for generating partial
                 tomography measurement data. Each item should be given as a list of
                 measurement basis configurations ``[m[0], m[1], ...]`` where ``m[i]``

--- a/qiskit_experiments/library/tomography/qst_experiment.py
+++ b/qiskit_experiments/library/tomography/qst_experiment.py
@@ -58,7 +58,7 @@ class StateTomography(TomographyExperiment):
         measurement_qubits: Optional[Sequence[int]] = None,
         basis_indices: Optional[Iterable[List[int]]] = None,
         qubits: Optional[Sequence[int]] = None,
-        analysis: Optional[Union[BaseAnalysis, None]] = "default",
+        analysis: Union[BaseAnalysis, None, str] = "default",
     ):
         """Initialize a quantum process tomography experiment.
 
@@ -70,7 +70,7 @@ class StateTomography(TomographyExperiment):
                 If None this will be qubits [0, N) for an N-qubit circuit.
             measurement_basis: Tomography basis for measurements. If not specified the
                 default basis is the :class:`~basis.PauliMeasurementBasis`.
-            measurement_indices: Optional, the physical_qubit indices to be measured.
+            measurement_indices: Optional, the `physical_qubits` indices to be measured.
                 If None all circuit physical qubits will be measured.
             measurement_qubits: DEPRECATED, equivalent to measurement_indices.
             basis_indices: Optional, a list of basis indices for generating partial
@@ -130,7 +130,7 @@ class StateTomography(TomographyExperiment):
             # Circuit couldn't be simulated
             return None
 
-        if self._meas_indices is None:
+        if not self._meas_indices:
             return state
 
         non_meas_qargs = list(range(len(self._meas_indices), self._circuit.num_qubits))

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -13,6 +13,7 @@
 Quantum Tomography experiment
 """
 
+import warnings
 from typing import Union, Optional, Iterable, List, Tuple, Sequence
 from itertools import product
 from qiskit.circuit import QuantumCircuit, Instruction, ClassicalRegister
@@ -20,7 +21,7 @@ from qiskit.circuit.library import Permutation
 from qiskit.providers.backend import Backend
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit_experiments.exceptions import QiskitError
-from qiskit_experiments.framework import BaseExperiment, Options
+from qiskit_experiments.framework import BaseExperiment, BaseAnalysis, Options
 from .basis import PreparationBasis, MeasurementBasis
 from .tomography_analysis import TomographyAnalysis
 
@@ -54,13 +55,16 @@ class TomographyExperiment(BaseExperiment):
         self,
         circuit: Union[QuantumCircuit, Instruction, BaseOperator],
         backend: Optional[Backend] = None,
+        physical_qubits: Optional[Sequence[int]] = None,
         measurement_basis: Optional[MeasurementBasis] = None,
+        measurement_indices: Optional[Sequence[int]] = None,
         measurement_qubits: Optional[Sequence[int]] = None,
         preparation_basis: Optional[PreparationBasis] = None,
+        preparation_indices: Optional[Sequence[int]] = None,
         preparation_qubits: Optional[Sequence[int]] = None,
         basis_indices: Optional[Iterable[Tuple[List[int], List[int]]]] = None,
         qubits: Optional[Sequence[int]] = None,
-        analysis: Optional[TomographyAnalysis] = None,
+        analysis: Optional[BaseAnalysis] = None,
     ):
         """Initialize a tomography experiment.
 
@@ -68,27 +72,57 @@ class TomographyExperiment(BaseExperiment):
             circuit: the quantum process circuit. If not a quantum circuit
                 it must be a class that can be appended to a quantum circuit.
             backend: The backend to run the experiment on.
+            physical_qubits: Optional, the physical qubits for the initial state circuit.
+                If None this will be qubits [0, N) for an N-qubit circuit.
             measurement_basis: Tomography basis for measurements.
-            measurement_qubits: Optional, the qubits to be measured. These should refer
-                to the logical qubits in the state circuit.
+            measurement_indices: Optional, the physical_qubit indices to be measured.
+                If None all circuit physical qubits will be measured.
+            measurement_qubits: DEPREACTED, equivalent to measurement_indices.
             preparation_basis: Tomography basis for measurements.
-            preparation_qubits: Optional, the qubits to be prepared. These should refer
-                to the logical qubits in the process circuit.
+            preparation_indices: Optional, the physical_qubits indices to be prepared.
+                If None all circuit physical qubits will be prepared.
+            preparation_qubits: DEPREACTED, equivalent to preparation_indices.
             basis_indices: Optional, the basis elements to be measured. If None
                 All basis elements will be measured.
-            qubits: Optional, the physical qubits for the initial state circuit.
-            analysis: Optional, analysis class to use for experiment. If None the default
-                tomography analysis will be used.
+            qubits: DEPRECATED, the physical qubits for the initial state circuit.
+            analysis: Optional, a custom analysis class to use. If None the default
+                :class:`~.TomographyAnalysis` will be used.
 
         Raises:
             QiskitError: if input params are invalid.
         """
+        # Deprecated kwargs
+        if qubits is not None:
+            physical_qubits = qubits
+            warnings.warn(
+                "The `qubits` kwarg has been renamed to `physical_qubits`."
+                " It will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if measurement_qubits is not None:
+            measurement_indices = measurement_qubits
+            warnings.warn(
+                "The `measurement_qubits` kwarg has been renamed to `measurement_indices`."
+                " It will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if preparation_qubits is not None:
+            preparation_indices = preparation_qubits
+            warnings.warn(
+                "The `preparation_qubits` kwarg has been renamed to `preparation_indices`."
+                " It will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         # Initialize BaseExperiment
-        if qubits is None:
-            qubits = tuple(range(circuit.num_qubits))
+        if physical_qubits is None:
+            physical_qubits = tuple(range(circuit.num_qubits))
         if analysis is None:
             analysis = TomographyAnalysis()
-        super().__init__(qubits, analysis=analysis, backend=backend)
+        super().__init__(physical_qubits, analysis=analysis, backend=backend)
 
         # Get the target tomography circuit
         if isinstance(circuit, QuantumCircuit):
@@ -102,39 +136,39 @@ class TomographyExperiment(BaseExperiment):
 
         # Measurement basis and qubits
         self._meas_circ_basis = measurement_basis
-        if measurement_qubits:
+        if measurement_indices:
             # Convert logical qubits to physical qubits
-            self._meas_qubits = tuple(measurement_qubits)
-            self._meas_physical_qubits = tuple(self.physical_qubits[i] for i in self._meas_qubits)
-            for qubit in self._meas_qubits:
+            self._meas_indices = tuple(measurement_indices)
+            self._meas_physical_qubits = tuple(self.physical_qubits[i] for i in self._meas_indices)
+            for qubit in self._meas_indices:
                 if qubit not in range(self.num_qubits):
                     raise QiskitError(
                         f"measurement qubit ({qubit}) is outside the range"
                         f" of circuit qubits [0, {self.num_qubits})."
                     )
         elif measurement_basis:
-            self._meas_qubits = tuple(range(self.num_qubits))
+            self._meas_indices = tuple(range(self.num_qubits))
             self._meas_physical_qubits = self.physical_qubits
         else:
-            self._meas_qubits = tuple()
+            self._meas_indices = tuple()
             self._meas_physical_qubits = tuple()
 
         # Preparation basis and qubits
         self._prep_circ_basis = preparation_basis
-        if preparation_qubits:
-            self._prep_qubits = tuple(preparation_qubits)
-            self._prep_physical_qubits = tuple(self.physical_qubits[i] for i in self._prep_qubits)
-            for qubit in self._prep_qubits:
+        if preparation_indices:
+            self._prep_indices = tuple(preparation_indices)
+            self._prep_physical_qubits = tuple(self.physical_qubits[i] for i in self._prep_indices)
+            for qubit in self._prep_indices:
                 if qubit not in range(self.num_qubits):
                     raise QiskitError(
                         f"preparation qubit ({qubit}) is outside the range"
                         f" of circuit qubits [0, {self.num_qubits})."
                     )
         elif preparation_basis:
-            self._prep_qubits = tuple(range(self.num_qubits))
+            self._prep_indices = tuple(range(self.num_qubits))
             self._prep_physical_qubits = self.physical_qubits
         else:
-            self._prep_qubits = tuple()
+            self._prep_indices = tuple()
             self._prep_physical_qubits = tuple()
 
         # Configure experiment options
@@ -142,19 +176,18 @@ class TomographyExperiment(BaseExperiment):
             self.set_experiment_options(basis_indices=basis_indices)
 
         # Configure analysis basis options
-        analysis_options = {}
-        if measurement_basis:
-            analysis_options["measurement_basis"] = measurement_basis
-        if preparation_basis:
-            analysis_options["preparation_basis"] = preparation_basis
-
-        self.analysis.set_options(**analysis_options)
+        if isinstance(self.analysis, TomographyAnalysis):
+            analysis_options = {}
+            if measurement_basis:
+                analysis_options["measurement_basis"] = measurement_basis
+            if preparation_basis:
+                analysis_options["preparation_basis"] = preparation_basis
+            self.analysis.set_options(**analysis_options)
 
     def circuits(self):
-
         circ_qubits = self._circuit.qubits
         circ_clbits = self._circuit.clbits
-        meas_creg = ClassicalRegister((len(self._meas_qubits)), name="c_tomo")
+        meas_creg = ClassicalRegister((len(self._meas_indices)), name="c_tomo")
         template = QuantumCircuit(
             *self._circuit.qregs, *self._circuit.cregs, meas_creg, name=f"{self._type}"
         )
@@ -177,9 +210,9 @@ class TomographyExperiment(BaseExperiment):
             if prep_element:
                 # Add tomography preparation
                 prep_circ = self._prep_circ_basis.circuit(prep_element, self._prep_physical_qubits)
-                circ.reset(self._prep_qubits)
-                circ.compose(prep_circ, self._prep_qubits, inplace=True)
-                circ.barrier(self._prep_qubits)
+                circ.reset(self._prep_indices)
+                circ.compose(prep_circ, self._prep_indices, inplace=True)
+                circ.barrier(self._prep_indices)
 
             # Add target circuit
             # Have to use compose since circuit.to_instruction has a bug
@@ -189,8 +222,8 @@ class TomographyExperiment(BaseExperiment):
             # Add tomography measurement
             if meas_element:
                 meas_circ = self._meas_circ_basis.circuit(meas_element, self._meas_physical_qubits)
-                circ.barrier(self._meas_qubits)
-                circ.compose(meas_circ, self._meas_qubits, meas_clbits, inplace=True)
+                circ.barrier(self._meas_indices)
+                circ.compose(meas_circ, self._meas_indices, meas_clbits, inplace=True)
 
             # Add metadata
             circ.metadata = metadata
@@ -230,8 +263,8 @@ class TomographyExperiment(BaseExperiment):
         respectively for the returned circuit.
         """
         default_range = tuple(range(self.num_qubits))
-        permute_meas = self._meas_qubits and self._meas_qubits != default_range
-        permute_prep = self._prep_qubits and self._prep_qubits != default_range
+        permute_meas = self._meas_indices and self._meas_indices != default_range
+        permute_prep = self._prep_indices and self._prep_indices != default_range
         if not permute_meas and not permute_prep:
             return self._circuit
 
@@ -243,10 +276,10 @@ class TomographyExperiment(BaseExperiment):
             perm_circ = QuantumCircuit(total_qubits)
 
         # Apply permutation to put prep qubits as [0, ..., M-1]
-        if self._prep_qubits:
-            prep_qargs = list(self._prep_qubits)
-            if len(self._prep_qubits) != total_qubits:
-                prep_qargs += [i for i in range(total_qubits) if i not in self._prep_qubits]
+        if self._prep_indices:
+            prep_qargs = list(self._prep_indices)
+            if len(self._prep_indices) != total_qubits:
+                prep_qargs += [i for i in range(total_qubits) if i not in self._prep_indices]
             perm_circ.append(Permutation(total_qubits, prep_qargs).inverse(), range(total_qubits))
 
         # Apply original circuit
@@ -256,10 +289,10 @@ class TomographyExperiment(BaseExperiment):
             perm_circ = perm_circ.compose(self._circuit, range(total_qubits))
 
         # Apply permutation to put meas qubits as [0, ..., M-1]
-        if self._meas_qubits:
-            meas_qargs = list(self._meas_qubits)
-            if len(self._meas_qubits) != total_qubits:
-                meas_qargs += [i for i in range(total_qubits) if i not in self._meas_qubits]
+        if self._meas_indices:
+            meas_qargs = list(self._meas_indices)
+            if len(self._meas_indices) != total_qubits:
+                meas_qargs += [i for i in range(total_qubits) if i not in self._meas_indices]
             perm_circ.append(Permutation(total_qubits, meas_qargs), range(total_qubits))
 
         return perm_circ

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -77,11 +77,11 @@ class TomographyExperiment(BaseExperiment):
             measurement_basis: Tomography basis for measurements.
             measurement_indices: Optional, the physical_qubit indices to be measured.
                 If None all circuit physical qubits will be measured.
-            measurement_qubits: DEPREACTED, equivalent to measurement_indices.
+            measurement_qubits: DEPRECATED, equivalent to measurement_indices.
             preparation_basis: Tomography basis for measurements.
             preparation_indices: Optional, the physical_qubits indices to be prepared.
                 If None all circuit physical qubits will be prepared.
-            preparation_qubits: DEPREACTED, equivalent to preparation_indices.
+            preparation_qubits: DEPRECATED, equivalent to preparation_indices.
             basis_indices: Optional, the basis elements to be measured. If None
                 All basis elements will be measured.
             qubits: DEPRECATED, the physical qubits for the initial state circuit.

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -64,7 +64,7 @@ class TomographyExperiment(BaseExperiment):
         preparation_qubits: Optional[Sequence[int]] = None,
         basis_indices: Optional[Iterable[Tuple[List[int], List[int]]]] = None,
         qubits: Optional[Sequence[int]] = None,
-        analysis: Optional[BaseAnalysis] = None,
+        analysis: Optional[Union[BaseAnalysis, None]] = "default",
     ):
         """Initialize a tomography experiment.
 
@@ -85,8 +85,9 @@ class TomographyExperiment(BaseExperiment):
             basis_indices: Optional, the basis elements to be measured. If None
                 All basis elements will be measured.
             qubits: DEPRECATED, the physical qubits for the initial state circuit.
-            analysis: Optional, a custom analysis class to use. If None the default
-                :class:`~.TomographyAnalysis` will be used.
+            analysis: Optional, a custom analysis instance to use. If ``"default"``
+                :class:`~.TomographyAnalysis` will be used. If None no analysis
+                instance will be set.
 
         Raises:
             QiskitError: if input params are invalid.
@@ -120,7 +121,7 @@ class TomographyExperiment(BaseExperiment):
         # Initialize BaseExperiment
         if physical_qubits is None:
             physical_qubits = tuple(range(circuit.num_qubits))
-        if analysis is None:
+        if analysis == "default":
             analysis = TomographyAnalysis()
         super().__init__(physical_qubits, analysis=analysis, backend=backend)
 

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -64,7 +64,7 @@ class TomographyExperiment(BaseExperiment):
         preparation_qubits: Optional[Sequence[int]] = None,
         basis_indices: Optional[Iterable[Tuple[List[int], List[int]]]] = None,
         qubits: Optional[Sequence[int]] = None,
-        analysis: Optional[Union[BaseAnalysis, None]] = "default",
+        analysis: Union[BaseAnalysis, None, str] = "default",
     ):
         """Initialize a tomography experiment.
 
@@ -74,13 +74,17 @@ class TomographyExperiment(BaseExperiment):
             backend: The backend to run the experiment on.
             physical_qubits: Optional, the physical qubits for the initial state circuit.
                 If None this will be qubits [0, N) for an N-qubit circuit.
-            measurement_basis: Tomography basis for measurements.
-            measurement_indices: Optional, the physical_qubit indices to be measured.
-                If None all circuit physical qubits will be measured.
+            measurement_basis: Tomography basis for measurements. If set to None
+                no tomography measurements will be performed.
+            measurement_indices: Optional, the `physical_qubits` indices to be
+                measured as specified by the `measurement_basis`. If None all
+                circuit physical qubits will be measured.
             measurement_qubits: DEPRECATED, equivalent to measurement_indices.
-            preparation_basis: Tomography basis for measurements.
-            preparation_indices: Optional, the physical_qubits indices to be prepared.
-                If None all circuit physical qubits will be prepared.
+            preparation_basis: Tomography basis for measurements. If set to None
+                no tomography preparations will be performed.
+            preparation_indices: Optional, the `physical_qubits` indices to be
+                prepared as specified by the `preparation_basis`. If None all
+                circuit physical qubits will be prepared.
             preparation_qubits: DEPRECATED, equivalent to preparation_indices.
             basis_indices: Optional, the basis elements to be measured. If None
                 All basis elements will be measured.

--- a/releasenotes/notes/tomo-kwargs-b091ce13d6983bc1.yaml
+++ b/releasenotes/notes/tomo-kwargs-b091ce13d6983bc1.yaml
@@ -1,0 +1,26 @@
+---
+features:
+  - |
+    Adds ``backend`` and ``analysis`` init kwargs to :class:`~.StateTomography`
+    and :class:`.ProcessTomography experiments to match the base
+    :class:`~.TomographyExperiment` init kwargs. This allows specifying the
+    intented backend, or a custom analysis class when initializing the
+    experiments.
+upgrade:
+  - |
+    Renames the ``qubits``, ``measurement_qubits``, and ``preparation_qubits``
+    init kwargs of :class:`~.StateTomography`,
+    :class:`~.ProcessTomography`, and :class:`~.TomographyExperiment` to
+    ``physical_qubits``, ``measurement_indices`` and ``preparation_indices``
+    respectively. This is to make the intended use of these kwargs more clear
+    as the measurement and preparation args refer to the index of circuit
+    qubits in the physical qubits list, not the physical qubit values
+    themselves.
+deprecations:
+  - |
+    Renames the ``qubits``, ``measurement_qubits``, and ``preparation_qubits``
+     init kwargs of :class:`~.StateTomography`,
+    :class:`~.ProcessTomography`, and :class:`~.TomographyExperiment` have
+    been deprecated. They have been replaced with kwargs ``physical_qubits``,
+    ``measurement_indices`` and ``preparation_indices`` respectively. The
+    renamed kwargs have the same functionality as the deprecated kwargs.

--- a/releasenotes/notes/tomo-kwargs-b091ce13d6983bc1.yaml
+++ b/releasenotes/notes/tomo-kwargs-b091ce13d6983bc1.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     Adds ``backend`` and ``analysis`` init kwargs to :class:`~.StateTomography`
-    and :class:`.ProcessTomography` experiments to match the base
+    and :class:`~.ProcessTomography` experiments to match the base
     :class:`~.TomographyExperiment` init kwargs. This allows specifying the
     intented backend, or a custom analysis class when initializing the
     experiments.

--- a/releasenotes/notes/tomo-kwargs-b091ce13d6983bc1.yaml
+++ b/releasenotes/notes/tomo-kwargs-b091ce13d6983bc1.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     Adds ``backend`` and ``analysis`` init kwargs to :class:`~.StateTomography`
-    and :class:`.ProcessTomography experiments to match the base
+    and :class:`.ProcessTomography` experiments to match the base
     :class:`~.TomographyExperiment` init kwargs. This allows specifying the
     intented backend, or a custom analysis class when initializing the
     experiments.

--- a/test/library/tomography/test_composite_tomography.py
+++ b/test/library/tomography/test_composite_tomography.py
@@ -26,7 +26,7 @@ class TestCompositeTomography(QiskitExperimentsTestCase):
     """Test composite tomography experiments"""
 
     def test_batch_qst_exp(self):
-        """Test batch state tomography experiment with measurement_qubits kwarg"""
+        """Test batch state tomography experiment with measurement_indices kwarg"""
         # Subsystem unitaries
         seed = 1111
         nq = 3
@@ -42,7 +42,7 @@ class TestCompositeTomography(QiskitExperimentsTestCase):
         targets = []
         for i in range(nq):
             targets.append(qi.Statevector(ops[i].to_instruction()))
-            exps.append(StateTomography(circuit, measurement_qubits=[i]))
+            exps.append(StateTomography(circuit, measurement_indices=[i]))
 
         # Run batch experiments
         backend = AerSimulator(seed_simulator=9000)
@@ -80,7 +80,7 @@ class TestCompositeTomography(QiskitExperimentsTestCase):
         exps = []
         targets = []
         for i in range(nq):
-            exps.append(StateTomography(ops[i], qubits=[i]))
+            exps.append(StateTomography(ops[i], physical_qubits=[i]))
             targets.append(qi.Statevector(ops[i].to_instruction()))
 
         # Run batch experiments
@@ -108,7 +108,7 @@ class TestCompositeTomography(QiskitExperimentsTestCase):
             target_fid = qi.state_fidelity(state, targets[i], validate=False)
             self.assertAlmostEqual(fid, target_fid, places=6, msg="result fidelity is incorrect")
 
-    def test_batch_qpt_exp_with_measurement_qubits(self):
+    def test_batch_qpt_exp_with_measurement_indices(self):
         """Test batch process tomography experiment with kwargs"""
         seed = 1111
         nq = 3
@@ -124,7 +124,9 @@ class TestCompositeTomography(QiskitExperimentsTestCase):
         targets = []
         for i in range(nq):
             targets.append(ops[i])
-            exps.append(ProcessTomography(circuit, measurement_qubits=[i], preparation_qubits=[i]))
+            exps.append(
+                ProcessTomography(circuit, measurement_indices=[i], preparation_indices=[i])
+            )
 
         # Run batch experiments
         backend = AerSimulator(seed_simulator=9000)
@@ -160,7 +162,7 @@ class TestCompositeTomography(QiskitExperimentsTestCase):
         exps = []
         targets = []
         for i in range(nq):
-            exps.append(ProcessTomography(ops[i], qubits=[i]))
+            exps.append(ProcessTomography(ops[i], physical_qubits=[i]))
             targets.append(ops[i])
 
         # Run batch experiments

--- a/test/library/tomography/test_process_tomography.py
+++ b/test/library/tomography/test_process_tomography.py
@@ -67,6 +67,19 @@ class TestProcessTomography(QiskitExperimentsTestCase):
                     fid, target_fid, places=6, msg=f"{fitter} result fidelity is incorrect"
                 )
 
+    def test_full_qpt_analysis_none(self):
+        """Test QPT experiment without analysis"""
+        seed = 4321
+        shots = 1000
+        # Generate tomography data without analysis
+        backend = AerSimulator(seed_simulator=seed, shots=shots)
+        target = qi.random_unitary(2, seed=seed)
+        exp = ProcessTomography(target, backend=backend, analysis=None)
+        self.assertEqual(exp.analysis, None)
+        expdata = exp.run()
+        self.assertExperimentDone(expdata)
+        self.assertFalse(expdata.analysis_results())
+
     def test_cvxpy_gaussian_lstsq_cx(self):
         """Test fitter with high fidelity threshold"""
         seed = 1234

--- a/test/library/tomography/test_process_tomography.py
+++ b/test/library/tomography/test_process_tomography.py
@@ -100,7 +100,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         )
 
     @ddt.data([0], [1], [2], [0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1])
-    def test_exp_measurement_preparation_qubits(self, qubits):
+    def test_exp_measurement_preparation_indices(self, qubits):
         """Test subset measurement process tomography generation"""
         # Subsystem unitaries
         seed = 1111
@@ -113,7 +113,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
             circ.append(op, [i])
 
         num_meas = len(qubits)
-        exp = ProcessTomography(circ, measurement_qubits=qubits, preparation_qubits=qubits)
+        exp = ProcessTomography(circ, measurement_indices=qubits, preparation_indices=qubits)
         tomo_circuits = exp.circuits()
 
         # Check correct number of circuits are generated
@@ -150,7 +150,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
             circ.append(op, [i])
 
         exp = ProcessTomography(
-            circ, measurement_qubits=[meas_qubit], preparation_qubits=[prep_qubit]
+            circ, measurement_indices=[meas_qubit], preparation_indices=[prep_qubit]
         )
         backend = AerSimulator(seed_simulator=9000)
         expdata = exp.run(backend, shots=5000)
@@ -182,7 +182,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
             circ.append(op, [i])
 
         exp = ProcessTomography(
-            circ, measurement_qubits=meas_qubits, preparation_qubits=prep_qubits
+            circ, measurement_indices=meas_qubits, preparation_indices=prep_qubits
         )
         backend = AerSimulator(seed_simulator=9000)
         expdata = exp.run(backend, shots=5000)
@@ -224,7 +224,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
 
         # Run
         backend = AerSimulator(seed_simulator=9000)
-        exp = ProcessTomography(circ, measurement_qubits=qubits, preparation_qubits=qubits)
+        exp = ProcessTomography(circ, measurement_indices=qubits, preparation_indices=qubits)
         expdata = exp.run(backend)
         self.assertExperimentDone(expdata)
         results = expdata.analysis_results()
@@ -250,7 +250,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         # Teleport qubit 0 -> 2
         backend = AerSimulator(seed_simulator=9000)
         exp = ProcessTomography(
-            teleport_circuit(flatten_creg), measurement_qubits=[2], preparation_qubits=[0]
+            teleport_circuit(flatten_creg), measurement_indices=[2], preparation_indices=[0]
         )
         expdata = exp.run(backend, shots=1000)
         self.assertExperimentDone(expdata)
@@ -274,8 +274,8 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         backend = AerSimulator(seed_simulator=9000)
         exp = ProcessTomography(
             teleport_bell_circuit(flatten_creg),
-            measurement_qubits=[2, 3],
-            preparation_qubits=[0, 3],
+            measurement_indices=[2, 3],
+            preparation_indices=[0, 3],
         )
         expdata = exp.run(backend, shots=1000)
         self.assertExperimentDone(expdata)
@@ -300,7 +300,9 @@ class TestProcessTomography(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = ProcessTomography(teleport_circuit(), measurement_qubits=[2], preparation_qubits=[0])
+        exp = ProcessTomography(
+            teleport_circuit(), measurement_indices=[2], preparation_indices=[0]
+        )
         loaded_exp = ProcessTomography.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))

--- a/test/library/tomography/test_state_tomography.py
+++ b/test/library/tomography/test_state_tomography.py
@@ -71,6 +71,19 @@ class TestStateTomography(QiskitExperimentsTestCase):
                     fid, target_fid, places=6, msg=f"{fitter} result fidelity is incorrect"
                 )
 
+    def test_full_qst_analysis_none(self):
+        """Test QST experiment"""
+        seed = 4321
+        shots = 1000
+        # Generate tomography data without analysis
+        backend = AerSimulator(seed_simulator=seed, shots=shots)
+        target = qi.random_statevector(2, seed=seed)
+        exp = StateTomography(target, backend=backend, analysis=None)
+        self.assertEqual(exp.analysis, None)
+        expdata = exp.run()
+        self.assertExperimentDone(expdata)
+        self.assertFalse(expdata.analysis_results())
+
     @ddt.data(True, False)
     def test_qst_teleport(self, flatten_creg):
         """Test subset state tomography generation"""

--- a/test/library/tomography/test_state_tomography.py
+++ b/test/library/tomography/test_state_tomography.py
@@ -76,7 +76,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
         """Test subset state tomography generation"""
         # Teleport qubit 0 -> 2
         backend = AerSimulator(seed_simulator=9000)
-        exp = StateTomography(teleport_circuit(flatten_creg), measurement_qubits=[2])
+        exp = StateTomography(teleport_circuit(flatten_creg), measurement_indices=[2])
         expdata = exp.run(backend)
         self.assertExperimentDone(expdata)
         results = expdata.analysis_results()
@@ -99,7 +99,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
         """Test subset state tomography generation"""
         # Teleport qubit 0 -> 2
         backend = AerSimulator(seed_simulator=9000)
-        exp = StateTomography(teleport_bell_circuit(flatten_creg), measurement_qubits=[2, 3])
+        exp = StateTomography(teleport_bell_circuit(flatten_creg), measurement_indices=[2, 3])
         expdata = exp.run(backend)
         self.assertExperimentDone(expdata)
         results = expdata.analysis_results()
@@ -134,7 +134,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
         [2, 0, 1],
         [2, 1, 0],
     )
-    def test_exp_circuits_measurement_qubits(self, meas_qubits):
+    def test_exp_circuits_measurement_indices(self, meas_qubits):
         """Test subset state tomography generation"""
         # Subsystem unitaries
         seed = 1111
@@ -147,7 +147,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
             circ.append(op, [i])
 
         num_meas = len(meas_qubits)
-        exp = StateTomography(circ, measurement_qubits=meas_qubits)
+        exp = StateTomography(circ, measurement_indices=meas_qubits)
         tomo_circuits = exp.circuits()
 
         # Check correct number of circuits are generated
@@ -169,7 +169,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
         self.assertGreater(fid, 0.99, msg="target_state is incorrect")
 
     @ddt.data([0], [1], [2], [0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1])
-    def test_full_exp_measurement_qubits(self, meas_qubits):
+    def test_full_exp_measurement_indices(self, meas_qubits):
         """Test subset state tomography generation"""
         # Subsystem unitaries
         seed = 1111
@@ -189,7 +189,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
 
         # Run
         backend = AerSimulator(seed_simulator=9000)
-        exp = StateTomography(circ, measurement_qubits=meas_qubits)
+        exp = StateTomography(circ, measurement_indices=meas_qubits)
         expdata = exp.run(backend)
         self.assertExperimentDone(expdata)
         results = expdata.analysis_results()
@@ -222,7 +222,9 @@ class TestStateTomography(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = StateTomography(QuantumCircuit(3), measurement_qubits=[0, 2], qubits=[5, 7, 1])
+        exp = StateTomography(
+            QuantumCircuit(3), measurement_indices=[0, 2], physical_qubits=[5, 7, 1]
+        )
         loaded_exp = StateTomography.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Renames `qubits` kwarg of tomography experiments to `physical_qubits` to be more explicit.
* Renames `measurement_qubits` and `preparation_qubits` kwargs of tomography experiments to `measurement_indices` and `preparation_indices` respectively. This is to avoid confusion since these args refer to the circuit qubit index in physical physical_qubits to be measurement or prepared.
* Adds `backend` and `analysis` kwargs to StateTomography and ProcessTomography

### Details and comments


