### PR TITLE
Add backend kwarg to readout error experiments

### DIFF
--- a/qiskit_experiments/library/characterization/correlated_readout_error.py
+++ b/qiskit_experiments/library/characterization/correlated_readout_error.py
@@ -12,8 +12,11 @@
 """
 Correlated readout error calibration experiment class.
 """
-from typing import Iterable, List
+import warnings
+from typing import Iterable, List, Optional
 from qiskit import QuantumCircuit
+from qiskit.providers.backend import BackendV2, Backend
+from qiskit.exceptions import QiskitError
 from qiskit_experiments.framework import BaseExperiment
 from qiskit_experiments.library.characterization.analysis.correlated_readout_error_analysis import (
     CorrelatedReadoutErrorAnalysis,
@@ -74,13 +77,46 @@ class CorrelatedReadoutError(BaseExperiment):
         .. ref_arxiv:: 1 2006.14044
     """
 
-    def __init__(self, qubits: Iterable[int]):
+    def __init__(
+        self,
+        physical_qubits: Optional[Iterable[int]] = None,
+        backend: Optional[Backend] = None,
+        qubits: Optional[Iterable[int]] = None,
+    ):
         """Initialize a correlated readout error characterization experiment.
 
         Args:
-            qubits: The qubits being characterized for readout error
+            physical_qubits: Optional, the backend qubits being characterized
+                for readout error. If None all qubits on the provided backend
+                will be characterized.
+            backend: Optional, the backend to characterize.
+            qubits: DEPRECATED, equivalent to ``physical_qubits``.
+
+        Raises:
+            QiskitError: if args are not valid.
         """
-        super().__init__(qubits)
+        # Deprecated qubits kwarg
+        if qubits is not None:
+            physical_qubits = qubits
+            warnings.warn(
+                "The `qubits` kwarg has been renamed to `physical_qubits`."
+                " It will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if physical_qubits is None:
+            if backend is None:
+                raise QiskitError("`physical_qubits` and `backend` kwargs cannot both be None.")
+            num_qubits = 0
+            if isinstance(backend, BackendV2):
+                num_qubits = backend.target.num_qubits
+            elif isinstance(backend, Backend):
+                num_qubits = backend.configuration().num_qubits
+            if num_qubits:
+                physical_qubits = range(num_qubits)
+            else:
+                raise QiskitError(f"Cannot infer backend qubits from backend {backend}")
+        super().__init__(physical_qubits, backend=backend)
         self.analysis = CorrelatedReadoutErrorAnalysis()
 
     def circuits(self) -> List[QuantumCircuit]:

--- a/qiskit_experiments/library/characterization/local_readout_error.py
+++ b/qiskit_experiments/library/characterization/local_readout_error.py
@@ -12,8 +12,11 @@
 """
 Local readout error calibration experiment class.
 """
-from typing import Iterable, List
+import warnings
+from typing import Iterable, List, Optional
 from qiskit import QuantumCircuit
+from qiskit.providers.backend import BackendV2, Backend
+from qiskit.exceptions import QiskitError
 from qiskit_experiments.framework import BaseExperiment
 from qiskit_experiments.library.characterization.analysis.local_readout_error_analysis import (
     LocalReadoutErrorAnalysis,
@@ -63,13 +66,46 @@ class LocalReadoutError(BaseExperiment):
         .. ref_arxiv:: 1 2006.14044
     """
 
-    def __init__(self, qubits: Iterable[int]):
+    def __init__(
+        self,
+        physical_qubits: Optional[Iterable[int]] = None,
+        backend: Optional[Backend] = None,
+        qubits: Optional[Iterable[int]] = None,
+    ):
         """Initialize a local readout error characterization experiment.
 
         Args:
-            qubits: The qubits being characterized for readout error
+            physical_qubits: Optional, the backend qubits being characterized
+                for readout error. If None all qubits on the provided backend
+                will be characterized.
+            backend: Optional, the backend to characterize.
+            qubits: DEPRECATED, equivalent to ``physical_qubits``.
+
+        Raises:
+            QiskitError: if args are not valid.
         """
-        super().__init__(qubits)
+        # Deprecated qubits kwarg
+        if qubits is not None:
+            physical_qubits = qubits
+            warnings.warn(
+                "The `qubits` kwarg has been renamed to `physical_qubits`."
+                " It will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if physical_qubits is None:
+            if backend is None:
+                raise QiskitError("`physical_qubits` and `backend` kwargs cannot both be None.")
+            num_qubits = 0
+            if isinstance(backend, BackendV2):
+                num_qubits = backend.target.num_qubits
+            elif isinstance(backend, Backend):
+                num_qubits = backend.configuration().num_qubits
+            if num_qubits:
+                physical_qubits = range(num_qubits)
+            else:
+                raise QiskitError(f"Cannot infer backend qubits from backend {backend}")
+        super().__init__(physical_qubits, backend=backend)
         self.analysis = LocalReadoutErrorAnalysis()
 
     def circuits(self) -> List[QuantumCircuit]:

--- a/releasenotes/notes/readout-error-c95b99ae5a6ba7ac.yaml
+++ b/releasenotes/notes/readout-error-c95b99ae5a6ba7ac.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Adds a ``backend`` init kwarg to the :class:`.LocalReadoutError` and
+    :class:`.CorrelatedReadoutError` experiments, and makes the
+    ``physical_qubits`` kwarg optional. If a backend is supplied without
+    specifying phyiscal qubits, the experiment will be initialized on all
+    qubits for the backend.
+deprecations:
+  - |
+    The ``qubits`` kwarg of the following experiments has been deprecated and
+    renamed to ``physical_qubits`` :class:`.LocalReadoutError`,
+    :class:`.CorrelatedReadoutError`.

--- a/releasenotes/notes/readout-error-c95b99ae5a6ba7ac.yaml
+++ b/releasenotes/notes/readout-error-c95b99ae5a6ba7ac.yaml
@@ -9,5 +9,5 @@ features:
 deprecations:
   - |
     The ``qubits`` kwarg of the following experiments has been deprecated and
-    renamed to ``physical_qubits`` :class:`.LocalReadoutError`,
+    renamed to ``physical_qubits``: :class:`.LocalReadoutError`,
     :class:`.CorrelatedReadoutError`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Adds `backend` kwarg to LocalReadoutError and CorrelatedReadoutError experiment inits. If this is set without specifying physical qubits all qubits on the backend will be used for the experiment.
* Renames the `qubits` init kwarg of LocalReadoutError and CorrelatedReadoutError to `physical_qubits.

### Details and comments


