### PR TITLE
Remove workaround from #1001 for Python 3.11.1

### DIFF
--- a/test/base.py
+++ b/test/base.py
@@ -19,20 +19,6 @@ import pickle
 import warnings
 from typing import Any, Callable, Optional
 
-# Temporary work around for https://github.com/Qiskit/qiskit-terra/issues/9291
-# The class decorator / method wrapper in qiskit does not handle
-# __init_subclass__ properly. Python 3.11.1 added an __init_subclass__ to
-# TestCase. It's not that important so as a temporary hack we just drop it.
-from unittest import TestCase
-
-if "__init_subclass__" in TestCase.__dict__:
-    del TestCase.__init_subclass__
-if not hasattr(TestCase, "_test_cleanups"):
-    TestCase._test_cleanups = []
-if not hasattr(TestCase, "_classSetupFailed"):
-    TestCase._classSetupFailed = False
-# pylint: disable=wrong-import-position
-
 import numpy as np
 import uncertainties
 from lmfit import Model


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR removes a workaround that was added to the tests in #1001 to deal with a technical issue (https://github.com/Qiskit/qiskit-terra/issues/9291, fixed in qiskit-terra 0.22.4) that prevented the tests from running in Python 3.11.1.

### Details and comments

Closes #1002

