### PR TITLE
Fix circuit generation of 3Q+ InterleavedRB

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
@@ -145,6 +145,7 @@ class InterleavedRB(StandardRB):
             self._interleaved_cliff = num_from_1q_circuit(interleaved_clifford.to_circuit())
         elif self.num_qubits == 2:
             self._interleaved_cliff = num_from_2q_circuit(interleaved_clifford.to_circuit())
+        # Convert interleaved element to circuit for speed in 3Q or more case
         else:
             self._interleaved_cliff = interleaved_clifford.to_circuit()
         self._interleaved_element = interleaved_element  # Original interleaved element

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
@@ -146,7 +146,7 @@ class InterleavedRB(StandardRB):
         elif self.num_qubits == 2:
             self._interleaved_cliff = num_from_2q_circuit(interleaved_clifford.to_circuit())
         else:
-            self._interleaved_cliff = interleaved_clifford
+            self._interleaved_cliff = interleaved_clifford.to_circuit()
         self._interleaved_element = interleaved_element  # Original interleaved element
         self._interleaved_op = None  # Transpiled interleaved element for speed
         self.analysis = InterleavedRBAnalysis()

--- a/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_experiment.py
@@ -290,7 +290,6 @@ class StandardRB(BaseExperiment, RestlessMixin):
         if self.num_qubits == 2:
             return rng.integers(CliffordUtils.NUM_CLIFFORD_2_QUBIT, size=length)
         # Return circuit object instead of Clifford object for 3 or more qubits case for speed
-        # TODO: Revisit after terra#7269, #7483, #8585
         return [random_clifford(self.num_qubits, rng).to_circuit() for _ in range(length)]
 
     def _to_instruction(
@@ -318,7 +317,6 @@ class StandardRB(BaseExperiment, RestlessMixin):
                 compose_1q if self.num_qubits == 1 else compose_2q, elements, base_elem
             )
         # 3 or more qubits: compose Clifford from circuits for speed
-        # TODO: Revisit after terra#7269, #7483, #8585
         circ = QuantumCircuit(self.num_qubits)
         for elem in elements:
             circ.compose(elem, inplace=True)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #1013 


### Details and comments
In 3Q+ RB circuit generation, QuantumCircuit objects are internally used for Clifford elements to be composed to compute the last inversion. The recent large refactoring #982 embeds a bug in the handling of interleaved element. It wrongly stores a Clifford object as an interleaved Clifford element. This PR fixes the bug so that it stores a QuantumCircuit object consistently.

