### PR TITLE
Convert characterization experiments to use BackendTiming

### DIFF
--- a/qiskit_experiments/library/characterization/ramsey_xy.py
+++ b/qiskit_experiments/library/characterization/ramsey_xy.py
@@ -20,7 +20,7 @@ from qiskit.circuit import Parameter
 from qiskit.providers.backend import Backend
 from qiskit.qobj.utils import MeasLevel
 
-from qiskit_experiments.framework import BaseExperiment
+from qiskit_experiments.framework import BackendTiming, BaseExperiment
 from qiskit_experiments.framework.restless_mixin import RestlessMixin
 from qiskit_experiments.library.characterization.analysis import RamseyXYAnalysis
 from qiskit_experiments.warnings import qubit_deprecate
@@ -124,14 +124,6 @@ class RamseyXY(BaseExperiment, RestlessMixin):
             delays = self.experiment_options.delays
         self.set_experiment_options(delays=delays, osc_freq=osc_freq)
 
-    def _set_backend(self, backend: Backend):
-        super()._set_backend(backend)
-
-        # Scheduling parameters
-        if not self._backend_data.is_simulator:
-            scheduling_method = getattr(self.transpile_options, "scheduling_method", "alap")
-            self.set_transpile_options(scheduling_method=scheduling_method)
-
     def _pre_circuit(self) -> QuantumCircuit:
         """Return a preparation circuit.
 
@@ -146,17 +138,14 @@ class RamseyXY(BaseExperiment, RestlessMixin):
         Returns:
             A list of circuits with a variable delay.
         """
-        dt_unit = False
-        if self.backend:
-            dt_factor = self._backend_data.dt
-            dt_unit = dt_factor is not None
+        timing = BackendTiming(self.backend)
 
-        # Compute the rz rotation angle to add a modulation.
-        p_delay_sec = Parameter("delay_sec")
-        if dt_unit:
-            p_delay_dt = Parameter("delay_dt")
+        p_delay = Parameter("delay")
 
