### PR TITLE
Tests for deprecating arguments and `physical_qubits` changes

### DIFF
--- a/qiskit_experiments/library/characterization/zz_ramsey.py
+++ b/qiskit_experiments/library/characterization/zz_ramsey.py
@@ -13,7 +13,7 @@
 ZZ Ramsey experiment
 """
 
-from typing import List, Tuple, Union, Sequence
+from typing import List, Tuple, Union
 
 import numpy as np
 
@@ -130,7 +130,7 @@ class ZZRamsey(BaseExperiment):
     @deprecate_arguments({"qubits": "physical_qubits"}, "0.5")
     def __init__(
         self,
-        physical_qubits: Sequence[int, int],
+        physical_qubits: Tuple[int, int],
         backend: Union[Backend, None] = None,
         **experiment_options,
     ):

--- a/qiskit_experiments/library/characterization/zz_ramsey.py
+++ b/qiskit_experiments/library/characterization/zz_ramsey.py
@@ -13,7 +13,7 @@
 ZZ Ramsey experiment
 """
 
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Sequence
 
 import numpy as np
 
@@ -127,10 +127,10 @@ class ZZRamsey(BaseExperiment):
         :py:class:`ZZRamseyAnalysis`
     """
 
-    @deprecate_arguments({"qubit": "physical_qubits"}, "0.5")
+    @deprecate_arguments({"qubits": "physical_qubits"}, "0.5")
     def __init__(
         self,
-        physical_qubits: (int, int),
+        physical_qubits: Sequence[int, int],
         backend: Union[Backend, None] = None,
         **experiment_options,
     ):

--- a/qiskit_experiments/library/tomography/qpt_experiment.py
+++ b/qiskit_experiments/library/tomography/qpt_experiment.py
@@ -19,6 +19,8 @@ from qiskit.circuit import QuantumCircuit, Instruction
 from qiskit.providers.backend import Backend
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.quantum_info import Choi, Operator, Statevector, DensityMatrix, partial_trace
+
+from qiskit_experiments.warnings import deprecate_arguments
 from qiskit_experiments.exceptions import QiskitError
 from .tomography_experiment import TomographyExperiment, TomographyAnalysis, BaseAnalysis
 from .qpt_analysis import ProcessTomographyAnalysis
@@ -50,6 +52,7 @@ class ProcessTomography(TomographyExperiment):
 
     """
 
+    @deprecate_arguments({"qubits": "physical_qubits"}, "0.5")
     def __init__(
         self,
         circuit: Union[QuantumCircuit, Instruction, BaseOperator],
@@ -62,7 +65,6 @@ class ProcessTomography(TomographyExperiment):
         preparation_indices: Optional[Sequence[int]] = None,
         preparation_qubits: Optional[Sequence[int]] = None,
         basis_indices: Optional[Iterable[Tuple[List[int], List[int]]]] = None,
-        qubits: Optional[Sequence[int]] = None,
         analysis: Union[BaseAnalysis, None, str] = "default",
         target: Union[Statevector, DensityMatrix, None, str] = "default",
     ):
@@ -91,7 +93,6 @@ class ProcessTomography(TomographyExperiment):
                 preparation basis index, and ``m[i]`` is the measurement basis index
                 for qubit-i. If not specified full tomography for all indices of the
                 preparation and measurement bases will be performed.
-            qubits: DEPRECATED, the physical qubits for the initial state circuit.
             analysis: Optional, a custom analysis instance to use. If ``"default"``
                 :class:`~.ProcessTomographyAnalysis` will be used. If None no analysis
                 instance will be set.
@@ -114,7 +115,6 @@ class ProcessTomography(TomographyExperiment):
             preparation_indices=preparation_indices,
             preparation_qubits=preparation_qubits,
             basis_indices=basis_indices,
-            qubits=qubits,
             analysis=analysis,
         )
 

--- a/qiskit_experiments/library/tomography/qst_experiment.py
+++ b/qiskit_experiments/library/tomography/qst_experiment.py
@@ -18,6 +18,8 @@ from qiskit.providers.backend import Backend
 from qiskit.circuit import QuantumCircuit, Instruction
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.quantum_info import Statevector, DensityMatrix, partial_trace
+
+from qiskit_experiments.warnings import deprecate_arguments
 from qiskit_experiments.exceptions import QiskitError
 from .tomography_experiment import TomographyExperiment, TomographyAnalysis, BaseAnalysis
 from .qst_analysis import StateTomographyAnalysis
