### PR TITLE
Requirements and test updates to fix CI

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -297,7 +297,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=matplotlib.cm,numpy.random,retworkx
+ignored-modules=matplotlib.cm,numpy.random,rustworkx
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of

--- a/qiskit_experiments/calibration_management/calibration_utils.py
+++ b/qiskit_experiments/calibration_management/calibration_utils.py
@@ -15,7 +15,7 @@
 from typing import Optional, Set, Tuple
 from functools import lru_cache
 import re
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.circuit import ParameterExpression, Parameter
 from qiskit.pulse import ScheduleBlock

--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -20,7 +20,7 @@ import csv
 import dataclasses
 import json
 import warnings
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.pulse import (
     ScheduleBlock,

--- a/qiskit_experiments/framework/json.py
+++ b/qiskit_experiments/framework/json.py
@@ -31,8 +31,8 @@ import lmfit
 import numpy as np
 import scipy.sparse as sps
 import uncertainties
-from qiskit.circuit import ParameterExpression, QuantumCircuit, Instruction
 from qiskit import qpy
+from qiskit.circuit import ParameterExpression, QuantumCircuit, Instruction
 from qiskit.circuit.library import BlueprintCircuit
 from qiskit.quantum_info import DensityMatrix
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
@@ -584,9 +584,7 @@ class ExperimentDecoder(json.JSONDecoder):
                 load_obj = tmp.loads(s=obj_val)
                 return load_obj
             if obj_type == "Instruction":
-                circuit = _decode_and_deserialize(
-                    obj_val, qpy.load, name="QuantumCircuit"
-                )[0]
+                circuit = _decode_and_deserialize(obj_val, qpy.load, name="QuantumCircuit")[0]
                 return circuit.data[0][0]
             if obj_type == "QuantumCircuit":
                 return _decode_and_deserialize(obj_val, qpy.load, name=obj_type)[0]

--- a/qiskit_experiments/framework/json.py
+++ b/qiskit_experiments/framework/json.py
@@ -31,7 +31,8 @@ import lmfit
 import numpy as np
 import scipy.sparse as sps
 import uncertainties
-from qiskit.circuit import ParameterExpression, QuantumCircuit, qpy_serialization, Instruction
+from qiskit.circuit import ParameterExpression, QuantumCircuit, Instruction
+from qiskit import qpy
 from qiskit.circuit.library import BlueprintCircuit
 from qiskit.quantum_info import DensityMatrix
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
@@ -497,7 +498,7 @@ class ExperimentEncoder(json.JSONEncoder):
             circuit = QuantumCircuit(obj.num_qubits, obj.num_clbits)
             circuit.append(obj, range(obj.num_qubits), range(obj.num_clbits))
             value = _serialize_and_encode(
-                data=circuit, serializer=lambda buff, data: qpy_serialization.dump(data, buff)
+                data=circuit, serializer=lambda buff, data: qpy.dump(data, buff)
             )
             return {"__type__": "Instruction", "__value__": value}
         if isinstance(obj, QuantumCircuit):
@@ -505,13 +506,13 @@ class ExperimentEncoder(json.JSONEncoder):
             if isinstance(obj, BlueprintCircuit):
                 obj = obj.decompose()
             value = _serialize_and_encode(
-                data=obj, serializer=lambda buff, data: qpy_serialization.dump(data, buff)
+                data=obj, serializer=lambda buff, data: qpy.dump(data, buff)
             )
             return {"__type__": "QuantumCircuit", "__value__": value}
         if isinstance(obj, ParameterExpression):
             value = _serialize_and_encode(
                 data=obj,
-                serializer=qpy_serialization._write_parameter_expression,
+                serializer=qpy._write_parameter_expression,
                 compress=False,
             )
             return {"__type__": "ParameterExpression", "__value__": value}
@@ -584,14 +585,14 @@ class ExperimentDecoder(json.JSONDecoder):
                 return load_obj
             if obj_type == "Instruction":
                 circuit = _decode_and_deserialize(
-                    obj_val, qpy_serialization.load, name="QuantumCircuit"
+                    obj_val, qpy.load, name="QuantumCircuit"
                 )[0]
                 return circuit.data[0][0]
             if obj_type == "QuantumCircuit":
-                return _decode_and_deserialize(obj_val, qpy_serialization.load, name=obj_type)[0]
+                return _decode_and_deserialize(obj_val, qpy.load, name=obj_type)[0]
             if obj_type == "ParameterExpression":
                 return _decode_and_deserialize(
-                    obj_val, qpy_serialization._read_parameter_expression, name=obj_type
+                    obj_val, qpy._read_parameter_expression, name=obj_type
                 )
             if obj_type == "safe_float":
                 return self._NaNs.get(obj_val, obj_val)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ qiskit_dynamics>=0.3.0
 matplotlib>=3.4
 uncertainties
 lmfit
+rustworkx

--- a/test/calibration/test_calibration_utils.py
+++ b/test/calibration/test_calibration_utils.py
@@ -13,7 +13,7 @@
 """Class to test utility functions for calibrations."""
 
 from test.base import QiskitExperimentsTestCase
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.circuit import Parameter
 import qiskit.pulse as pulse

--- a/test/calibration/test_calibrations.py
+++ b/test/calibration/test_calibrations.py
@@ -775,22 +775,6 @@ class TestRegistering(QiskitExperimentsTestCase):
 
         self.cals.get_template("xp", (3,))
 
-    def test_register_schedule(self):
-        """Test that we cannot register a schedule in a call."""
-
-        xp = pulse.Schedule(name="xp")
-        xp.insert(0, pulse.Play(pulse.Gaussian(160, 0.5, 40), pulse.DriveChannel(0)), inplace=True)
-
-        with pulse.build(name="call_xp") as call_xp:
-            pulse.call(xp)
-
-        try:
-            self.cals.add_schedule(call_xp, num_qubits=1)
-        except CalibrationError as error:
-            self.assertEqual(
-                error.message, "Calling a Schedule is forbidden, call ScheduleBlock instead."
-            )
-
 
 class CrossResonanceTest(QiskitExperimentsTestCase):
     """Setup class for an echoed cross-resonance calibration."""

--- a/test/library/calibration/test_fine_drag.py
+++ b/test/library/calibration/test_fine_drag.py
@@ -105,6 +105,8 @@ class TestFineDragCal(QiskitExperimentsTestCase):
 
         transpile_opts = copy.copy(drag_cal.transpile_options.__dict__)
         transpile_opts["initial_layout"] = list(drag_cal.physical_qubits)
+        transpile_opts["optimization_level"] = 0
+
         circs = transpile(
             drag_cal.circuits(), inst_map=self.cals.default_inst_map, **transpile_opts
         )

--- a/test/library/calibration/test_fine_drag.py
+++ b/test/library/calibration/test_fine_drag.py
@@ -130,6 +130,8 @@ class TestFineDragCal(QiskitExperimentsTestCase):
 
         transpile_opts = copy.copy(drag_cal.transpile_options.__dict__)
         transpile_opts["initial_layout"] = list(drag_cal.physical_qubits)
+        transpile_opts["optimization_level"] = 0
+
         circs = transpile(
             drag_cal.circuits(), inst_map=self.cals.default_inst_map, **transpile_opts
         )


### PR DESCRIPTION
To fix CI, retworkx is the old name for rustworkx and has been updated. Also added it as a requirement, ~~but if it's only used for calibrations, it can be an optional requirement instead~~.

Some tests have also been updated: `test_register_schedule` has been removed since terra's pulse builder update makes it obsolete. `test_update_cals` now has `optimization_level` explicitly set to 0 so `sx` doesn't get decomposed during transpilation.