### PR TITLE
Added cron tests against Terra main

### DIFF
--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -24,3 +24,44 @@ jobs:
         run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Run Tests
         run: tox -epy38 -- -n test/database_service/test_experiment_data_integration.py
+  terra-main-tests:
+    name: tests-python${{ matrix.python-version }}-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
+    steps:
+      - name: Print Concurrency Group
+        env:
+          CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+        run: |
+          echo -e "\033[31;1;4mConcurrency Group\033[0m"
+          echo -e "$CONCURRENCY_GROUP\n"
+        shell: bash
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Pip cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-
+            ${{ runner.os }}-${{ matrix.python-version }}
+      - name: Install Deps
+        run: |
+          python -m pip install -U tox setuptools virtualenv wheel
+          python -m pip install git+https://github.com/Qiskit/qiskit-terra.git@main
+      - name: Install and Run Tests
+        run: tox -e py
+        if: runner.os != 'macOS'
+      - name: Install and Run Tests
+        run: tox -e py
+        if: runner.os == 'macOS'
+        env:
+          OMP_NUM_THREADS: 1

--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -48,20 +48,18 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-${{ hashFiles('setup.py','requirements.txt','requirements-dev.txt','constraints.txt') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
-        run: |
-          python -m pip install -U tox setuptools virtualenv wheel
-          python -m pip install git+https://github.com/Qiskit/qiskit-terra.git@main
+        run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests
-        run: tox -e py
+        run: tox -e terra-main
         if: runner.os != 'macOS'
       - name: Install and Run Tests
-        run: tox -e py
+        run: tox -e terra-main
         if: runner.os == 'macOS'
         env:
           OMP_NUM_THREADS: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,9 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U tox setuptools virtualenv wheel
+        run: |
+          python -m pip install -U tox setuptools virtualenv wheel
+          python -m pip install git+https://github.com/Qiskit/qiskit-terra.git@main
       - name: Install and Run Tests
         run: tox -e py
         if: runner.os != 'macOS'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,9 +38,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
-        run: |
-          python -m pip install -U tox setuptools virtualenv wheel
-          python -m pip install git+https://github.com/Qiskit/qiskit-terra.git@main
+        run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests
         run: tox -e py
         if: runner.os != 'macOS'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-${{ hashFiles('setup.py','requirements.txt','requirements-dev.txt','constraints.txt') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-lint-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-lint-${{ hashFiles('setup.py','requirements.txt','requirements-dev.txt','constraints.txt') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.python-version }}-pip-lint-
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
@@ -85,7 +85,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-docs-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-docs-${{ hashFiles('setup.py','requirements.txt','requirements-dev.txt','constraints.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-docs-
             ${{ runner.os }}-pip-

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,25 @@ passenv =
   QISKIT_IBM_*
 commands = stestr run {posargs}
 
+[testenv:terra-main]
+usedevelop = True
+install_command = pip install -U {opts} {packages}
+setenv =
+  VIRTUAL_ENV={envdir}
+  QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
+deps =
+  git+https://github.com/Qiskit/qiskit-ibmq-provider
+  git+https://github.com/jupyter/jupyter-sphinx
+  git+https://github.com/Qiskit/qiskit-terra
+  -r{toxinidir}/requirements-dev.txt
+passenv =
+  OMP_NUM_THREADS
+  QISKIT_PARALLEL
+  RAYON_NUM_THREADS
+  QISKIT_IBM_*
+commands = stestr run {posargs}
+
+
 [testenv:lint]
 envdir = .tox/lint
 commands =
@@ -55,3 +74,5 @@ commands =
 
 [pycodestyle]
 max-line-length = 100
+
+


### PR DESCRIPTION
All of our current push and PR tests run against Terra stable, including Neko tests. These cron tests will run against Terra main nightly to let us know if there are any recent breaking changes that need to be addressed.