@@ -48,6 +50,7 @@ class StateTomography(TomographyExperiment):
 
     """
 
+    @deprecate_arguments({"qubits": "physical_qubits"}, "0.5")
     def __init__(
         self,
         circuit: Union[QuantumCircuit, Instruction, BaseOperator, Statevector],
@@ -57,7 +60,6 @@ class StateTomography(TomographyExperiment):
         measurement_indices: Optional[Sequence[int]] = None,
         measurement_qubits: Optional[Sequence[int]] = None,
         basis_indices: Optional[Iterable[List[int]]] = None,
-        qubits: Optional[Sequence[int]] = None,
         analysis: Union[BaseAnalysis, None, str] = "default",
         target: Union[Statevector, DensityMatrix, None, str] = "default",
     ):
@@ -79,7 +81,6 @@ class StateTomography(TomographyExperiment):
                 measurement basis configurations ``[m[0], m[1], ...]`` where ``m[i]``
                 is the measurement basis index for qubit-i. If not specified full
                 tomography for all indices of the measurement basis will be performed.
-            qubits: DEPRECATED, the physical qubits for the initial state circuit.
             analysis: Optional, a custom analysis instance to use. If ``"default"``
                 :class:`~.StateTomographyAnalysis` will be used. If None no analysis
                 instance will be set.
@@ -109,7 +110,6 @@ class StateTomography(TomographyExperiment):
             measurement_indices=measurement_indices,
             measurement_qubits=measurement_qubits,
             basis_indices=basis_indices,
-            qubits=qubits,
             analysis=analysis,
         )
 

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -20,6 +20,8 @@ from qiskit.circuit import QuantumCircuit, Instruction, ClassicalRegister
 from qiskit.circuit.library import Permutation
 from qiskit.providers.backend import Backend
 from qiskit.quantum_info.operators.base_operator import BaseOperator
+
+from qiskit_experiments.warnings import deprecate_arguments
 from qiskit_experiments.exceptions import QiskitError
 from qiskit_experiments.framework import BaseExperiment, BaseAnalysis, Options
 from .basis import PreparationBasis, MeasurementBasis
@@ -51,6 +53,7 @@ class TomographyExperiment(BaseExperiment):
 
         return options
 
+    @deprecate_arguments({"qubits": "physical_qubits"}, "0.5")
     def __init__(
         self,
         circuit: Union[QuantumCircuit, Instruction, BaseOperator],
@@ -63,7 +66,6 @@ class TomographyExperiment(BaseExperiment):
         preparation_indices: Optional[Sequence[int]] = None,
         preparation_qubits: Optional[Sequence[int]] = None,
         basis_indices: Optional[Iterable[Tuple[List[int], List[int]]]] = None,
-        qubits: Optional[Sequence[int]] = None,
         analysis: Union[BaseAnalysis, None, str] = "default",
     ):
         """Initialize a tomography experiment.
@@ -88,7 +90,6 @@ class TomographyExperiment(BaseExperiment):
             preparation_qubits: DEPRECATED, equivalent to preparation_indices.
             basis_indices: Optional, the basis elements to be measured. If None
                 All basis elements will be measured.
-            qubits: DEPRECATED, the physical qubits for the initial state circuit.
             analysis: Optional, a custom analysis instance to use. If ``"default"``
                 :class:`~.TomographyAnalysis` will be used. If None no analysis
                 instance will be set.
