### PR TITLE
Composite experiments `qubits` deprecation

### DIFF
--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -17,6 +17,7 @@ from typing import List, Sequence, Optional, Union
 from abc import abstractmethod
 import warnings
 from qiskit.providers.backend import Backend
+from qiskit_experiments.warnings import deprecate_arguments
 from qiskit_experiments.exceptions import QiskitError
 from qiskit_experiments.framework import BaseExperiment
 from .composite_analysis import CompositeAnalysis
@@ -25,10 +26,11 @@ from .composite_analysis import CompositeAnalysis
 class CompositeExperiment(BaseExperiment):
     """Composite Experiment base class"""
 
+    @deprecate_arguments({"qubits": "physical_qubits"}, "0.5")
     def __init__(
         self,
         experiments: List[BaseExperiment],
-        qubits: Sequence[int],
+        physical_qubits: Sequence[int],
         backend: Optional[Backend] = None,
         experiment_type: Optional[str] = None,
         flatten_results: bool = False,
@@ -38,7 +40,7 @@ class CompositeExperiment(BaseExperiment):
 
         Args:
             experiments: a list of experiment objects.
-            qubits: list of physical qubits for the experiment.
+            physical_qubits: list of physical qubits for the experiment.
             backend: Optional, the backend to run the experiment on.
             experiment_type: Optional, composite experiment subclass name.
             flatten_results: If True flatten all component experiment results
@@ -62,7 +64,7 @@ class CompositeExperiment(BaseExperiment):
                 [exp.analysis for exp in self._experiments], flatten_results=flatten_results
             )
         super().__init__(
-            qubits,
+            physical_qubits,
             analysis=analysis,
             backend=backend,
             experiment_type=experiment_type,

--- a/qiskit_experiments/library/characterization/local_readout_error.py
+++ b/qiskit_experiments/library/characterization/local_readout_error.py
@@ -79,7 +79,6 @@ class LocalReadoutError(BaseExperiment):
                 for readout error. If None all qubits on the provided backend
                 will be characterized.
             backend: Optional, the backend to characterize.
-            qubits: DEPRECATED, equivalent to ``physical_qubits``.
 
         Raises:
             QiskitError: if args are not valid.

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -742,9 +742,11 @@ class TestBatchTranspileOptions(QiskitExperimentsTestCase):
         transpiled circuit) to a coupling map with distance 3 between qubits 0 and 3.
         """
 
-        def __init__(self, qubits, backend=None):
+        def __init__(self, physical_qubits, backend=None):
             super().__init__(
-                qubits, analysis=TestBatchTranspileOptions.SimpleAnalysis(), backend=backend
+                physical_qubits,
+                analysis=TestBatchTranspileOptions.SimpleAnalysis(),
+                backend=backend,
             )
 
         def circuits(self):


### PR DESCRIPTION
Composite experiments were left out of the `qubits` to `physical_qubits` change, which is fixed in this PR.