### PR TITLE
Fix bug in postprocess_fitter

### DIFF
--- a/qiskit_experiments/library/tomography/fitters/postprocess_fit.py
+++ b/qiskit_experiments/library/tomography/fitters/postprocess_fit.py
@@ -85,14 +85,14 @@ def postprocess_fitter(
         fit_traces.append(fit_trace)
         if (
             trace is not None
-            and not np.isclose(fit_trace, 0, atol=1e-10)
+            and not np.isclose(abs(fit_trace), 0, atol=1e-10)
             and not np.isclose(abs(fit_trace - trace), 0, atol=1e-10)
         ):
-            scale = trace / fit_trace
-            fit = fit * scale
-            eigvals = eigvals * scale
+            scaled_trace = trace / fit_trace
+            fit = fit * scaled_trace
+            eigvals = eigvals * scaled_trace
         else:
-            trace = fit_trace
+            scaled_trace = fit_trace
 
         # Convert class of value
         if qpt:
@@ -101,7 +101,7 @@ def postprocess_fitter(
             state = DensityMatrix(fit, dims=output_dims)
 
         metadata = {
-            "trace": trace,
+            "trace": scaled_trace,
             "eigvals": eigvals,
             "eigvecs": eigvecs,
             "raw_eigvals": raw_eigvals,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes bug in `postprocess_fitter` from #1021 

### Details and comments

Fixes bug where trace variable was getting overwritten in loop, leading to wrong trace in certain conditional cases if some components had zero trace. Adds additional tests to cover this case.