@@ -96,15 +97,6 @@ class TomographyExperiment(BaseExperiment):
         Raises:
             QiskitError: if input params are invalid.
         """
-        # Deprecated kwargs
-        if qubits is not None:
-            physical_qubits = qubits
-            warnings.warn(
-                "The `qubits` kwarg has been renamed to `physical_qubits`."
-                " It will be removed in a future release.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         if measurement_qubits is not None:
             measurement_indices = measurement_qubits
             warnings.warn(

--- a/qiskit_experiments/warnings.py
+++ b/qiskit_experiments/warnings.py
@@ -191,11 +191,11 @@ def _rename_kwargs(func_name, kwargs, kwarg_map, last_version, msg, stacklevel):
             if msg:
                 message += msg
 
-            warnings.warn(message, stacklevel=stacklevel)
+            warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)
 
 
 def qubit_deprecate() -> Callable:
-    """Decorator to deprecate from qubit to physcial_qubits"""
+    """Decorator to deprecate from qubit to physical_qubits"""
 
     def decorator(func):
         @functools.wraps(func)
@@ -233,7 +233,6 @@ def qubit_deprecate() -> Callable:
                     category=category,
                     stacklevel=3,
                 )
-
                 kwargs["physical_qubits"] = [kwargs.pop("qubit")]
 
             return func(*args, **kwargs)

--- a/test/framework/test_warnings.py
+++ b/test/framework/test_warnings.py
@@ -71,7 +71,7 @@ class TestWarningsHelper(QiskitExperimentsTestCase):
             instance = OldExperiment(qubits=[0], physical_qubits=[0])
         with self.assertWarns(DeprecationWarning):
             instance = OldExperiment(qubits=[0])
-        self.assertEquals(instance._physical_qubits, (0,))
+        self.assertEqual(instance._physical_qubits, (0,))
 
     def test_deprecated_qubit(self):
         """Test for the temporary qubit_deprecate wrapper."""

--- a/test/framework/test_warnings.py
+++ b/test/framework/test_warnings.py
@@ -56,7 +56,7 @@ class TestWarningsHelper(QiskitExperimentsTestCase):
 
         self.assertIsInstance(instance, NewExperiment)
 
-    def test_deprecated_qubits(self):
+    def test_deprecated_argument(self):
         """Test that deprecating arguments works as expected."""
 
         class OldExperiment(TempExperiment):

--- a/test/framework/test_warnings.py
+++ b/test/framework/test_warnings.py
@@ -17,6 +17,18 @@ from test.base import QiskitExperimentsTestCase
 
 from qiskit_experiments.framework import BaseExperiment
 from qiskit_experiments.warnings import deprecated_class
+from qiskit_experiments.warnings import deprecate_arguments
+from qiskit_experiments.warnings import qubit_deprecate
+
+
+class TempExperiment(BaseExperiment):
+    """Fake experiment."""
+
+    def __init__(self, physical_qubits):
+        super().__init__(physical_qubits)
+
+    def circuits(self):
+        pass
 
 
 class TestWarningsHelper(QiskitExperimentsTestCase):
@@ -26,15 +38,6 @@ class TestWarningsHelper(QiskitExperimentsTestCase):
         """Test old class is instantiated as a new class instance."""
 
         # Here we assume we want to rename class but want to have deprecation period
-        class TempExperiment(BaseExperiment):
-            """Fake experiment."""
-
-            def __init__(self, qubits):
-                super().__init__(qubits)
-
-            def circuits(self):
-                pass
-
         class NewExperiment(TempExperiment):
             """Experiment to be renamed."""
 
@@ -52,3 +55,34 @@ class TestWarningsHelper(QiskitExperimentsTestCase):
             instance = OldExperiment([0])
 
         self.assertIsInstance(instance, NewExperiment)
+
+    def test_deprecated_qubits(self):
+        """Test that deprecating arguments works as expected."""
+
+        class OldExperiment(TempExperiment):
+            """Original experiment."""
+
+            @deprecate_arguments({"qubits": "physical_qubits"})
+            def __init__(self, physical_qubits):
+                super().__init__(physical_qubits)
+
+        # Test that providing both old and new kwargs throws an error
+        with self.assertRaises(TypeError):
+            instance = OldExperiment(qubits=[0], physical_qubits=[0])
+        with self.assertWarns(DeprecationWarning):
+            instance = OldExperiment(qubits=[0])
+        self.assertEquals(instance._physical_qubits, (0,))
+
+    def test_deprecated_qubit(self):
+        """Test for the temporary qubit_deprecate wrapper."""
+
+        class OldExperiment(TempExperiment):
+            """Original experiment."""
+
+            @qubit_deprecate()
+            def __init__(self, physical_qubits):
+                super().__init__(physical_qubits)
+
+        with self.assertWarns(DeprecationWarning):
+            instance = OldExperiment(qubit=0)
+        self.assertEqual(instance._physical_qubits, (0,))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Added two tests for the `deprecate_arguments` wrapper and the temporary `qubit_deprecate` wrapper. Also replaced the tomography `qubits` deprecations with the wrapper. These should be the last deprecation changes needed for the experiments themselves (unless I missed something).


