### PR TITLE
Memory slot fix in resonator spectroscopy.

### DIFF
--- a/qiskit_experiments/library/characterization/resonator_spectroscopy.py
+++ b/qiskit_experiments/library/characterization/resonator_spectroscopy.py
@@ -113,7 +113,7 @@ class ResonatorSpectroscopy(Spectroscopy):
             initial_circuit (QuantumCircuit): A single-qubit initial circuit to run before the
                 measurement/spectroscopy pulse. The circuit must contain only a single qubit and zero
                 classical bits. If None, no circuit is appended before the measurement. Defaults to None.
-            memory_slot: The memory slot that the acquire instruction uses in the pulse schedule.
+            memory_slot (int): The memory slot that the acquire instruction uses in the pulse schedule.
                 The default value is ``0``. This argument allows the experiment to function in a
                 :class:`.ParallelExperiment`.
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR adds an optional `memory_slot` argument to the `ResonatorSpectroscopy` experiment.

### Details and comments

In the current experiment the memory slot is always set to 0 preventing users from parallelizing this experiment.
This PR adds a memory slot experiment option which defaults to 0.
This enables users to use the experiment in a ParallelExperiment with the code below:
```python
from qiskit_experiments.library import ResonatorSpectroscopy
from qiskit_experiments.framework import ParallelExperiment

specs = []

for slot, qubit in enumerate([0, 1, 3, 4]):
    specs.append(ResonatorSpectroscopy(qubit=qubit, backend=backend, memory_slot=slot))

exp = ParallelExperiment(specs, backend=backend)
```
without this extra argument the parallel experiment will return data such as
```
'memory': [[959284.3125, -976790.875], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
```
Below is some output with this PR.
![image](https://user-images.githubusercontent.com/38065505/212758818-c88f0bf3-06a2-4cf7-9e7d-404dc3b58a1c.png)

