### PR TITLE
Work around QiskitTestCase issue with Python 3.11.1

### DIFF
--- a/test/base.py
+++ b/test/base.py
@@ -19,6 +19,16 @@ import pickle
 import warnings
 from typing import Any, Callable, Optional
 
+# Temporary work around for https://github.com/Qiskit/qiskit-terra/issues/9291
+# The class decorator / method wrapper in qiskit does not handle
+# __init_subclass__ properly. Python 3.11.1 added an __init_subclass__ to
+# TestCase. It's not that important so as a temporary hack we just drop it.
+from unittest import TestCase
+
+if "__init_subclass__" in TestCase.__dict__:
+    del TestCase.__init_subclass__
+# pylint: disable=wrong-import-position
+
 import numpy as np
 import uncertainties
 from lmfit import Model

--- a/test/base.py
+++ b/test/base.py
@@ -24,7 +24,10 @@ from typing import Any, Callable, Optional
 # __init_subclass__ properly. Python 3.11.1 added an __init_subclass__ to
 # TestCase. It's not that important so as a temporary hack we just drop it.
 from unittest import TestCase
-
+if not hasattr(TestCase, "_test_cleanups"):
+    TestCase._test_cleanups = []
+if not hasattr(TestCase, "_classSetupFailed"):
+    TestCase._classSetupFailed = False
 if "__init_subclass__" in TestCase.__dict__:
     del TestCase.__init_subclass__
 # pylint: disable=wrong-import-position

--- a/test/base.py
+++ b/test/base.py
@@ -24,12 +24,13 @@ from typing import Any, Callable, Optional
 # __init_subclass__ properly. Python 3.11.1 added an __init_subclass__ to
 # TestCase. It's not that important so as a temporary hack we just drop it.
 from unittest import TestCase
+
+if "__init_subclass__" in TestCase.__dict__:
+    del TestCase.__init_subclass__
 if not hasattr(TestCase, "_test_cleanups"):
     TestCase._test_cleanups = []
 if not hasattr(TestCase, "_classSetupFailed"):
     TestCase._classSetupFailed = False
-if "__init_subclass__" in TestCase.__dict__:
-    del TestCase.__init_subclass__
 # pylint: disable=wrong-import-position
 
 import numpy as np


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Python 3.11.1 added an `__init_subclass__` method to `unittest.TestCase` which exposed a problem with code that QiskitTestCase uses to ensure subclasses call parent methods. As a temporary work around, this commit removes  `unittest.TestCase.__init_subclass__` as it is not important for the tests to run.

### Details and comments

See https://github.com/Qiskit/qiskit-terra/issues/9291

