### PR TITLE
Adds target kwarg to tomography init

### DIFF
--- a/qiskit_experiments/library/tomography/qpt_experiment.py
+++ b/qiskit_experiments/library/tomography/qpt_experiment.py
@@ -64,6 +64,7 @@ class ProcessTomography(TomographyExperiment):
         basis_indices: Optional[Iterable[Tuple[List[int], List[int]]]] = None,
         qubits: Optional[Sequence[int]] = None,
         analysis: Union[BaseAnalysis, None, str] = "default",
+        target: Union[Statevector, DensityMatrix, None, str] = "default",
     ):
         """Initialize a quantum process tomography experiment.
 
@@ -94,6 +95,10 @@ class ProcessTomography(TomographyExperiment):
             analysis: Optional, a custom analysis instance to use. If ``"default"``
                 :class:`~.ProcessTomographyAnalysis` will be used. If None no analysis
                 instance will be set.
+            target: Optional, a custom quantum state target for computing the
+                state fidelity of the fitted density matrix during analysis.
+                If "default" the state will be inferred from the input circuit
+                if it contains no classical instructions.
         """
         if analysis == "default":
             analysis = ProcessTomographyAnalysis()
@@ -115,7 +120,9 @@ class ProcessTomography(TomographyExperiment):
 
         # Set target quantum channel
         if isinstance(self.analysis, TomographyAnalysis):
-            self.analysis.set_options(target=self._target_quantum_channel())
+            if target == "default":
+                target = self._target_quantum_channel()
+            self.analysis.set_options(target=target)
 
     def _target_quantum_channel(self) -> Union[Choi, Operator]:
         """Return the process tomography target"""

--- a/qiskit_experiments/library/tomography/qst_experiment.py
+++ b/qiskit_experiments/library/tomography/qst_experiment.py
@@ -59,6 +59,7 @@ class StateTomography(TomographyExperiment):
         basis_indices: Optional[Iterable[List[int]]] = None,
         qubits: Optional[Sequence[int]] = None,
         analysis: Union[BaseAnalysis, None, str] = "default",
+        target: Union[Statevector, DensityMatrix, None, str] = "default",
     ):
         """Initialize a quantum process tomography experiment.
 
@@ -82,6 +83,10 @@ class StateTomography(TomographyExperiment):
             analysis: Optional, a custom analysis instance to use. If ``"default"``
                 :class:`~.StateTomographyAnalysis` will be used. If None no analysis
                 instance will be set.
+            target: Optional, a custom quantum state target for computing the
+                state fidelity of the fitted density matrix during analysis.
+                If "default" the state will be inferred from the input circuit
+                if it contains no classical instructions.
         """
         if isinstance(circuit, Statevector):
             # Convert to circuit using initialize instruction
@@ -110,7 +115,9 @@ class StateTomography(TomographyExperiment):
 
         # Set target quantum state
         if isinstance(self.analysis, TomographyAnalysis):
-            self.analysis.set_options(target=self._target_quantum_state())
+            if target == "default":
+                target = self._target_quantum_state()
+            self.analysis.set_options(target=target)
 
     def _target_quantum_state(self) -> Union[Statevector, DensityMatrix]:
         """Return the state tomography target"""

--- a/releasenotes/notes/tomography-b091ce13d6983bc1.yaml
+++ b/releasenotes/notes/tomography-b091ce13d6983bc1.yaml
@@ -3,7 +3,7 @@ features:
   - |
     Adds ``backend``, ``analysis``, and ``target`` init kwargs to the
     :class:`~.StateTomography` and :class:`~.ProcessTomography` experiments.
-    These allow specifying intented backend, a custom analysis class, or a
+    These allow specifying intended backend, a custom analysis class, or a
     custom target for fidelity calculations, when initializing the experiments.
 upgrade:
   - |

--- a/releasenotes/notes/tomography-b091ce13d6983bc1.yaml
+++ b/releasenotes/notes/tomography-b091ce13d6983bc1.yaml
@@ -1,11 +1,10 @@
 ---
 features:
   - |
-    Adds ``backend`` and ``analysis`` init kwargs to :class:`~.StateTomography`
-    and :class:`~.ProcessTomography` experiments to match the base
-    :class:`~.TomographyExperiment` init kwargs. This allows specifying the
-    intented backend, or a custom analysis class when initializing the
-    experiments.
+    Adds ``backend``, ``analysis``, and ``target`` init kwargs to the
+    :class:`~.StateTomography` and :class:`~.ProcessTomography` experiments.
+    These allow specifying intented backend, a custom analysis class, or a
+    custom target for fidelity calculations, when initializing the experiments.
 upgrade:
   - |
     Renames the ``qubits``, ``measurement_qubits``, and ``preparation_qubits``

--- a/test/library/tomography/test_process_tomography.py
+++ b/test/library/tomography/test_process_tomography.py
@@ -348,7 +348,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         state = expdata.analysis_results("state").value
         self.assertTrue(
             isinstance(state, qi.Choi),
-            msg=f"Fitted state is not Choi matrix",
+            msg="Fitted state is not Choi matrix",
         )
         with self.assertRaises(
             ExperimentEntryNotFound, msg="process_fidelity should not exist when target=None"

--- a/test/library/tomography/test_state_tomography.py
+++ b/test/library/tomography/test_state_tomography.py
@@ -23,6 +23,7 @@ from qiskit_aer import AerSimulator
 
 from qiskit_experiments.library import StateTomography
 from qiskit_experiments.library.tomography import StateTomographyAnalysis
+from qiskit_experiments.database_service import ExperimentEntryNotFound
 from .tomo_utils import FITTERS, filter_results, teleport_circuit, teleport_bell_circuit
 
 
@@ -243,8 +244,26 @@ class TestStateTomography(QiskitExperimentsTestCase):
         self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_analysis_config(self):
-        """ "Test converting analysis to and from config works"""
+        """Test converting analysis to and from config works"""
         analysis = StateTomographyAnalysis()
         loaded = StateTomographyAnalysis.from_config(analysis.config())
         self.assertNotEqual(analysis, loaded)
         self.assertEqual(analysis.config(), loaded.config())
+
+    def test_target_none(self):
+        """Test setting target=None disables fidelity calculation."""
+        seed = 4343
+        backend = AerSimulator(seed_simulator=seed)
+        target = qi.random_statevector(2, seed=seed)
+        exp = StateTomography(target, backend=backend, target=None)
+        expdata = exp.run()
+        self.assertExperimentDone(expdata)
+        state = expdata.analysis_results("state").value
+        self.assertTrue(
+            isinstance(state, qi.DensityMatrix),
+            msg=f"Fitted state is not density matrix",
+        )
+        with self.assertRaises(
+            ExperimentEntryNotFound, msg="state_fidelity should not exist when target=None"
+        ):
+            expdata.analysis_results("state_fidelity")

--- a/test/library/tomography/test_state_tomography.py
+++ b/test/library/tomography/test_state_tomography.py
@@ -261,7 +261,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
         state = expdata.analysis_results("state").value
         self.assertTrue(
             isinstance(state, qi.DensityMatrix),
-            msg=f"Fitted state is not density matrix",
+            msg="Fitted state is not density matrix",
         )
         with self.assertRaises(
             ExperimentEntryNotFound, msg="state_fidelity should not exist when target=None"


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #994 

Updates State and process tomography experiments to directly set the target option for TomographyAnalysis rather than pass it through experiment data metadata.

### Details and comments


