### PR TITLE
Update characterization and calibration experiments to use `physical_qubits`

### DIFF
--- a/qiskit_experiments/calibration_management/base_calibration_experiment.py
+++ b/qiskit_experiments/calibration_management/base_calibration_experiment.py
@@ -14,7 +14,7 @@
 
 from abc import ABC, abstractmethod
 import logging
-from typing import List, Optional, Type, Union
+from typing import List, Optional, Sequence, Type, Union
 import warnings
 
 from qiskit import QuantumCircuit
@@ -192,7 +192,7 @@ class BaseCalibrationExperiment(BaseExperiment, ABC):
                 schedule=self._sched_name,
             )
 
-    def _validate_channels(self, schedule: ScheduleBlock, physical_qubits: List[int]):
+    def _validate_channels(self, schedule: ScheduleBlock, physical_qubits: Sequence[int]):
         """Check that the physical qubits are contained in the schedule.
 
         This is a helper method that experiment developers can call in their implementation

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -28,14 +28,16 @@ from qiskit_experiments.framework.store_init_args import StoreInitArgs
 from qiskit_experiments.framework.base_analysis import BaseAnalysis
 from qiskit_experiments.framework.experiment_data import ExperimentData
 from qiskit_experiments.framework.configs import ExperimentConfig
+from qiskit_experiments.warnings import deprecate_arguments
 
 
 class BaseExperiment(ABC, StoreInitArgs):
     """Abstract base class for experiments."""
 
+    @deprecate_arguments({"qubits": "physical_qubits"}, "0.5")
     def __init__(
         self,
-        qubits: Sequence[int],
+        physical_qubits: Sequence[int],
         analysis: Optional[BaseAnalysis] = None,
         backend: Optional[Backend] = None,
         experiment_type: Optional[str] = None,
@@ -43,7 +45,7 @@ class BaseExperiment(ABC, StoreInitArgs):
         """Initialize the experiment object.
 
         Args:
-            qubits: list of physical qubits for the experiment.
+            physical_qubits: list of physical qubits for the experiment.
             analysis: Optional, the analysis to use for the experiment.
             backend: Optional, the backend to run the experiment on.
             experiment_type: Optional, the experiment type string.
@@ -55,8 +57,8 @@ class BaseExperiment(ABC, StoreInitArgs):
         self._type = experiment_type if experiment_type else type(self).__name__
 
         # Circuit parameters
-        self._num_qubits = len(qubits)
-        self._physical_qubits = tuple(qubits)
+        self._num_qubits = len(physical_qubits)
+        self._physical_qubits = tuple(physical_qubits)
         if self._num_qubits != len(set(self._physical_qubits)):
             raise QiskitError("Duplicate qubits in physical qubits list.")
 

