### PR TITLE
[WiP] Allow passthrough of custom interleaved gate in InterleavedRB

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
@@ -183,7 +183,7 @@ class InterleavedRB(StandardRB):
                 new_seq.append(elem)
                 new_seq.append(self._interleaved_cliff)
             interleaved_sequences.append(new_seq)
-        interleaved_circuits = self._sequences_to_circuits(interleaved_sequences)
+        interleaved_circuits = self._sequences_to_circuits(interleaved_sequences, True)
         for circ, seq in zip(interleaved_circuits, reference_sequences):
             circ.metadata = {
                 "xval": len(seq),  # set length of the reference sequence
@@ -194,12 +194,14 @@ class InterleavedRB(StandardRB):
         return reference_circuits + interleaved_circuits
 
     def _to_instruction(
-        self, elem: SequenceElementType, basis_gates: Optional[Tuple[str]] = None
+        self,
+        elem: SequenceElementType,
+        basis_gates: Optional[Tuple[str]] = None,
+        preserve: bool = False,
     ) -> Instruction:
         if elem is self._interleaved_cliff:
-            return self._interleaved_op
-
-        return super()._to_instruction(elem, basis_gates)
+            elem = self._interleaved_element
+        return super()._to_instruction(elem, basis_gates, preserve)
 
     def __set_up_interleaved_op(self) -> None:
         # Convert interleaved element to transpiled circuit operation and store it for speed


### PR DESCRIPTION
### Summary

This is a quick attempt to solve #649. 

### Details and comments

This WiP PR is a bit hacky at present because the parent class method `StandardRB._sequence_to_circuit` is modified to suit the need of the child, `InterleavedRB`: no doubt this could be cleaned up a bit. It nonetheless shows how `_to_instruction` can be changed to allow passthrough of the original object to interleave. The `elem is self._interleaved_cliff` should also raise eyebrows as those are ints for `num_qubits <= 2`.

Here is a screenshot of the MWE output in #649:
 
![image](https://user-images.githubusercontent.com/2229105/211100511-d01d9a7f-d122-4eb6-96e9-80ee154636ea.png)