-        rotation_angle = 2 * np.pi * self.experiment_options.osc_freq * p_delay_sec
+        rotation_angle = 2 * np.pi * self.experiment_options.osc_freq * p_delay
+
+        if timing.delay_unit == "dt":
+            rotation_angle = rotation_angle * timing.dt
 
         # Create the X and Y circuits.
         metadata = {
@@ -168,12 +157,7 @@ class RamseyXY(BaseExperiment, RestlessMixin):
 
         ram_x = self._pre_circuit()
         ram_x.sx(0)
-
-        if dt_unit:
-            ram_x.delay(p_delay_dt, 0, "dt")
-        else:
-            ram_x.delay(p_delay_sec, 0, "s")
-
+        ram_x.delay(p_delay, 0, timing.delay_unit)
         ram_x.rz(rotation_angle, 0)
         ram_x.sx(0)
         ram_x.measure_active()
@@ -181,12 +165,7 @@ class RamseyXY(BaseExperiment, RestlessMixin):
 
         ram_y = self._pre_circuit()
         ram_y.sx(0)
-
-        if dt_unit:
-            ram_y.delay(p_delay_dt, 0, "dt")
-        else:
-            ram_y.delay(p_delay_sec, 0, "s")
-
+        ram_y.delay(p_delay, 0, timing.delay_unit)
         ram_y.rz(rotation_angle - np.pi / 2, 0)
         ram_y.sx(0)
         ram_y.measure_active()
@@ -194,37 +173,17 @@ class RamseyXY(BaseExperiment, RestlessMixin):
 
         circs = []
         for delay in self.experiment_options.delays:
-            if dt_unit:
-                delay_dt = round(delay / dt_factor)
-                real_delay_in_sec = delay_dt * dt_factor
-            else:
-                real_delay_in_sec = delay
-
-            # create ramsey x
-            if dt_unit:
-                assigned_x = ram_x.assign_parameters(
-                    {p_delay_sec: real_delay_in_sec, p_delay_dt: delay_dt}, inplace=False
-                )
-            else:
-                assigned_x = ram_x.assign_parameters(
-                    {p_delay_sec: real_delay_in_sec}, inplace=False
-                )
-
+            assigned_x = ram_x.assign_parameters(
+                {p_delay: timing.round_delay(time=delay)}, inplace=False
+            )
             assigned_x.metadata["series"] = "X"
-            assigned_x.metadata["xval"] = real_delay_in_sec
+            assigned_x.metadata["xval"] = timing.delay_time(time=delay)
 
-            # create ramsey y
-            if dt_unit:
-                assigned_y = ram_y.assign_parameters(
-                    {p_delay_sec: real_delay_in_sec, p_delay_dt: delay_dt}, inplace=False
-                )
-            else:
-                assigned_y = ram_y.assign_parameters(
-                    {p_delay_sec: real_delay_in_sec}, inplace=False
-                )
-
+            assigned_y = ram_y.assign_parameters(
+                {p_delay: timing.round_delay(time=delay)}, inplace=False
+            )
             assigned_y.metadata["series"] = "Y"
-            assigned_y.metadata["xval"] = real_delay_in_sec
+            assigned_y.metadata["xval"] = timing.delay_time(time=delay)
 
             circs.extend([assigned_x, assigned_y])
 

--- a/qiskit_experiments/library/characterization/spectroscopy.py
+++ b/qiskit_experiments/library/characterization/spectroscopy.py
@@ -99,16 +99,6 @@ class Spectroscopy(BaseExperiment, ABC):
 
         self.set_experiment_options(**experiment_options)
 
-    def _set_backend(self, backend: Backend):
-        """Set the backend for the experiment and extract config information."""
-        super()._set_backend(backend)
-
-        self._dt = self._backend_data.dt
-        self._granularity = self._backend_data.granularity
-
-        if self._dt is None or self._granularity is None:
-            raise QiskitError(f"{self.__class__.__name__} needs both dt and sample granularity.")
-
     @property
     @abstractmethod
     def _backend_center_frequency(self) -> float:

--- a/qiskit_experiments/library/characterization/t2hahn.py
+++ b/qiskit_experiments/library/characterization/t2hahn.py
@@ -128,7 +128,7 @@ class T2Hahn(BaseExperiment):
         timing = BackendTiming(self.backend)
 
         circuits = []
-        for delay_gate in np.asarray(self.experiment_options.delays, dtype=float):
+        for delay_gate in self.experiment_options.delays:
             circ = QuantumCircuit(1, 1)
 
             # First X rotation in 90 degrees

--- a/qiskit_experiments/library/characterization/t2hahn.py
+++ b/qiskit_experiments/library/characterization/t2hahn.py
@@ -129,12 +129,6 @@ class T2Hahn(BaseExperiment):
 
         circuits = []
         for delay_gate in np.asarray(self.experiment_options.delays, dtype=float):
-            num_delays = self.experiment_options.num_echoes + 1
-            # Equal delay is put before and after each echo, so each echo gets
-            # two delay gates. When there are multiple echoes, the total delay
-            # between echoes is 2 * single_delay, made up of two delay gates.
-            single_delay = delay_gate / num_delays / 2
-
             circ = QuantumCircuit(1, 1)
 
             # First X rotation in 90 degrees
@@ -144,11 +138,18 @@ class T2Hahn(BaseExperiment):
                 circ.delay(timing.round_delay(time=delay_gate), 0, timing.delay_unit)
                 total_delay = timing.delay_time(time=delay_gate)
             else:
+                num_echoes = self.experiment_options.num_echoes
+
+                # Equal delay is put before and after each echo, so each echo gets
+                # two delay gates. When there are multiple echoes, the total delay
+                # between echoes is 2 * single_delay, made up of two delay gates.
+                single_delay = delay_gate / num_echoes / 2
+
                 for _ in range(self.experiment_options.num_echoes):
                     circ.delay(timing.round_delay(time=single_delay), 0, timing.delay_unit)
                     circ.rx(np.pi, 0)
                     circ.delay(timing.round_delay(time=single_delay), 0, timing.delay_unit)
-                total_delay = timing.delay_time(time=single_delay) * num_delays * 2
+                total_delay = timing.delay_time(time=single_delay) * num_echoes * 2
 
             if self.experiment_options.num_echoes % 2 == 1:
                 circ.rx(np.pi / 2, 0)  # X90 again since the num of echoes is odd

--- a/qiskit_experiments/library/characterization/t2ramsey.py
+++ b/qiskit_experiments/library/characterization/t2ramsey.py
@@ -21,7 +21,7 @@ import qiskit
 from qiskit import QuantumCircuit
 from qiskit.providers.backend import Backend
 
-from qiskit_experiments.framework import BaseExperiment, Options
+from qiskit_experiments.framework import BackendTiming, BaseExperiment, Options
 from qiskit_experiments.library.characterization.analysis.t2ramsey_analysis import T2RamseyAnalysis
 from qiskit_experiments.warnings import qubit_deprecate
 
@@ -97,14 +97,6 @@ class T2Ramsey(BaseExperiment):
         super().__init__(physical_qubits, analysis=T2RamseyAnalysis(), backend=backend)
         self.set_experiment_options(delays=delays, osc_freq=osc_freq)
 
-    def _set_backend(self, backend: Backend):
-        super()._set_backend(backend)
-
-        # Scheduling parameters
-        if not self._backend_data.is_simulator:
-            scheduling_method = getattr(self.transpile_options, "scheduling_method", "alap")
-            self.set_transpile_options(scheduling_method=scheduling_method)
-
     def circuits(self) -> List[QuantumCircuit]:
         """Return a list of experiment circuits.
 
@@ -114,27 +106,17 @@ class T2Ramsey(BaseExperiment):
         Returns:
             The experiment circuits
         """
-        dt_unit = False
-        if self.backend:
-            dt_factor = self._backend_data.dt
-            dt_unit = dt_factor is not None
+        timing = BackendTiming(self.backend)
 
         circuits = []
         for delay in self.experiment_options.delays:
-            if dt_unit:
-                delay_dt = round(delay / dt_factor)
-                real_delay_in_sec = delay_dt * dt_factor
-            else:
-                real_delay_in_sec = delay
-
-            rotation_angle = 2 * np.pi * self.experiment_options.osc_freq * real_delay_in_sec
+            rotation_angle = (
+                2 * np.pi * self.experiment_options.osc_freq * timing.delay_time(time=delay)
+            )
 
             circ = qiskit.QuantumCircuit(1, 1)
             circ.sx(0)  # Brings the qubit to the X Axis
-            if dt_unit:
-                circ.delay(delay_dt, 0, "dt")
-            else:
-                circ.delay(delay, 0, "s")
+            circ.delay(timing.round_delay(time=delay), 0, timing.delay_unit)
             circ.rz(rotation_angle, 0)
             circ.barrier(0)
             circ.sx(0)
@@ -144,7 +126,7 @@ class T2Ramsey(BaseExperiment):
             circ.metadata = {
                 "experiment_type": self._type,
                 "qubit": self.physical_qubits[0],
-                "xval": real_delay_in_sec,
+                "xval": timing.delay_time(time=delay),
                 "osc_freq": self.experiment_options.osc_freq,
                 "unit": "s",
             }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR converts the remaining characterization experiments to use `BackendTiming` which was introducted in #860 and used in #782.

### Details and comments