--- a/qiskit_experiments/library/calibration/fine_amplitude.py
+++ b/qiskit_experiments/library/calibration/fine_amplitude.py
@@ -25,6 +25,7 @@ from qiskit_experiments.calibration_management import (
 from qiskit_experiments.library.characterization import FineAmplitude
 from qiskit_experiments.framework import ExperimentData, Options
 from qiskit_experiments.calibration_management.update_library import BaseUpdater
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class FineAmplitudeCal(BaseCalibrationExperiment, FineAmplitude):
@@ -41,9 +42,10 @@ class FineAmplitudeCal(BaseCalibrationExperiment, FineAmplitude):
 
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: Union[int, Tuple[int, int]],
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         schedule_name: str,
         backend: Optional[Backend] = None,
@@ -55,8 +57,9 @@ class FineAmplitudeCal(BaseCalibrationExperiment, FineAmplitude):
         """see class :class:`FineAmplitude` for details.
 
         Args:
-            qubit: The qubit for which to run the fine amplitude calibration. This can
-                also be a pair of qubits which correspond to control and target qubit.
+            physical_qubits: Sequence containing the qubit(s) for which to run
+                the fine amplitude calibration. This can be a pair of qubits
+                which correspond to control and target qubit.
             calibrations: The calibrations instance with the schedules.
             schedule_name: The name of the schedule to calibrate.
             backend: Optional, the backend to run the experiment on.
@@ -68,12 +71,11 @@ class FineAmplitudeCal(BaseCalibrationExperiment, FineAmplitude):
             measurement_qubits: The qubits in the given physical qubits that need to
                 be measured.
         """
-        qubits = qubit if isinstance(qubit, tuple) else (qubit,)
-        gate = gate or Gate(name=schedule_name, num_qubits=len(qubits), params=[])
+        gate = gate or Gate(name=schedule_name, num_qubits=len(physical_qubits), params=[])
 
         super().__init__(
             calibrations,
-            qubits,
+            physical_qubits,
             gate,
             schedule_name=schedule_name,
             backend=backend,
@@ -165,9 +167,10 @@ class FineXAmplitudeCal(FineAmplitudeCal):
         qiskit_experiments.library.characterization.fine_amplitude.FineAmplitude
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         schedule_name: str,
         backend: Optional[Backend] = None,
@@ -175,7 +178,7 @@ class FineXAmplitudeCal(FineAmplitudeCal):
         auto_update: bool = True,
     ):
         super().__init__(
-            qubit,
+            physical_qubits,
             calibrations,
             schedule_name,
             backend=backend,
@@ -217,9 +220,10 @@ class FineSXAmplitudeCal(FineAmplitudeCal):
         qiskit_experiments.library.characterization.fine_amplitude.FineAmplitude
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         schedule_name: str,
         backend: Optional[Backend] = None,
@@ -227,7 +231,7 @@ class FineSXAmplitudeCal(FineAmplitudeCal):
         auto_update: bool = True,
     ):
         super().__init__(
-            qubit,
+            physical_qubits,
             calibrations,
             schedule_name,
             backend=backend,

--- a/qiskit_experiments/library/calibration/fine_amplitude.py
+++ b/qiskit_experiments/library/calibration/fine_amplitude.py
@@ -12,7 +12,7 @@
 
 """Fine amplitude calibration experiment."""
 
-from typing import Dict, Optional, Sequence, Tuple, Union
+from typing import Dict, Optional, Sequence
 import numpy as np
 
 from qiskit.circuit import Gate, QuantumCircuit

--- a/qiskit_experiments/library/calibration/fine_drag_cal.py
+++ b/qiskit_experiments/library/calibration/fine_drag_cal.py
@@ -64,7 +64,7 @@ class FineDragCal(BaseCalibrationExperiment, FineDrag):
         """
         super().__init__(
             calibrations,
-            physical_qubits
+            physical_qubits,
             Gate(name=schedule_name, num_qubits=1, params=[]),
             schedule_name=schedule_name,
             backend=backend,

--- a/qiskit_experiments/library/calibration/fine_drag_cal.py
+++ b/qiskit_experiments/library/calibration/fine_drag_cal.py
@@ -12,7 +12,7 @@
 
 """Fine drag calibration experiment."""
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence
 import numpy as np
 
 from qiskit.circuit import Gate, QuantumCircuit
@@ -27,6 +27,7 @@ from qiskit_experiments.calibration_management import (
 )
 from qiskit_experiments.calibration_management.update_library import BaseUpdater
 from qiskit_experiments.library.characterization.fine_drag import FineDrag
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class FineDragCal(BaseCalibrationExperiment, FineDrag):
@@ -36,9 +37,10 @@ class FineDragCal(BaseCalibrationExperiment, FineDrag):
         qiskit_experiments.library.characterization.fine_drag.FineDrag
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         schedule_name: str,
         backend: Optional[Backend] = None,
@@ -51,7 +53,8 @@ class FineDragCal(BaseCalibrationExperiment, FineDrag):
         is :math:`\pi` as seen from the default experiment options.
 
         Args:
-            qubit: The qubit for which to run the fine drag calibration.
+            physical_qubits: Sequence containing the qubit for which to run the
+                fine drag calibration.
             calibrations: The calibrations instance with the schedules.
             schedule_name: The name of the schedule to calibrate.
             backend: Optional, the backend to run the experiment on.
@@ -61,7 +64,7 @@ class FineDragCal(BaseCalibrationExperiment, FineDrag):
         """
         super().__init__(
             calibrations,
-            qubit,
+            physical_qubits
             Gate(name=schedule_name, num_qubits=1, params=[]),
             schedule_name=schedule_name,
             backend=backend,
@@ -153,9 +156,10 @@ class FineXDragCal(FineDragCal):
         qiskit_experiments.library.characterization.fine_drag.FineDrag
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         backend: Optional[Backend] = None,
         cal_parameter_name: Optional[str] = "β",
@@ -164,7 +168,8 @@ class FineXDragCal(FineDragCal):
         r"""see class :class:`FineDrag` for details.
 
         Args:
-            qubit: The qubit for which to run the fine drag calibration.
+            physical_qubits: Sequence containing the qubit for which to run the
+                fine drag calibration.
             calibrations: The calibrations instance with the schedules.
             backend: Optional, the backend to run the experiment on.
             cal_parameter_name: The name of the parameter in the schedule to update.
@@ -188,9 +193,10 @@ class FineSXDragCal(FineDragCal):
         qiskit_experiments.library.characterization.fine_drag.FineDrag
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         backend: Optional[Backend] = None,
         cal_parameter_name: Optional[str] = "β",
@@ -199,7 +205,8 @@ class FineSXDragCal(FineDragCal):
         r"""see class :class:`FineDrag` for details.
 
         Args:
-            qubit: The qubit for which to run the fine drag calibration.
+            physical_qubits: Sequence containing the qubit for which to run the
+                fine drag calibration.
             calibrations: The calibrations instance with the schedules.
             backend: Optional, the backend to run the experiment on.
             cal_parameter_name: The name of the parameter in the schedule to update.

--- a/qiskit_experiments/library/calibration/fine_drag_cal.py
+++ b/qiskit_experiments/library/calibration/fine_drag_cal.py
@@ -177,7 +177,7 @@ class FineXDragCal(FineDragCal):
                 default this variable is set to True.
         """
         super().__init__(
-            qubit,
+            physical_qubits,
             calibrations,
             schedule_name="x",
             backend=backend,
@@ -214,7 +214,7 @@ class FineSXDragCal(FineDragCal):
                 default this variable is set to True.
         """
         super().__init__(
-            qubit,
+            physical_qubits,
             calibrations,
             schedule_name="sx",
             backend=backend,

--- a/qiskit_experiments/library/calibration/fine_frequency_cal.py
+++ b/qiskit_experiments/library/calibration/fine_frequency_cal.py
@@ -12,7 +12,7 @@
 
 """Fine frequency calibration experiment."""
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 import numpy as np
 
 from qiskit.providers.backend import Backend
@@ -25,6 +25,7 @@ from qiskit_experiments.calibration_management import (
     Calibrations,
 )
 from qiskit_experiments.library.characterization.fine_frequency import FineFrequency
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class FineFrequencyCal(BaseCalibrationExperiment, FineFrequency):
@@ -34,9 +35,10 @@ class FineFrequencyCal(BaseCalibrationExperiment, FineFrequency):
         :py:class:`FineFrequency`
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         backend: Optional[Backend] = None,
         delay_duration: Optional[int] = None,
@@ -52,7 +54,8 @@ class FineFrequencyCal(BaseCalibrationExperiment, FineFrequency):
         error attributed to a frequency offset in the qubit.
 
         Args:
-            qubit: The qubit for which to run the fine frequency calibration.
+            physical_qubits: Sequence containing the qubit for which to run the
+                fine frequency calibration.
             calibrations: The calibrations instance with the schedules.
             backend: Optional, the backend to run the experiment on.
             delay_duration: The duration of the delay at :math:`n=1`. If this value is
@@ -64,11 +67,11 @@ class FineFrequencyCal(BaseCalibrationExperiment, FineFrequency):
                 should be the name of a valid schedule in the calibrations.
         """
         if delay_duration is None:
-            delay_duration = calibrations.get_schedule(gate_name, qubit).duration
+            delay_duration = calibrations.get_schedule(gate_name, physical_qubits[0]).duration
 
         super().__init__(
             calibrations,
-            qubit,
+            physical_qubits,
             delay_duration=delay_duration,
             schedule_name=None,
             repetitions=repetitions,

--- a/qiskit_experiments/library/calibration/frequency_cal.py
+++ b/qiskit_experiments/library/calibration/frequency_cal.py
@@ -12,7 +12,7 @@
 
 """Ramsey XY frequency calibration experiment."""
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.providers.backend import Backend
@@ -24,6 +24,7 @@ from qiskit_experiments.calibration_management.update_library import BaseUpdater
 from qiskit_experiments.calibration_management.base_calibration_experiment import (
     BaseCalibrationExperiment,
 )
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class FrequencyCal(BaseCalibrationExperiment, RamseyXY):
@@ -33,9 +34,10 @@ class FrequencyCal(BaseCalibrationExperiment, RamseyXY):
         qiskit_experiments.library.characterization.ramsey_xy.RamseyXY
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         backend: Optional[Backend] = None,
         delays: Optional[List] = None,
@@ -44,7 +46,8 @@ class FrequencyCal(BaseCalibrationExperiment, RamseyXY):
     ):
         """
         Args:
-            qubit: The qubit on which to run the frequency calibration.
+            physical_qubits: Sequence containing the qubit on which to run the
+                frequency calibration.
             calibrations: The calibrations instance with the schedules.
             backend: Optional, the backend to run the experiment on.
             delays: The list of delays that will be scanned in the experiment, in seconds.
@@ -55,7 +58,7 @@ class FrequencyCal(BaseCalibrationExperiment, RamseyXY):
         """
         super().__init__(
             calibrations,
-            qubit,
+            physical_qubits,
             backend=backend,
             delays=delays,
             osc_freq=osc_freq,

--- a/qiskit_experiments/library/calibration/half_angle_cal.py
+++ b/qiskit_experiments/library/calibration/half_angle_cal.py
@@ -12,7 +12,7 @@
 
 """Half angle calibration."""
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit
@@ -25,6 +25,7 @@ from qiskit_experiments.calibration_management import (
 )
 from qiskit_experiments.library.characterization import HalfAngle
 from qiskit_experiments.calibration_management.update_library import BaseUpdater
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class HalfAngleCal(BaseCalibrationExperiment, HalfAngle):
@@ -34,9 +35,10 @@ class HalfAngleCal(BaseCalibrationExperiment, HalfAngle):
         qiskit_experiments.library.characterization.half_angle.HalfAngle
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         backend: Optional[Backend] = None,
         schedule_name: str = "sx",
@@ -46,7 +48,8 @@ class HalfAngleCal(BaseCalibrationExperiment, HalfAngle):
         """see class :class:`HalfAngle` for details.
 
         Args:
-            qubit: The qubit for which to run the half-angle calibration.
+            physical_qubits: Sequence containing the qubit for which to run the
+                half-angle calibration.
             calibrations: The calibrations instance with the schedules.
             backend: Optional, the backend to run the experiment on.
             schedule_name: The name of the schedule to calibrate which defaults to sx.
@@ -57,7 +60,7 @@ class HalfAngleCal(BaseCalibrationExperiment, HalfAngle):
         """
         super().__init__(
             calibrations,
-            qubit,
+            physical_qubits,
             backend=backend,
             schedule_name=schedule_name,
             cal_parameter_name=cal_parameter_name,

--- a/qiskit_experiments/library/calibration/rough_amplitude_cal.py
+++ b/qiskit_experiments/library/calibration/rough_amplitude_cal.py
@@ -13,7 +13,7 @@
 """Rough amplitude calibration using Rabi."""
 
 from collections import namedtuple
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, Optional, Sequence
 import numpy as np
 
 from qiskit import QuantumCircuit
@@ -24,6 +24,7 @@ from qiskit_experiments.framework import ExperimentData
 from qiskit_experiments.calibration_management import BaseCalibrationExperiment, Calibrations
 from qiskit_experiments.library.characterization import Rabi
 from qiskit_experiments.calibration_management.update_library import BaseUpdater
+from qiskit_experiments.warnings import qubit_deprecate
 
 AnglesSchedules = namedtuple(
     "AnglesSchedules", ["target_angle", "parameter", "schedule", "previous_value"]
@@ -37,9 +38,10 @@ class RoughAmplitudeCal(BaseCalibrationExperiment, Rabi):
         qiskit_experiments.library.characterization.rabi.Rabi
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         schedule_name: str = "x",
         amplitudes: Iterable[float] = None,
@@ -52,7 +54,8 @@ class RoughAmplitudeCal(BaseCalibrationExperiment, Rabi):
         r"""see class :class:`Rabi` for details.
 
         Args:
-            qubit: The qubit for which to run the rough amplitude calibration.
+            physical_qubits: Sequence containing the qubit for which to run the
+                rough amplitude calibration.
             calibrations: The calibrations instance with the schedules.
             schedule_name: The name of the schedule to calibrate. Defaults to "x".
             amplitudes: A list of amplitudes to scan. If None is given 51 amplitudes ranging
@@ -65,6 +68,7 @@ class RoughAmplitudeCal(BaseCalibrationExperiment, Rabi):
             group: The group of calibration parameters to use. The default value is "default".
             backend: Optional, the backend to run the experiment on.
         """
+        qubit = physical_qubits[0]
         schedule = calibrations.get_schedule(
             schedule_name, qubit, assign_params={cal_parameter_name: Parameter("amp")}, group=group
         )
@@ -74,7 +78,7 @@ class RoughAmplitudeCal(BaseCalibrationExperiment, Rabi):
 
         super().__init__(
             calibrations,
-            qubit,
+            physical_qubits,
             schedule=schedule,
             amplitudes=amplitudes,
             backend=backend,
@@ -196,16 +200,17 @@ class RoughXSXAmplitudeCal(RoughAmplitudeCal):
         qiskit_experiments.library.characterization.rabi.Rabi
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         amplitudes: Iterable[float] = None,
         backend: Optional[Backend] = None,
     ):
         """A rough amplitude calibration that updates both the sx and x pulses."""
         super().__init__(
-            qubit,
+            physical_qubits,
             calibrations,
             schedule_name="x",
             amplitudes=amplitudes,
@@ -231,9 +236,10 @@ class EFRoughXSXAmplitudeCal(RoughAmplitudeCal):
 
     __outcome__ = "rabi_rate_12"
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         amplitudes: Iterable[float] = None,
         backend: Optional[Backend] = None,
@@ -242,7 +248,8 @@ class EFRoughXSXAmplitudeCal(RoughAmplitudeCal):
         r"""A rough amplitude calibration that updates both the sx and x pulses on 1<->2.
 
         Args:
-            qubit: The index of the qubit (technically a qutrit) to run on.
+            physical_qubits: Sequence containing the index of the qubit
+                (technically a qutrit) to run on.
             calibrations: The calibrations instance that stores the pulse schedules.
             amplitudes: The amplitudes to scan.
             backend: Optional, the backend to run the experiment on.
@@ -251,7 +258,7 @@ class EFRoughXSXAmplitudeCal(RoughAmplitudeCal):
                 the 1<->2 transition.
         """
         super().__init__(
-            qubit,
+            physical_qubits,
             calibrations,
             schedule_name="x" + ef_pulse_label,
             amplitudes=amplitudes,

--- a/qiskit_experiments/library/calibration/rough_drag_cal.py
+++ b/qiskit_experiments/library/calibration/rough_drag_cal.py
@@ -34,6 +34,7 @@ class RoughDragCal(BaseCalibrationExperiment, RoughDrag):
         qiskit_experiments.library.characterization.rough_drag.RoughDrag
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
         physical_qubits: Sequence[int],

--- a/qiskit_experiments/library/calibration/rough_drag_cal.py
+++ b/qiskit_experiments/library/calibration/rough_drag_cal.py
@@ -12,7 +12,7 @@
 
 """Rough drag calibration experiment."""
 
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, Optional, Sequence
 
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.providers.backend import Backend
@@ -24,6 +24,7 @@ from qiskit_experiments.calibration_management import (
 )
 from qiskit_experiments.calibration_management.update_library import BaseUpdater
 from qiskit_experiments.library.characterization.drag import RoughDrag
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class RoughDragCal(BaseCalibrationExperiment, RoughDrag):
@@ -35,7 +36,7 @@ class RoughDragCal(BaseCalibrationExperiment, RoughDrag):
 
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         backend: Optional[Backend] = None,
         schedule_name: str = "x",
@@ -47,7 +48,8 @@ class RoughDragCal(BaseCalibrationExperiment, RoughDrag):
         r"""see class :class:`RoughDrag` for details.
 
         Args:
-            qubit: The qubit for which to run the rough drag calibration.
+            physical_qubits: Sequence containing the qubit for which to run the
+                rough drag calibration.
             calibrations: The calibrations instance with the schedules.
             backend: Optional, the backend to run the experiment on.
             schedule_name: The name of the schedule to calibrate. Defaults to "x".
@@ -59,6 +61,7 @@ class RoughDragCal(BaseCalibrationExperiment, RoughDrag):
                 default this variable is set to True.
             group: The group of calibration parameters to use. The default value is "default".
         """
+        qubit = physical_qubits[0]
         schedule = calibrations.get_schedule(
             schedule_name, qubit, assign_params={cal_parameter_name: Parameter("β")}, group=group
         )
@@ -68,7 +71,7 @@ class RoughDragCal(BaseCalibrationExperiment, RoughDrag):
 
         super().__init__(
             calibrations,
-            qubit,
+            physical_qubits,
             schedule=schedule,
             betas=betas,
             backend=backend,

--- a/qiskit_experiments/library/calibration/rough_frequency.py
+++ b/qiskit_experiments/library/calibration/rough_frequency.py
@@ -12,7 +12,7 @@
 
 """Calibration version of spectroscopy experiments."""
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Sequence
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.providers.backend import Backend

--- a/qiskit_experiments/library/calibration/rough_frequency.py
+++ b/qiskit_experiments/library/calibration/rough_frequency.py
@@ -24,6 +24,7 @@ from qiskit_experiments.calibration_management.calibrations import Calibrations
 from qiskit_experiments.calibration_management.base_calibration_experiment import (
     BaseCalibrationExperiment,
 )
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class RoughFrequencyCal(BaseCalibrationExperiment, QubitSpectroscopy):
@@ -33,9 +34,10 @@ class RoughFrequencyCal(BaseCalibrationExperiment, QubitSpectroscopy):
         qiskit_experiments.library.characterization.qubit_spectroscopy.QubitSpectroscopy
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         frequencies: Iterable[float],
         backend: Optional[Backend] = None,
@@ -45,7 +47,7 @@ class RoughFrequencyCal(BaseCalibrationExperiment, QubitSpectroscopy):
         """See :class:`QubitSpectroscopy` for detailed documentation.
 
         Args:
-            qubit: The qubit on which to run spectroscopy.
+            physical_qubits: List with the qubit on which to run spectroscopy.
             calibrations: If calibrations is given then running the experiment may update the values
                 of the frequencies stored in calibrations.
             frequencies: The frequencies to scan in the experiment, in Hz.
@@ -61,7 +63,7 @@ class RoughFrequencyCal(BaseCalibrationExperiment, QubitSpectroscopy):
         """
         super().__init__(
             calibrations,
-            qubit,
+            physical_qubits,
             frequencies,
             backend=backend,
             absolute=absolute,
@@ -86,7 +88,7 @@ class RoughEFFrequencyCal(BaseCalibrationExperiment, EFSpectroscopy):
     # pylint: disable=super-init-not-called
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         calibrations: Calibrations,
         frequencies: Iterable[float],
         auto_update: bool = True,
@@ -95,7 +97,7 @@ class RoughEFFrequencyCal(BaseCalibrationExperiment, EFSpectroscopy):
         """See :class:`QubitSpectroscopy` for detailed documentation.
 
         Args:
-            qubit: The qubit on which to run spectroscopy.
+            physical_qubits: List containing the qubit on which to run spectroscopy.
             calibrations: If calibrations is given then running the experiment may update the values
                 of the frequencies stored in calibrations.
             frequencies: The frequencies to scan in the experiment, in Hz.
@@ -110,7 +112,7 @@ class RoughEFFrequencyCal(BaseCalibrationExperiment, EFSpectroscopy):
         """
         super().__init__(
             calibrations,
-            qubit,
+            physical_qubits,
             frequencies,
             absolute,
             cal_parameter_name="f12",

--- a/qiskit_experiments/library/characterization/drag.py
+++ b/qiskit_experiments/library/characterization/drag.py
@@ -12,7 +12,7 @@
 
 """Rough drag experiment."""
 
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Sequence
 import numpy as np
 
 from qiskit import QuantumCircuit
@@ -24,6 +24,7 @@ from qiskit.pulse import ScheduleBlock
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
 from qiskit_experiments.library.characterization.analysis import DragCalAnalysis
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class RoughDrag(BaseExperiment, RestlessMixin):
@@ -92,9 +93,10 @@ class RoughDrag(BaseExperiment, RestlessMixin):
 
         return options
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         schedule: ScheduleBlock,
         betas: Optional[Iterable[float]] = None,
         backend: Optional[Backend] = None,
@@ -102,7 +104,8 @@ class RoughDrag(BaseExperiment, RestlessMixin):
         """Initialize a Drag experiment in the given qubit.
 
         Args:
-            qubit: The qubit for which to run the Drag calibration.
+            physical_qubits: Sequence containing the qubit for which to run the
+                Drag calibration.
             schedule: The schedule to run. This schedule should have one free parameter
                 corresponding to a DRAG parameter.
             betas: The values of the DRAG parameter to scan. If None is given the default range
@@ -114,7 +117,7 @@ class RoughDrag(BaseExperiment, RestlessMixin):
         """
 
         # Create analysis in finalize to reflect user change to reps
-        super().__init__([qubit], analysis=DragCalAnalysis(), backend=backend)
+        super().__init__(physical_qubits, analysis=DragCalAnalysis(), backend=backend)
 
         if betas is not None:
             self.set_experiment_options(betas=betas)

--- a/qiskit_experiments/library/characterization/ef_spectroscopy.py
+++ b/qiskit_experiments/library/characterization/ef_spectroscopy.py
@@ -12,13 +12,14 @@
 
 """Spectroscopy for the e-f transition."""
 
-from typing import Iterable, Optional
+from typing import Iterable, List, Optional, Sequence
 from qiskit import QuantumCircuit
 from qiskit.providers import Backend
 from qiskit.circuit import Gate
 
 from qiskit_experiments.curve_analysis import ParameterRepr
 from qiskit_experiments.library.characterization.qubit_spectroscopy import QubitSpectroscopy
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class EFSpectroscopy(QubitSpectroscopy):
@@ -37,14 +38,15 @@ class EFSpectroscopy(QubitSpectroscopy):
 
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         frequencies: Iterable[float],
         backend: Optional[Backend] = None,
         absolute: bool = True,
     ):
-        super().__init__(qubit, frequencies, backend=backend, absolute=absolute)
+        super().__init__(physical_qubits, frequencies, backend=backend, absolute=absolute)
         self.analysis.set_options(result_parameters=[ParameterRepr("freq", "f12")])
 
     def _template_circuit(self, freq_param) -> QuantumCircuit:

--- a/qiskit_experiments/library/characterization/ef_spectroscopy.py
+++ b/qiskit_experiments/library/characterization/ef_spectroscopy.py
@@ -12,7 +12,7 @@
 
 """Spectroscopy for the e-f transition."""
 
-from typing import Iterable, List, Optional, Sequence
+from typing import Iterable, Optional, Sequence
 from qiskit import QuantumCircuit
 from qiskit.providers import Backend
 from qiskit.circuit import Gate

--- a/qiskit_experiments/library/characterization/fine_amplitude.py
+++ b/qiskit_experiments/library/characterization/fine_amplitude.py
@@ -301,7 +301,7 @@ class FineSXAmplitude(FineAmplitude):
         the appropriate values for the default options.
     """
 
-    @physical_qubits()
+    @qubit_deprecate()
     def __init__(self, physical_qubits: Sequence[int], backend: Optional[Backend] = None):
         """Initialize the experiment."""
         super().__init__(physical_qubits, SXGate(), backend=backend)

--- a/qiskit_experiments/library/characterization/fine_amplitude.py
+++ b/qiskit_experiments/library/characterization/fine_amplitude.py
@@ -370,7 +370,9 @@ class FineZXAmplitude(FineAmplitude):
         # Failing to do so causes issues with QuantumCircuit.calibrations.
         gate = Gate("szx", 2, [])
 
-        super().__init__(physical_qubits, gate, backend=backend, measurement_qubits=[physical_qubits[1]])
+        super().__init__(
+            physical_qubits, gate, backend=backend, measurement_qubits=[physical_qubits[1]]
+        )
         # Set default analysis options
         self.analysis.set_options(
             fixed_parameters={

--- a/qiskit_experiments/library/characterization/fine_amplitude.py
+++ b/qiskit_experiments/library/characterization/fine_amplitude.py
@@ -370,7 +370,7 @@ class FineZXAmplitude(FineAmplitude):
         # Failing to do so causes issues with QuantumCircuit.calibrations.
         gate = Gate("szx", 2, [])
 
-        super().__init__(physical_qubits, gate, backend=backend, measurement_qubits=[qubits[1]])
+        super().__init__(physical_qubits, gate, backend=backend, measurement_qubits=[physical_qubits[1]])
         # Set default analysis options
         self.analysis.set_options(
             fixed_parameters={

--- a/qiskit_experiments/library/characterization/fine_amplitude.py
+++ b/qiskit_experiments/library/characterization/fine_amplitude.py
@@ -23,6 +23,7 @@ from qiskit_experiments.data_processing import DataProcessor, nodes
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
 from qiskit_experiments.library.characterization.analysis import FineAmplitudeAnalysis
+from qiskit_experiments.warnings import deprecate_arguments, qubit_deprecate
 
 
 class FineAmplitude(BaseExperiment, RestlessMixin):
@@ -68,7 +69,7 @@ class FineAmplitude(BaseExperiment, RestlessMixin):
         .. code-block:: python
 
             qubit = 3
-            amp_cal = FineAmplitude(qubit, SXGate())
+            amp_cal = FineAmplitude([qubit], SXGate())
             amp_cal.set_experiment_options(
                 angle_per_gate=np.pi/2,
                 add_xp_circuit=False,
@@ -113,9 +114,10 @@ class FineAmplitude(BaseExperiment, RestlessMixin):
 
         return options
 
+    @deprecate_arguments({"qubits": "physical_qubits"}, "0.5")
     def __init__(
         self,
-        qubits: Sequence[int],
+        physical_qubits: Sequence[int],
         gate: Gate,
         backend: Optional[Backend] = None,
         measurement_qubits: Sequence[int] = None,
@@ -123,13 +125,14 @@ class FineAmplitude(BaseExperiment, RestlessMixin):
         """Setup a fine amplitude experiment on the given qubit.
 
         Args:
-            qubits: The qubit(s) on which to run the fine amplitude calibration experiment.
+            physical_qubits: Sequence containing qubit(s) on which to run the
+                fine amplitude calibration experiment.
             gate: The gate that will be repeated.
             backend: Optional, the backend to run the experiment on.
             measurement_qubits: The qubits in the given physical qubits that need to
                 be measured.
         """
-        super().__init__(qubits, analysis=FineAmplitudeAnalysis(), backend=backend)
+        super().__init__(physical_qubits, analysis=FineAmplitudeAnalysis(), backend=backend)
         self.set_experiment_options(gate=gate)
 
         if measurement_qubits is not None:
@@ -259,9 +262,10 @@ class FineXAmplitude(FineAmplitude):
         the appropriate values for the default options.
     """
 
-    def __init__(self, qubit: int, backend: Optional[Backend] = None):
+    @qubit_deprecate()
+    def __init__(self, physical_qubits: Sequence[int], backend: Optional[Backend] = None):
         """Initialize the experiment."""
-        super().__init__([qubit], XGate(), backend=backend)
+        super().__init__(physical_qubits, XGate(), backend=backend)
         # Set default analysis options
         self.analysis.set_options(
             fixed_parameters={
@@ -297,9 +301,10 @@ class FineSXAmplitude(FineAmplitude):
         the appropriate values for the default options.
     """
 
-    def __init__(self, qubit: int, backend: Optional[Backend] = None):
+    @physical_qubits()
+    def __init__(self, physical_qubits: Sequence[int], backend: Optional[Backend] = None):
         """Initialize the experiment."""
-        super().__init__([qubit], SXGate(), backend=backend)
+        super().__init__(physical_qubits, SXGate(), backend=backend)
         # Set default analysis options
         self.analysis.set_options(
             fixed_parameters={
@@ -357,14 +362,15 @@ class FineZXAmplitude(FineAmplitude):
         :code:`RZXGate(np.pi / 2)` rotation.
     """
 
-    def __init__(self, qubits: Sequence[int], backend: Optional[Backend] = None):
+    @deprecate_arguments({"qubits": "physical_qubits"}, "0.5")
+    def __init__(self, physical_qubits: Sequence[int], backend: Optional[Backend] = None):
         """Initialize the experiment."""
 
         # We cannot use RZXGate since it has a parameter so we redefine the gate.
         # Failing to do so causes issues with QuantumCircuit.calibrations.
         gate = Gate("szx", 2, [])
 
-        super().__init__(qubits, gate, backend=backend, measurement_qubits=[qubits[1]])
+        super().__init__(physical_qubits, gate, backend=backend, measurement_qubits=[qubits[1]])
         # Set default analysis options
         self.analysis.set_options(
             fixed_parameters={

--- a/qiskit_experiments/library/characterization/fine_drag.py
+++ b/qiskit_experiments/library/characterization/fine_drag.py
@@ -12,7 +12,7 @@
 
 """Fine DRAG characterization experiment."""
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 import numpy as np
 
 from qiskit import QuantumCircuit
@@ -22,6 +22,7 @@ from qiskit.providers.backend import Backend
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
 from qiskit_experiments.curve_analysis.standard_analysis import ErrorAmplificationAnalysis
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class FineDrag(BaseExperiment, RestlessMixin):
@@ -152,11 +153,13 @@ class FineDrag(BaseExperiment, RestlessMixin):
 
         return options
 
-    def __init__(self, qubit: int, gate: Gate, backend: Optional[Backend] = None):
+    @qubit_deprecate()
+    def __init__(self, physical_qubits: Sequence[int], gate: Gate, backend: Optional[Backend] = None):
         """Setup a fine amplitude experiment on the given qubit.
 
         Args:
-            qubit: The qubit on which to run the fine amplitude calibration experiment.
+            physical_qubits: List containing the qubit on which to run the fine
+                amplitude calibration experiment.
             gate: The gate that will be repeated.
             backend: Optional, the backend to run the experiment on.
         """
@@ -170,7 +173,7 @@ class FineDrag(BaseExperiment, RestlessMixin):
             },
         )
 
-        super().__init__([qubit], analysis=analysis, backend=backend)
+        super().__init__(physical_qubits, analysis=analysis, backend=backend)
         self.set_experiment_options(gate=gate)
 
     @staticmethod
@@ -246,9 +249,10 @@ class FineXDrag(FineDrag):
         qiskit_experiments.library.characterization.fine_drag.FineDrag
     """
 
-    def __init__(self, qubit: int, backend: Optional[Backend] = None):
+    @qubit_deprecate()
+    def __init__(self, physical_qubits: Sequence[int], backend: Optional[Backend] = None):
         """Initialize the experiment."""
-        super().__init__(qubit, XGate(), backend=backend)
+        super().__init__(physical_qubits, XGate(), backend=backend)
 
     @classmethod
     def _default_experiment_options(cls) -> Options:
@@ -275,9 +279,10 @@ class FineSXDrag(FineDrag):
         qiskit_experiments.library.characterization.fine_drag.FineDrag
     """
 
-    def __init__(self, qubit: int, backend: Optional[Backend] = None):
+    @qubit_deprecate()
+    def __init__(self, physical_qubits: Sequence[int], backend: Optional[Backend] = None):
         """Initialize the experiment."""
-        super().__init__(qubit, SXGate(), backend=backend)
+        super().__init__(physical_qubits, SXGate(), backend=backend)
 
     @classmethod
     def _default_experiment_options(cls) -> Options:

--- a/qiskit_experiments/library/characterization/fine_drag.py
+++ b/qiskit_experiments/library/characterization/fine_drag.py
@@ -154,7 +154,9 @@ class FineDrag(BaseExperiment, RestlessMixin):
         return options
 
     @qubit_deprecate()
-    def __init__(self, physical_qubits: Sequence[int], gate: Gate, backend: Optional[Backend] = None):
+    def __init__(
+        self, physical_qubits: Sequence[int], gate: Gate, backend: Optional[Backend] = None
+    ):
         """Setup a fine amplitude experiment on the given qubit.
 
         Args:

--- a/qiskit_experiments/library/characterization/fine_frequency.py
+++ b/qiskit_experiments/library/characterization/fine_frequency.py
@@ -12,7 +12,7 @@
 
 """Fine frequency characterization experiment."""
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 import numpy as np
 
 from qiskit import QuantumCircuit
@@ -20,6 +20,7 @@ from qiskit.providers.backend import Backend
 
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.curve_analysis.standard_analysis import ErrorAmplificationAnalysis
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class FineFrequency(BaseExperiment):
@@ -50,9 +51,10 @@ class FineFrequency(BaseExperiment):
         :py:class:`~qiskit_experiments.curve_analysis.ErrorAmplificationAnalysis`
     """
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         delay_duration: int,
         backend: Optional[Backend] = None,
         repetitions: Optional[List[int]] = None,
@@ -60,7 +62,8 @@ class FineFrequency(BaseExperiment):
         """Setup a fine frequency experiment on the given qubit.
 
         Args:
-            qubit: The qubit on which to run the fine frequency characterization experiment.
+            physical_qubits: List containing the qubit on which to run the fine
+                frequency characterization experiment.
             delay_duration: The duration of the delay at :math:`n=1` in dt.
             backend: Optional, the backend to run the experiment on.
             repetitions: The number of repetitions, if not given then the default value
@@ -75,7 +78,7 @@ class FineFrequency(BaseExperiment):
             },
         )
 
-        super().__init__([qubit], analysis=analysis, backend=backend)
+        super().__init__(physical_qubits, analysis=analysis, backend=backend)
 
         if repetitions is not None:
             self.set_experiment_options(repetitions=repetitions)

--- a/qiskit_experiments/library/characterization/half_angle.py
+++ b/qiskit_experiments/library/characterization/half_angle.py
@@ -12,7 +12,7 @@
 
 """Half angle characterization."""
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 import numpy as np
 
 from qiskit import QuantumCircuit
@@ -21,6 +21,7 @@ from qiskit.providers import Backend
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.curve_analysis.standard_analysis import ErrorAmplificationAnalysis
 from qiskit_experiments.curve_analysis import ParameterRepr
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class HalfAngle(BaseExperiment):
@@ -78,11 +79,13 @@ class HalfAngle(BaseExperiment):
         options.inst_map = None
         return options
 
-    def __init__(self, qubit: int, backend: Optional[Backend] = None):
+    @qubit_deprecate()
+    def __init__(self, physical_qubits: Sequence[int], backend: Optional[Backend] = None):
         """Setup a half angle experiment on the given qubit.
 
         Args:
-            qubit: The qubit on which to run the fine amplitude calibration experiment.
+            physical_qubits: List containing the qubits on which to run the
+                fine amplitude calibration experiment.
             backend: Optional, the backend to run the experiment on.
         """
         analysis = ErrorAmplificationAnalysis()
@@ -101,7 +104,7 @@ class HalfAngle(BaseExperiment):
             bounds=default_bounds,
         )
 
-        super().__init__([qubit], analysis=analysis, backend=backend)
+        super().__init__(physical_qubits, analysis=analysis, backend=backend)
 
     @staticmethod
     def _pre_circuit() -> QuantumCircuit:

--- a/qiskit_experiments/library/characterization/rabi.py
+++ b/qiskit_experiments/library/characterization/rabi.py
@@ -12,7 +12,7 @@
 
 """Rabi amplitude experiment."""
 
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Optional, Sequence, Tuple
 import numpy as np
 
 from qiskit import QuantumCircuit
@@ -25,6 +25,7 @@ from qiskit.exceptions import QiskitError
 from qiskit_experiments.framework import BaseExperiment, Options
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
 from qiskit_experiments.curve_analysis import ParameterRepr, OscillationAnalysis
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class Rabi(BaseExperiment, RestlessMixin):
@@ -87,9 +88,10 @@ class Rabi(BaseExperiment, RestlessMixin):
 
         return options
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         schedule: ScheduleBlock,
         amplitudes: Optional[Iterable[float]] = None,
         backend: Optional[Backend] = None,
@@ -97,14 +99,14 @@ class Rabi(BaseExperiment, RestlessMixin):
         """Initialize a Rabi experiment on the given qubit.
 
         Args:
-            qubit: The qubit on which to run the Rabi experiment.
+            physical_qubits: List with the qubit on which to run the Rabi experiment.
             schedule: The schedule that will be used in the Rabi experiment. This schedule
                 should have one free parameter namely the amplitude.
             amplitudes: The pulse amplitudes that one wishes to scan. If this variable is not
                 specified it will default to :code:`np.linspace(-0.95, 0.95, 51)`.
             backend: Optional, the backend to run the experiment on.
         """
-        super().__init__([qubit], analysis=OscillationAnalysis(), backend=backend)
+        super().__init__(physical_qubits, analysis=OscillationAnalysis(), backend=backend)
 
         self.analysis.set_options(
             result_parameters=[ParameterRepr("freq", self.__outcome__)],

--- a/qiskit_experiments/library/characterization/ramsey_xy.py
+++ b/qiskit_experiments/library/characterization/ramsey_xy.py
@@ -12,7 +12,7 @@
 
 """Ramsey XY frequency characterization experiment."""
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 import numpy as np
 
 from qiskit import QuantumCircuit
@@ -23,6 +23,7 @@ from qiskit.qobj.utils import MeasLevel
 from qiskit_experiments.framework import BaseExperiment
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
 from qiskit_experiments.library.characterization.analysis import RamseyXYAnalysis
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class RamseyXY(BaseExperiment, RestlessMixin):
@@ -99,9 +100,10 @@ class RamseyXY(BaseExperiment, RestlessMixin):
 
         return options
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         backend: Optional[Backend] = None,
         delays: Optional[List] = None,
         osc_freq: float = 2e6,
@@ -109,13 +111,14 @@ class RamseyXY(BaseExperiment, RestlessMixin):
         """Create new experiment.
 
         Args:
-            qubit: The qubit on which to run the Ramsey XY experiment.
+            physical_qubits: List containing the qubit on which to run the
+                Ramsey XY experiment.
             backend: Optional, the backend to run the experiment on.
             delays: The delays to scan, in seconds.
             osc_freq: the oscillation frequency induced by the user through a virtual
                 Rz rotation. This quantity is given in Hz.
         """
-        super().__init__([qubit], analysis=RamseyXYAnalysis(), backend=backend)
+        super().__init__(physical_qubits, analysis=RamseyXYAnalysis(), backend=backend)
 
         if delays is None:
             delays = self.experiment_options.delays

--- a/qiskit_experiments/library/characterization/resonator_spectroscopy.py
+++ b/qiskit_experiments/library/characterization/resonator_spectroscopy.py
@@ -194,7 +194,9 @@ class ResonatorSpectroscopy(Spectroscopy):
                 center_freq = BackendData(backend).meas_freqs[physical_qubits[0]]
                 frequencies += center_freq
 
-        super().__init__(physical_qubits, frequencies, backend, absolute, analysis, **experiment_options)
+        super().__init__(
+            physical_qubits, frequencies, backend, absolute, analysis, **experiment_options
+        )
 
     @property
     def _backend_center_frequency(self) -> float:

--- a/qiskit_experiments/library/characterization/resonator_spectroscopy.py
+++ b/qiskit_experiments/library/characterization/resonator_spectroscopy.py
@@ -12,7 +12,7 @@
 
 """Spectroscopy experiment class for resonators."""
 
-from typing import Iterable, List, Optional, Sequence, Tuple
+from typing import Iterable, Optional, Sequence, Tuple
 import numpy as np
 
 from qiskit import QuantumCircuit

--- a/qiskit_experiments/library/characterization/spectroscopy.py
+++ b/qiskit_experiments/library/characterization/spectroscopy.py
@@ -13,7 +13,7 @@
 """Abstract spectroscopy experiment base class."""
 
 from abc import ABC, abstractmethod
-from typing import Iterable, Optional
+from typing import Iterable, List, Optional, Sequence
 
 import numpy as np
 import qiskit.pulse as pulse
@@ -24,6 +24,7 @@ from qiskit.qobj.utils import MeasLevel
 
 from qiskit_experiments.framework import BaseAnalysis, BaseExperiment, Options
 from qiskit_experiments.curve_analysis import ResonanceAnalysis
+from qiskit_experiments.warnings import qubit_deprecate
 
 
 class Spectroscopy(BaseExperiment, ABC):
@@ -61,9 +62,10 @@ class Spectroscopy(BaseExperiment, ABC):
 
         return options
 
+    @qubit_deprecate()
     def __init__(
         self,
-        qubit: int,
+        physical_qubits: Sequence[int],
         frequencies: Iterable[float],
         backend: Optional[Backend] = None,
         absolute: bool = True,
@@ -73,7 +75,7 @@ class Spectroscopy(BaseExperiment, ABC):
         """A spectroscopy experiment where the frequency of a pulse is scanned.
 
         Args:
-            qubit: The qubit on which to run spectroscopy.
+            physical_qubits: List containing the qubit on which to run spectroscopy.
             frequencies: The frequencies to scan in the experiment, in Hz.
             backend: Optional, the backend to run the experiment on.
             absolute: Boolean to specify if the frequencies are absolute or relative to the
@@ -87,7 +89,7 @@ class Spectroscopy(BaseExperiment, ABC):
         """
         analysis = analysis or ResonanceAnalysis()
 
-        super().__init__([qubit], analysis=analysis, backend=backend)
+        super().__init__(physical_qubits, analysis=analysis, backend=backend)
 
         if len(frequencies) < 3:
             raise QiskitError("Spectroscopy requires at least three frequencies.")

--- a/qiskit_experiments/library/characterization/spectroscopy.py
+++ b/qiskit_experiments/library/characterization/spectroscopy.py
@@ -13,7 +13,7 @@
 """Abstract spectroscopy experiment base class."""
 
 from abc import ABC, abstractmethod
-from typing import Iterable, List, Optional, Sequence
+from typing import Iterable, Optional, Sequence
 
 import numpy as np
 import qiskit.pulse as pulse

--- a/qiskit_experiments/library/characterization/zz_ramsey.py
+++ b/qiskit_experiments/library/characterization/zz_ramsey.py
@@ -141,7 +141,7 @@ class ZZRamsey(BaseExperiment):
             backend: Optional, the backend to run the experiment on.
             experiment_options: experiment options to set
         """
-        super().__init__(qubits=physical_qubits, analysis=ZZRamseyAnalysis(), backend=backend)
+        super().__init__(physical_qubits, analysis=ZZRamseyAnalysis(), backend=backend)
         # Override the default of get_processor() which is "1" * num_qubits. We
         # only fit the probability of the target qubit.
         self.analysis.set_options(outcome="1")

--- a/qiskit_experiments/warnings.py
+++ b/qiskit_experiments/warnings.py
@@ -208,10 +208,11 @@ def qubit_deprecate() -> Callable:
                 args[1] = [args[1]]
                 args = tuple(args)
                 warnings.warn(
-                    f"The first argument of {func_name} has been renamed from qubits to "
-                    "physical_qubits, and is expecting a sequence instead of an integer. "
-                    "Support of integer values is deprecated and will be removed after Qiskit "
-                    "Experiments 0.5.",
+                    f'The first argument of {func_name} has been renamed from "qubit" to '
+                    '"physical_qubits" and is expecting a sequence with a single integer. '
+                    "Support for directly passing an integer argument is "
+                    "deprecated and will be removed after Qiskit Experiments "
+                    "0.5.",
                     category=category,
                     stacklevel=3,
                 )
@@ -219,14 +220,16 @@ def qubit_deprecate() -> Callable:
             if kwargs and "qubit" in kwargs:
                 if "physical_qubits" in kwargs:
                     raise TypeError(
-                        f"{func_name} received both physical_qubits and the deprecated qubits "
-                        "parameter. Only physical_qubits should be supplied."
+                        f'{func_name} received both "physical_qubits" and the deprecated "qubit" '
+                        'parameter. Only "physical_qubits" should be supplied.'
                     )
 
                 warnings.warn(
-                    f"{func_name} keyword argument qubit is deprecated and "
-                    f"replaced with physical_qubits. It will be removed after Qiskit Experiments "
-                    "0.5.",
+                    f'{func_name} keyword argument "qubit" is deprecated and has been '
+                    'replaced with "physical_qubits". "physical_qubits" should be '
+                    "passed as a sequence containing a single integer. "
+                    'Support for using "qubit" with an integer argument is '
+                    "deprecated and will be removed after Qiskit Experiments 0.5.",
                     category=category,
                     stacklevel=3,
                 )

--- a/releasenotes/notes/qubit-deprecate-13f123c35f0a3535.yaml
+++ b/releasenotes/notes/qubit-deprecate-13f123c35f0a3535.yaml
@@ -1,4 +1,7 @@
 ---
 deprecations:
   - |
-    Experiment constructor arguments `qubit` and `qubits` have been renamed `physical_qubits`. For the `qubit` case, the argument type has changed from integer to sequence.
+    Experiment constructor arguments ``qubit`` and ``qubits`` have been renamed
+    ``physical_qubits``. For the ``qubit`` case, the argument type has changed
+    from an integer to a sequence with a single integer. For example,
+    ``FineXAmplitude()`` becomes ``FineXAmplitude([0])``.

--- a/test/calibration/test_base_calibration_experiment.py
+++ b/test/calibration/test_base_calibration_experiment.py
@@ -34,7 +34,7 @@ class TestBaseCalibrationClass(QiskitExperimentsTestCase):
 
             def __init__(self):
                 """A dummy class for parent order testing."""
-                super().__init__(Calibrations(coupling_map=[]), 0, [0, 1, 2])
+                super().__init__(Calibrations(coupling_map=[]), [0], [0, 1, 2])
 
             def _attach_calibrations(self, circuit: QuantumCircuit):
                 """Needed as this method is abstract"""
@@ -50,4 +50,4 @@ class TestBaseCalibrationClass(QiskitExperimentsTestCase):
 
                 def __init__(self):
                     """A dummy class for parent order testing."""
-                    super().__init__(Calibrations(coupling_map=[]), 0, [0, 1, 2])
+                    super().__init__(Calibrations(coupling_map=[]), [0], [0, 1, 2])

--- a/test/calibration/test_update_library.py
+++ b/test/calibration/test_update_library.py
@@ -73,7 +73,7 @@ class TestFrequencyUpdate(QiskitExperimentsTestCase):
         freq01 = backend.defaults().qubit_freq_est[qubit]
         frequencies = np.linspace(freq01 - 10.0e6, freq01 + 10.0e6, 21)
 
-        spec = QubitSpectroscopy(qubit, frequencies)
+        spec = QubitSpectroscopy([qubit], frequencies)
         spec.set_run_options(meas_level=MeasLevel.CLASSIFIED)
         exp_data = spec.run(backend)
         self.assertExperimentDone(exp_data)

--- a/test/data_processing/test_restless_experiment.py
+++ b/test/data_processing/test_restless_experiment.py
@@ -39,9 +39,9 @@ class TestFineAmpEndToEndRestless(QiskitExperimentsTestCase):
         backend = MockRestlessFineAmp(error, np.pi, "x")
 
         with self.assertRaises(DataProcessorError):
-            FineXAmplitude(0, backend).enable_restless(rep_delay=2.0)
+            FineXAmplitude([0], backend).enable_restless(rep_delay=2.0)
 
-        amp_exp = FineXAmplitude(0, backend)
+        amp_exp = FineXAmplitude([0], backend)
         amp_exp.enable_restless(rep_delay=2.0, suppress_t1_error=True)
 
         self.assertTrue(
@@ -58,7 +58,7 @@ class TestFineAmpEndToEndRestless(QiskitExperimentsTestCase):
         error = -np.pi * pi_ratio
         backend = MockRestlessFineAmp(error, np.pi, "x")
 
-        amp_exp = FineXAmplitude(0, backend)
+        amp_exp = FineXAmplitude([0], backend)
         amp_exp.enable_restless(rep_delay=1e-6)
 
         expdata = amp_exp.run(backend)
@@ -80,7 +80,7 @@ class TestFineAmpEndToEndRestless(QiskitExperimentsTestCase):
         error = -np.pi * pi_ratio
         backend = MockRestlessFineAmp(error, np.pi, "x")
 
-        amp_exp = FineXAmplitude(0, backend)
+        amp_exp = FineXAmplitude([0], backend)
         # standard data processor.
         standard_processor = DataProcessor("counts", [Probability("01")])
         amp_exp.analysis.set_options(data_processor=standard_processor)

--- a/test/library/calibration/test_drag.py
+++ b/test/library/calibration/test_drag.py
@@ -54,7 +54,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
         drag_experiment_helper = DragHelper(gate_name="Drag(xp)")
         backend = MockIQBackend(drag_experiment_helper)
 
-        drag = RoughDrag(1, self.x_plus)
+        drag = RoughDrag([1], self.x_plus)
 
         expdata = drag.run(backend)
         self.assertExperimentDone(expdata)
@@ -68,7 +68,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
         # rather increase beta.
         drag_experiment_helper.frequency = 0.0044
 
-        drag = RoughDrag(0, self.x_plus)
+        drag = RoughDrag([0], self.x_plus)
         exp_data = drag.run(backend)
         self.assertExperimentDone(exp_data)
         result = exp_data.analysis_results(1)
@@ -79,7 +79,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
 
         # Large leakage will make the curves oscillate quickly.
         drag_experiment_helper.frequency = 0.04
-        drag = RoughDrag(1, self.x_plus, betas=np.linspace(-4, 4, 31))
+        drag = RoughDrag([1], self.x_plus, betas=np.linspace(-4, 4, 31))
         # pylint: disable=no-member
         drag.set_run_options(shots=200)
         drag.analysis.set_options(p0={"beta": 1.8, "freq": 0.08})
@@ -110,7 +110,7 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
             )
         )
 
-        drag = RoughDrag(0, self.x_plus, betas=betas)
+        drag = RoughDrag([0], self.x_plus, betas=betas)
         drag.set_experiment_options(reps=reps)
 
         exp_data = drag.run(backend)
@@ -139,7 +139,7 @@ class TestDragCircuits(QiskitExperimentsTestCase):
         """Test the default circuit."""
 
         backend = MockIQBackend(DragHelper(gate_name="Drag(xp)", frequency=0.005))
-        drag = RoughDrag(0, self.x_plus)
+        drag = RoughDrag([0], self.x_plus)
         drag.set_experiment_options(reps=[2, 4, 8])
         drag.backend = MockIQBackend(DragHelper(gate_name="Drag(xp)"))
         circuits = drag.circuits()
@@ -158,7 +158,7 @@ class TestDragCircuits(QiskitExperimentsTestCase):
             pulse.play(Drag(duration=160, amp=amp, sigma=40, beta=beta), DriveChannel(0))
 
         with self.assertRaises(QiskitError):
-            RoughDrag(1, xp, betas=np.linspace(-3, 3, 21))
+            RoughDrag([1], xp, betas=np.linspace(-3, 3, 21))
 
 
 class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
@@ -182,7 +182,7 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
         prev_beta = self.cals.get_parameter_value("β", (0,), "x")
         self.assertEqual(prev_beta, 0)
 
-        expdata = RoughDragCal(qubit, self.cals, backend=self.backend).run()
+        expdata = RoughDragCal([qubit], self.cals, backend=self.backend).run()
         self.assertExperimentDone(expdata)
 
         new_beta = self.cals.get_parameter_value("β", (0,), "x")
@@ -191,7 +191,7 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
 
     def test_dragcal_experiment_config(self):
         """Test RoughDragCal config can round trip"""
-        exp = RoughDragCal(0, self.cals, backend=self.backend)
+        exp = RoughDragCal([0], self.cals, backend=self.backend)
         loaded_exp = RoughDragCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))
@@ -199,14 +199,14 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
     @unittest.skip("Calibration experiments are not yet JSON serializable")
     def test_dragcal_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = RoughDragCal(0, self.cals)
+        exp = RoughDragCal([0], self.cals)
         self.assertRoundTripSerializable(exp, self.json_equiv)
 
     def test_drag_experiment_config(self):
         """Test RoughDrag config can roundtrip"""
         with pulse.build(name="xp") as sched:
             pulse.play(pulse.Drag(160, 0.5, 40, Parameter("β")), pulse.DriveChannel(0))
-        exp = RoughDrag(0, backend=self.backend, schedule=sched)
+        exp = RoughDrag([0], backend=self.backend, schedule=sched)
         loaded_exp = RoughDrag.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))
@@ -216,5 +216,5 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
         """Test round trip JSON serialization"""
         with pulse.build(name="xp") as sched:
             pulse.play(pulse.Drag(160, 0.5, 40, Parameter("β")), pulse.DriveChannel(0))
-        exp = RoughDrag(0, backend=self.backend, schedule=sched)
+        exp = RoughDrag([0], backend=self.backend, schedule=sched)
         self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/library/calibration/test_fine_amplitude.py
+++ b/test/library/calibration/test_fine_amplitude.py
@@ -41,7 +41,7 @@ class TestFineAmpEndToEnd(QiskitExperimentsTestCase):
     def test_end_to_end_under_rotation(self, pi_ratio):
         """Test the experiment end to end."""
 
-        amp_exp = FineXAmplitude(0)
+        amp_exp = FineXAmplitude([0])
         amp_exp.set_transpile_options(basis_gates=["x", "sx"])
 
         error = -np.pi * pi_ratio
@@ -61,7 +61,7 @@ class TestFineAmpEndToEnd(QiskitExperimentsTestCase):
     def test_end_to_end_over_rotation(self, pi_ratio):
         """Test the experiment end to end."""
 
-        amp_exp = FineXAmplitude(0)
+        amp_exp = FineXAmplitude([0])
         amp_exp.set_transpile_options(basis_gates=["x", "sx"])
 
         error = np.pi * pi_ratio
@@ -126,7 +126,7 @@ class TestFineAmplitudeCircuits(QiskitExperimentsTestCase):
     def test_xp(self):
         """Test a circuit with the x gate."""
 
-        amp_cal = FineXAmplitude(0)
+        amp_cal = FineXAmplitude([0])
         circs = amp_cal.circuits()
 
         self.assertTrue(circs[0].data[0][0].name == "measure")
@@ -139,7 +139,7 @@ class TestFineAmplitudeCircuits(QiskitExperimentsTestCase):
     def test_x90p(self):
         """Test circuits with an x90p pulse."""
 
-        amp_cal = FineSXAmplitude(0)
+        amp_cal = FineSXAmplitude([0])
 
         expected = [0, 1, 2, 3, 5, 7, 9, 11, 13, 15, 17, 21, 23, 25]
         for idx, circ in enumerate(amp_cal.circuits()):
@@ -153,7 +153,7 @@ class TestSpecializations(QiskitExperimentsTestCase):
     def test_fine_x_amp(self):
         """Test the fine X amplitude."""
 
-        exp = FineXAmplitude(0)
+        exp = FineXAmplitude([0])
 
         self.assertTrue(exp.experiment_options.add_cal_circuits)
         self.assertDictEqual(
@@ -164,13 +164,13 @@ class TestSpecializations(QiskitExperimentsTestCase):
 
     def test_x_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = FineXAmplitude(0)
+        exp = FineXAmplitude([0])
         self.assertRoundTripSerializable(exp, self.json_equiv)
 
     def test_fine_sx_amp(self):
         """Test the fine SX amplitude."""
 
-        exp = FineSXAmplitude(0)
+        exp = FineSXAmplitude([0])
 
         self.assertFalse(exp.experiment_options.add_cal_circuits)
 
@@ -184,7 +184,7 @@ class TestSpecializations(QiskitExperimentsTestCase):
 
     def test_sx_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = FineSXAmplitude(0)
+        exp = FineSXAmplitude([0])
         self.assertRoundTripSerializable(exp, self.json_equiv)
 
     @data((2, 3), (3, 1), (0, 1))
@@ -216,7 +216,7 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         """Test that the options are properly propagated."""
 
         # Test the X gate cal
-        amp_cal = FineXAmplitudeCal(0, self.cals, "x")
+        amp_cal = FineXAmplitudeCal([0], self.cals, "x")
 
         exp_opt = amp_cal.experiment_options
 
@@ -227,7 +227,7 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         self.assertTrue(np.allclose(exp_opt.target_angle, np.pi))
 
         # Test the SX gate cal
-        amp_cal = FineSXAmplitudeCal(0, self.cals, "sx")
+        amp_cal = FineSXAmplitudeCal([0], self.cals, "sx")
 
         exp_opt = amp_cal.experiment_options
 
@@ -248,7 +248,7 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         # Initial pulse amplitude
         init_amp = 0.5
 
-        amp_cal = FineXAmplitudeCal(0, self.cals, "x")
+        amp_cal = FineXAmplitudeCal([0], self.cals, "x")
 
         circs = transpile(amp_cal.circuits(), self.backend, inst_map=self.cals.default_inst_map)
 
@@ -287,7 +287,7 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         # Initial pulse amplitude
         init_amp = 0.25
 
-        amp_cal = FineSXAmplitudeCal(0, self.cals, "sx")
+        amp_cal = FineSXAmplitudeCal([0], self.cals, "sx")
 
         circs = transpile(amp_cal.circuits(), self.backend, inst_map=self.cals.default_inst_map)
 
@@ -312,12 +312,12 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = FineSXAmplitudeCal(0, self.cals, "sx")
+        exp = FineSXAmplitudeCal([0], self.cals, "sx")
         loaded_exp = FineSXAmplitudeCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = FineSXAmplitudeCal(0, self.cals, "sx")
+        exp = FineSXAmplitudeCal([0], self.cals, "sx")
         self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/library/calibration/test_fine_drag.py
+++ b/test/library/calibration/test_fine_drag.py
@@ -43,7 +43,7 @@ class TestFineDrag(QiskitExperimentsTestCase):
     def test_circuits(self):
         """Test the circuits of the experiment."""
 
-        drag = FineDrag(0, Gate("Drag", num_qubits=1, params=[]))
+        drag = FineDrag([0], Gate("Drag", num_qubits=1, params=[]))
         drag.set_experiment_options(schedule=self.schedule)
         drag.backend = FakeArmonkV2()
         for circuit in drag.circuits()[1:]:
@@ -53,7 +53,7 @@ class TestFineDrag(QiskitExperimentsTestCase):
     def test_end_to_end(self):
         """A simple test to check if the experiment will run and fit data."""
 
-        drag = FineDrag(0, Gate("Drag", num_qubits=1, params=[]))
+        drag = FineDrag([0], Gate("Drag", num_qubits=1, params=[]))
         drag.set_experiment_options(schedule=self.schedule)
         drag.set_transpile_options(basis_gates=["rz", "Drag", "sx"])
         exp_data = drag.run(MockIQBackend(FineDragHelper()))
@@ -63,14 +63,14 @@ class TestFineDrag(QiskitExperimentsTestCase):
 
     def test_end_to_end_no_schedule(self):
         """Test that we can run without a schedule."""
-        exp_data = FineXDrag(0).run(MockIQBackend(FineDragHelper()))
+        exp_data = FineXDrag([0]).run(MockIQBackend(FineDragHelper()))
         self.assertExperimentDone(exp_data)
 
         self.assertEqual(exp_data.analysis_results(0).quality, "good")
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = FineDrag(0, Gate("Drag", num_qubits=1, params=[]))
+        exp = FineDrag([0], Gate("Drag", num_qubits=1, params=[]))
         config = exp.config()
         loaded_exp = FineDrag.from_config(config)
         self.assertNotEqual(exp, loaded_exp)
@@ -90,7 +90,7 @@ class TestFineDragCal(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = FineDragCal(0, self.cals, schedule_name="x")
+        exp = FineDragCal([0], self.cals, schedule_name="x")
         config = exp.config()
         loaded_exp = FineDragCal.from_config(config)
         self.assertNotEqual(exp, loaded_exp)
@@ -101,7 +101,7 @@ class TestFineDragCal(QiskitExperimentsTestCase):
 
         init_beta = 0.0
 
-        drag_cal = FineDragCal(0, self.cals, "x", self.backend)
+        drag_cal = FineDragCal([0], self.cals, "x", self.backend)
 
         transpile_opts = copy.copy(drag_cal.transpile_options.__dict__)
         transpile_opts["initial_layout"] = list(drag_cal.physical_qubits)

--- a/test/library/calibration/test_fine_frequency.py
+++ b/test/library/calibration/test_fine_frequency.py
@@ -55,7 +55,7 @@ class TestFineFreqEndToEnd(QiskitExperimentsTestCase):
         backend = MockIQBackend(exp_helper)
         exp_helper.dt = backend.configuration().dt
 
-        freq_exp = FineFrequency(0, 160, backend)
+        freq_exp = FineFrequency([0], 160, backend)
         freq_exp.set_transpile_options(inst_map=self.inst_map)
 
         expdata = freq_exp.run(shots=100)
@@ -94,12 +94,12 @@ class TestFineFreqEndToEnd(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = FineFrequency(0, 160)
+        exp = FineFrequency([0], 160)
         loaded_exp = FineFrequency.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = FineFrequency(0, 160)
+        exp = FineFrequency([0], 160)
         self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/library/calibration/test_fine_frequency.py
+++ b/test/library/calibration/test_fine_frequency.py
@@ -77,7 +77,7 @@ class TestFineFreqEndToEnd(QiskitExperimentsTestCase):
         backend = MockIQBackend(exp_helper)
         exp_helper.dt = backend.configuration().dt
 
-        fine_freq = FineFrequencyCal(0, self.cals, backend)
+        fine_freq = FineFrequencyCal([0], self.cals, backend)
         armonk_freq = BackendData(FakeArmonkV2()).drive_freqs[0]
 
         freq_before = self.cals.get_parameter_value(self.cals.__drive_freq_parameter__, 0)

--- a/test/library/calibration/test_rabi.py
+++ b/test/library/calibration/test_rabi.py
@@ -137,7 +137,7 @@ class TestEFRabi(QiskitExperimentsTestCase):
             pulse.play(pulse.Gaussian(160, Parameter("amp"), 40), pulse.DriveChannel(2))
             pulse.shift_frequency(-anharm, pulse.DriveChannel(2))
 
-        rabi12 = EFRabi(2, sched)
+        rabi12 = EFRabi([2], sched)
         rabi12.set_experiment_options(amplitudes=[0.5])
         circ = rabi12.circuits()[0]
 
@@ -152,7 +152,7 @@ class TestEFRabi(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = EFRabi(0, self.sched)
+        exp = EFRabi([0], self.sched)
         loaded_exp = EFRabi.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))
@@ -160,7 +160,7 @@ class TestEFRabi(QiskitExperimentsTestCase):
     @unittest.skip("Schedules are not yet JSON serializable")
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = EFRabi(0, self.sched)
+        exp = EFRabi([0], self.sched)
         self.assertRoundTripSerializable(exp, self.json_equiv)
 
 

--- a/test/library/calibration/test_rabi.py
+++ b/test/library/calibration/test_rabi.py
@@ -53,7 +53,7 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
 
         test_tol = 0.015
 
-        rabi = Rabi(self.qubit, self.sched, backend=self.backend)
+        rabi = Rabi([self.qubit], self.sched, backend=self.backend)
         rabi.set_experiment_options(amplitudes=np.linspace(-0.1, 0.1, 21))
         expdata = rabi.run()
         self.assertExperimentDone(expdata)
@@ -67,7 +67,7 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
 
     def test_wrong_processor(self):
         """Test that we can override the data processing by giving a faulty data processor."""
-        rabi = Rabi(self.qubit, self.sched, backend=self.backend)
+        rabi = Rabi([self.qubit], self.sched, backend=self.backend)
         fail_key = "fail_key"
 
         rabi.analysis.set_options(data_processor=DataProcessor(fail_key, []))
@@ -81,7 +81,7 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = Rabi(self.qubit, self.sched)
+        exp = Rabi([self.qubit], self.sched)
         loaded_exp = Rabi.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))
@@ -89,7 +89,7 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
     @unittest.skip("Schedules are not yet JSON serializable")
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = Rabi(self.qubit, self.sched)
+        exp = Rabi([self.qubit], self.sched)
         self.assertRoundTripSerializable(exp, self.json_equiv)
 
 
@@ -119,7 +119,7 @@ class TestEFRabi(QiskitExperimentsTestCase):
 
         # Note that the backend is not sophisticated enough to simulate an e-f
         # transition so we run the test with a tiny frequency shift, still driving the e-g transition.
-        rabi = EFRabi(self.qubit, self.sched, backend=self.backend)
+        rabi = EFRabi([self.qubit], self.sched, backend=self.backend)
         rabi.set_experiment_options(amplitudes=np.linspace(-0.1, 0.1, 11))
         expdata = rabi.run()
         self.assertExperimentDone(expdata)
@@ -178,7 +178,7 @@ class TestRabiCircuits(QiskitExperimentsTestCase):
 
     def test_default_schedule(self):
         """Test the default schedule."""
-        rabi = Rabi(2, self.sched)
+        rabi = Rabi([2], self.sched)
         rabi.set_experiment_options(amplitudes=[0.5])
         circs = rabi.circuits()
 
@@ -196,7 +196,7 @@ class TestRabiCircuits(QiskitExperimentsTestCase):
             pulse.play(pulse.Drag(160, amp, 40, 10), pulse.DriveChannel(2))
             pulse.play(pulse.Drag(160, amp, 40, 10), pulse.DriveChannel(2))
 
-        rabi = Rabi(2, self.sched)
+        rabi = Rabi([2], self.sched)
         rabi.set_experiment_options(schedule=my_schedule, amplitudes=[0.5])
         circs = rabi.circuits()
 

--- a/test/library/calibration/test_rabi.py
+++ b/test/library/calibration/test_rabi.py
@@ -291,7 +291,7 @@ class TestCompositeExperiment(QiskitExperimentsTestCase):
             with pulse.build() as sched:
                 pulse.play(pulse.Gaussian(160, Parameter("amp"), 40), pulse.DriveChannel(qubit))
 
-            experiments.append(Rabi(qubit, sched, amplitudes=[0.5]))
+            experiments.append(Rabi([qubit], sched, amplitudes=[0.5]))
 
         par_exp = ParallelExperiment(experiments)
         par_circ = par_exp.circuits()[0]

--- a/test/library/calibration/test_ramsey_xy.py
+++ b/test/library/calibration/test_ramsey_xy.py
@@ -47,7 +47,7 @@ class TestRamseyXY(QiskitExperimentsTestCase):
         abs_tol = max(1e3, abs(freq_shift) * test_tol)
 
         exp_helper = RamseyXYHelper()
-        ramsey = RamseyXY(0)
+        ramsey = RamseyXY([0])
         ramsey.backend = MockIQBackend(exp_helper)
 
         exp_helper.freq_shift = freq_shift
@@ -75,7 +75,7 @@ class TestRamseyXY(QiskitExperimentsTestCase):
 
         # oscillation with 6 MHz
         backend = MockIQBackend(RamseyXYHelper(freq_shift=freq_shift + osc_shift))
-        expdata = FrequencyCal(0, self.cals, backend, osc_freq=osc_shift).run()
+        expdata = FrequencyCal([0], self.cals, backend, osc_freq=osc_shift).run()
         self.assertExperimentDone(expdata)
 
         # Check that qubit frequency after running the cal is shifted by freq_shift, i.e. 4 MHz.
@@ -98,7 +98,7 @@ class TestRamseyXY(QiskitExperimentsTestCase):
             def _run_analysis(self, experiment_data):
                 return ([], [])
 
-        expt = FrequencyCal(0, self.cals, backend, auto_update=True)
+        expt = FrequencyCal([0], self.cals, backend, auto_update=True)
         expt.analysis = NoResults()
         expdata = expt.run()
         expdata.block_for_results(timeout=3)
@@ -106,19 +106,19 @@ class TestRamseyXY(QiskitExperimentsTestCase):
 
     def test_ramseyxy_experiment_config(self):
         """Test RamseyXY config roundtrips"""
-        exp = RamseyXY(0)
+        exp = RamseyXY([0])
         loaded_exp = RamseyXY.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_ramseyxy_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = RamseyXY(0)
+        exp = RamseyXY([0])
         self.assertRoundTripSerializable(exp, self.json_equiv)
 
     def test_cal_experiment_config(self):
         """Test FrequencyCal config roundtrips"""
-        exp = FrequencyCal(0, self.cals)
+        exp = FrequencyCal([0], self.cals)
         loaded_exp = FrequencyCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))
@@ -126,5 +126,5 @@ class TestRamseyXY(QiskitExperimentsTestCase):
     @unittest.skip("Cal experiments are not yet JSON serializable")
     def test_freqcal_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = FrequencyCal(0, self.cals)
+        exp = FrequencyCal([0], self.cals)
         self.assertRoundTripSerializable(exp, self.json_equiv)

--- a/test/library/calibration/test_rough_amplitude.py
+++ b/test/library/calibration/test_rough_amplitude.py
@@ -39,7 +39,7 @@ class TestRoughAmpCal(QiskitExperimentsTestCase):
     def test_circuits(self):
         """Test the quantum circuits."""
         test_amps = [-0.5, 0, 0.5]
-        rabi = RoughXSXAmplitudeCal(0, self.cals, amplitudes=test_amps)
+        rabi = RoughXSXAmplitudeCal([0], self.cals, amplitudes=test_amps)
 
         circs = transpile(rabi.circuits(), self.backend, inst_map=self.cals.default_inst_map)
 
@@ -59,7 +59,7 @@ class TestRoughAmpCal(QiskitExperimentsTestCase):
         default_amp = 0.5 / self.backend.rabi_rate_01
 
         rabi = RoughXSXAmplitudeCal(
-            0, self.cals, amplitudes=np.linspace(-0.1, 0.1, 11), backend=self.backend
+            [0], self.cals, amplitudes=np.linspace(-0.1, 0.1, 11), backend=self.backend
         )
         expdata = rabi.run()
         self.assertExperimentDone(expdata)
@@ -71,7 +71,7 @@ class TestRoughAmpCal(QiskitExperimentsTestCase):
 
         self.cals.add_parameter_value(int(4 * 160 / 5), "duration", (), schedule="x")
         rabi = RoughXSXAmplitudeCal(
-            0, self.cals, amplitudes=np.linspace(-0.1, 0.1, 11), backend=self.backend
+            [0], self.cals, amplitudes=np.linspace(-0.1, 0.1, 11), backend=self.backend
         )
         expdata = rabi.run()
         self.assertExperimentDone(expdata)
@@ -85,7 +85,7 @@ class TestRoughAmpCal(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = RoughXSXAmplitudeCal(0, self.cals)
+        exp = RoughXSXAmplitudeCal([0], self.cals)
         config = exp.config()
         loaded_exp = RoughXSXAmplitudeCal.from_config(config)
         self.assertNotEqual(exp, loaded_exp)
@@ -125,7 +125,7 @@ class TestSpecializations(QiskitExperimentsTestCase):
         """Test that we get the expected circuits with calibrations for the EF experiment."""
 
         test_amps = [-0.5, 0, 0.5]
-        rabi_ef = EFRoughXSXAmplitudeCal(0, self.cals, amplitudes=test_amps)
+        rabi_ef = EFRoughXSXAmplitudeCal([0], self.cals, amplitudes=test_amps)
 
         circs = transpile(rabi_ef.circuits(), self.backend, inst_map=self.cals.default_inst_map)
 
@@ -152,7 +152,7 @@ class TestSpecializations(QiskitExperimentsTestCase):
         default_amp = 0.5 / self.backend.rabi_rate_12
 
         rabi_ef = EFRoughXSXAmplitudeCal(
-            0, self.cals, amplitudes=np.linspace(-0.1, 0.1, 11), backend=self.backend
+            [0], self.cals, amplitudes=np.linspace(-0.1, 0.1, 11), backend=self.backend
         )
         expdata = rabi_ef.run()
         self.assertExperimentDone(expdata)
@@ -166,7 +166,7 @@ class TestSpecializations(QiskitExperimentsTestCase):
 
         self.cals.add_parameter_value(int(4 * 160 / 5), "duration", 0, "x12")
         self.cals.add_parameter_value(int(4 * 160 / 5), "duration", 0, "sx12")
-        rabi_ef = EFRoughXSXAmplitudeCal(0, self.cals, amplitudes=np.linspace(-0.1, 0.1, 11))
+        rabi_ef = EFRoughXSXAmplitudeCal([0], self.cals, amplitudes=np.linspace(-0.1, 0.1, 11))
         expdata = rabi_ef.run(self.backend)
         self.assertExperimentDone(expdata)
 

--- a/test/library/calibration/test_rough_frequency.py
+++ b/test/library/calibration/test_rough_frequency.py
@@ -40,7 +40,7 @@ class TestRoughFrequency(QiskitExperimentsTestCase):
         absolute = False
 
         freq = RoughFrequencyCal(
-            qubit, cals, frequencies, auto_update=auto_update, absolute=absolute
+            [qubit], cals, frequencies, auto_update=auto_update, absolute=absolute
         )
 
         self.assertEqual(freq.physical_qubits, (qubit,))
@@ -63,7 +63,7 @@ class TestRoughFrequency(QiskitExperimentsTestCase):
 
         frequencies = np.linspace(freq01 - 10.0e6, freq01 + 10.0e6, 11)
 
-        spec = RoughFrequencyCal(0, cals, frequencies, backend=backend_5mhz)
+        spec = RoughFrequencyCal([0], cals, frequencies, backend=backend_5mhz)
         spec.set_experiment_options(amp=0.005)
         expdata = spec.run()
         self.assertExperimentDone(expdata)
@@ -76,7 +76,7 @@ class TestRoughFrequency(QiskitExperimentsTestCase):
         """Test converting to and from config works"""
         cals = Calibrations.from_backend(self.backend)
         frequencies = [1, 2, 3]
-        exp = RoughFrequencyCal(0, cals, frequencies)
+        exp = RoughFrequencyCal([0], cals, frequencies)
         loaded_exp = RoughFrequencyCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))

--- a/test/library/characterization/test_half_angle.py
+++ b/test/library/characterization/test_half_angle.py
@@ -36,7 +36,7 @@ class TestHalfAngle(QiskitExperimentsTestCase):
         backend = MockIQBackend(exp_helper)
         for error in [-0.05, -0.02, 0.02, 0.05]:
             exp_helper.error = error
-            hac = HalfAngle(0)
+            hac = HalfAngle([0])
             exp_data = hac.run(backend)
 
             self.assertExperimentDone(exp_data)
@@ -53,7 +53,7 @@ class TestHalfAngle(QiskitExperimentsTestCase):
         for inst in ["sx", "y"]:
             inst_map.add(inst, (qubit,), pulse.Schedule(name=inst))
 
-        hac = HalfAngle(qubit)
+        hac = HalfAngle([qubit])
         hac.set_transpile_options(inst_map=inst_map)
 
         # mimic what will happen in the experiment.
@@ -70,7 +70,7 @@ class TestHalfAngle(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = HalfAngle(1)
+        exp = HalfAngle([1])
         config = exp.config()
         loaded_exp = HalfAngle.from_config(config)
         self.assertNotEqual(exp, loaded_exp)

--- a/test/library/characterization/test_qubit_spectroscopy.py
+++ b/test/library/characterization/test_qubit_spectroscopy.py
@@ -46,7 +46,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         freq01 = backend.defaults().qubit_freq_est[qubit]
         frequencies = np.linspace(freq01 - 10.0e6, freq01 + 10.0e6, 21)
 
-        spec = QubitSpectroscopy(qubit, frequencies)
+        spec = QubitSpectroscopy([qubit], frequencies)
         spec.set_run_options(meas_level=MeasLevel.CLASSIFIED)
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
@@ -59,7 +59,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
 
         # Test if we find still find the peak when it is shifted by 5 MHz.
         exp_helper.freq_offset = 5.0e6
-        spec = QubitSpectroscopy(qubit, frequencies)
+        spec = QubitSpectroscopy([qubit], frequencies)
         spec.set_run_options(meas_level=MeasLevel.CLASSIFIED)
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
@@ -87,7 +87,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         freq01 = backend.defaults().qubit_freq_est[qubit]
         frequencies = np.linspace(freq01 - 10.0e6, freq01 + 10.0e6, 21)
 
-        spec = QubitSpectroscopy(qubit, frequencies)
+        spec = QubitSpectroscopy([qubit], frequencies)
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
         result = expdata.analysis_results(1)
@@ -99,7 +99,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         exp_helper.freq_offset = 5.0e6
         exp_helper.iq_cluster_centers = [((1.0, 1.0), (-1.0, -1.0))]
 
-        spec = QubitSpectroscopy(qubit, frequencies)
+        spec = QubitSpectroscopy([qubit], frequencies)
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
         result = expdata.analysis_results(1)
@@ -135,7 +135,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
 
         # Note that the backend is not sophisticated enough to simulate an e-f
         # transition so we run the test with g-e.
-        spec = EFSpectroscopy(qubit, frequencies)
+        spec = EFSpectroscopy([qubit], frequencies)
         spec.backend = backend
         spec.set_run_options(meas_level=MeasLevel.CLASSIFIED)
         expdata = spec.run(backend)
@@ -153,14 +153,14 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = QubitSpectroscopy(1, np.linspace(100, 150, 20) * 1e6)
+        exp = QubitSpectroscopy([1], np.linspace(100, 150, 20) * 1e6)
         loaded_exp = QubitSpectroscopy.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = QubitSpectroscopy(1, np.linspace(int(100e6), int(150e6), int(20e6)))
+        exp = QubitSpectroscopy([1], np.linspace(int(100e6), int(150e6), int(20e6)))
         # Checking serialization of the experiment
         self.assertRoundTripSerializable(exp, self.json_equiv)
 
@@ -180,7 +180,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         qubit = 1
         freq01 = backend.defaults().qubit_freq_est[qubit]
         frequencies = np.linspace(freq01 - 10.0e6, freq01 + 10.0e6, 21)
-        exp = QubitSpectroscopy(qubit, frequencies)
+        exp = QubitSpectroscopy([qubit], frequencies)
 
         exp.set_run_options(meas_level=MeasLevel.CLASSIFIED, shots=1024)
         expdata = exp.run(backend).block_for_results()
@@ -208,7 +208,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         qubit = 1
         freq01 = backend.defaults().qubit_freq_est[qubit]
         frequencies = np.linspace(freq01 - 10.0e6, freq01 + 10.0e6, 21)
-        exp = QubitSpectroscopy(qubit, frequencies)
+        exp = QubitSpectroscopy([qubit], frequencies)
 
         exp.set_run_options(meas_level=MeasLevel.KERNELED, shots=1024)
         expdata = exp.run(backend).block_for_results()
@@ -248,11 +248,11 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
 
         exp_list = [
             QubitSpectroscopy(
-                qubit1,
+                [qubit1],
                 frequencies1,
             ),
             QubitSpectroscopy(
-                qubit2,
+                [qubit2],
                 frequencies2,
             ),
         ]

--- a/test/library/characterization/test_resonator_spectroscopy.py
+++ b/test/library/characterization/test_resonator_spectroscopy.py
@@ -93,7 +93,7 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         res_freq = backend.defaults().meas_freq_est[qubit]
 
         frequencies = np.linspace(res_freq - 20e6, res_freq + 20e6, 51)
-        spec = ResonatorSpectroscopy(qubit, backend=backend, frequencies=frequencies)
+        spec = ResonatorSpectroscopy([qubit], backend=backend, frequencies=frequencies)
 
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
@@ -105,14 +105,14 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
-        exp = ResonatorSpectroscopy(1, frequencies=np.linspace(100, 150, 20) * 1e6)
+        exp = ResonatorSpectroscopy([1], frequencies=np.linspace(100, 150, 20) * 1e6)
         loaded_exp = ResonatorSpectroscopy.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
         self.assertTrue(self.json_equiv(exp, loaded_exp))
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
-        exp = ResonatorSpectroscopy(1, frequencies=np.linspace(int(100e6), int(150e6), int(20e6)))
+        exp = ResonatorSpectroscopy([1], frequencies=np.linspace(int(100e6), int(150e6), int(20e6)))
         self.assertRoundTripSerializable(exp, self.json_equiv)
 
     @data(-5e6, 0, 3e6)
@@ -132,7 +132,7 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         res_freq = backend.defaults().meas_freq_est[qubit]
 
         frequencies = np.linspace(res_freq - 20e6, res_freq + 20e6, 51)
-        exp = ResonatorSpectroscopy(qubit, backend=backend, frequencies=frequencies)
+        exp = ResonatorSpectroscopy([qubit], backend=backend, frequencies=frequencies)
 
         expdata = exp.run(backend).block_for_results()
         self.assertExperimentDone(expdata)
@@ -184,10 +184,10 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         frequencies2 = np.linspace(res_freq2 - 20e6, res_freq2 + 20e6, 53)
 
         res_spect1 = ResonatorSpectroscopy(
-            qubit1, backend=parallel_backend, frequencies=frequencies1
+            [qubit1], backend=parallel_backend, frequencies=frequencies1
         )
         res_spect2 = ResonatorSpectroscopy(
-            qubit2, backend=parallel_backend, frequencies=frequencies2
+            [qubit2], backend=parallel_backend, frequencies=frequencies2
         )
 
         exp_list = [res_spect1, res_spect2]
@@ -234,12 +234,12 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         # Create resonator spectroscopy experiments. We only use 3 frequencies to reduce the number of
         # circuits to check.
         res_spec_no_initial = ResonatorSpectroscopy(
-            0,
+            [0],
             backend=backend,
             frequencies=[5e9, 5.05e9, 5.1e9],
         )
         res_spec_initial = ResonatorSpectroscopy(
-            0,
+            [0],
             backend=backend,
             frequencies=[5e9, 5.05e9, 5.1e9],
         )
@@ -298,7 +298,7 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         )
         backend._configuration.timing_constraints = {"granularity": 16}
 
-        res_spec = ResonatorSpectroscopy(0, backend)
+        res_spec = ResonatorSpectroscopy([0], backend)
         try:
             res_spec.set_experiment_options(initial_circuit=circuit)
         except QiskitError as exp_exception:
@@ -320,7 +320,7 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         )
         backend._configuration.timing_constraints = {"granularity": 16}
 
-        res_spec = ResonatorSpectroscopy(0, backend)
+        res_spec = ResonatorSpectroscopy([0], backend)
         with self.assertRaises(
             QiskitError,
             msg=f"Setting initial circuit to invalid '{circuit_label}' did not fail with exception.",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR completes the work started in #1031 to address #1000 by replacing all usage of `qubits` or `qubit` in the `__init__` of `BaseExperiment` subclasses with `physical_qubits`.

### Details and comments

All remaining experiment classes were updated following #1031's example, using deprecation warnings for the old argument form. All tests were also updated. As a sanity check, I ran the old version of the tests with deprecation warnings allowed and confirmed that the tests still passed. Usage in docstrings was also updated (harder to test for anything was missed) but usage in other docs was left for #983.

I also made some wording changes to the deprecation messages and updated `BaseExperiment` itself.

@coruscating Just checking -- the removal of support for the `qubit` argument is in 0.6? The other deprecated code in the repo is for after 0.6 (the plotting changes). So right after 0.5 releases soon, we can pull all the deprecations out of `main`?
