### PR TITLE
Adjust acquire_alignment access to avoid warning

### DIFF
--- a/test/framework/test_backend_timing.py
+++ b/test/framework/test_backend_timing.py
@@ -18,7 +18,7 @@ from ddt import data, ddt, unpack
 from qiskit import QiskitError
 from qiskit.providers.fake_provider import FakeNairobiV2
 
-from qiskit_experiments.framework import BackendTiming
+from qiskit_experiments.framework import BackendData, BackendTiming
 
 
 @ddt
@@ -33,11 +33,13 @@ class TestBackendTiming(QiskitExperimentsTestCase):
         # terra. Just to be safe, we check that the properties we care about
         # for these tests are never changed from what the tests assume.
         backend = FakeNairobiV2()
+        # Using BackendData to handle acquire/aquire rename. Can replace with
+        # target.acquire_alignment when testing against terra >=0.24
+        backend_data = BackendData(backend)
         target = backend.target
-        acquire_alignment = getattr(target, "acquire_alignment", target.aquire_alignment)
         assumptions = (
             (abs(target.dt * 4.5e9 - 1) < 1e-6)
-            and acquire_alignment == 16
+            and backend_data.acquire_alignment == 16
             and target.pulse_alignment == 1
             and target.min_length == 64
             and target.granularity == 16
@@ -45,7 +47,7 @@ class TestBackendTiming(QiskitExperimentsTestCase):
         if not assumptions:  # pragma: no cover
             raise ValueError("FakeNairobiV2 properties have changed!")
 
-        cls.acquire_alignment = acquire_alignment
+        cls.acquire_alignment = backend_data.acquire_alignment
         cls.dt = target.dt
         cls.granularity = target.granularity
         cls.min_length = target.min_length


### PR DESCRIPTION
Accessing aquire_alignment triggers a deprecation warning with terra 0.24 which causes tests to fail.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR refactors a test to avoid referencing `Target.aquire_alignment` when `Target.acquire_alignment` is defined.

### Details and comments


https://github.com/Qiskit/qiskit-terra/pull/9473 deprecated `Target.aquire_alignment` for `Target.acquire_alignment`. Our tests fail if a deprecation warning is emitted. The test was already trying both spellings but it did so in a way that triggered the deprecation warning.
