### PR TITLE
Add `max_circuits` BaseExperiment option

### DIFF
--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -268,8 +268,17 @@ class BaseExperiment(ABC, StoreInitArgs):
 
     def _run_jobs(self, circuits: List[QuantumCircuit], **run_options) -> List[Job]:
         """Run circuits on backend as 1 or more jobs."""
+        # Get max circuits for job splitting
+        max_circuits_option = getattr(self.experiment_options, "max_circuits", None)
+        max_circuits_backend = self._backend_data.max_circuits
+        if max_circuits_option and max_circuits_backend:
+            max_circuits = min(max_circuits_option, max_circuits_backend)
+        elif max_circuits_option:
+            max_circuits = max_circuits_option
+        else:
+            max_circuits = max_circuits_backend
+
         # Run experiment jobs
-        max_circuits = self._backend_data.max_circuits
         if max_circuits and len(circuits) > max_circuits:
             # Split jobs for backends that have a maximum job size
             job_circuits = [
@@ -319,7 +328,7 @@ class BaseExperiment(ABC, StoreInitArgs):
         # that experiment and their default values. Only options listed
         # here can be modified later by the different methods for
         # setting options.
-        return Options()
+        return Options(max_circuits=None)
 
     @property
     def experiment_options(self) -> Options:

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -322,7 +322,12 @@ class BaseExperiment(ABC, StoreInitArgs):
 
     @classmethod
     def _default_experiment_options(cls) -> Options:
-        """Default kwarg options for experiment"""
+        """Default experiment options.
+
+        Experiment Options:
+            max_circuits (Optional[int]): The maximum number of circuits per job when
+                running an experiment on a backend.
+        """
         # Experiment subclasses should override this method to return
         # an `Options` object containing all the supported options for
         # that experiment and their default values. Only options listed

--- a/qiskit_experiments/test/fake_backend.py
+++ b/qiskit_experiments/test/fake_backend.py
@@ -26,23 +26,24 @@ class FakeBackend(BackendV1):
     Fake backend for test purposes only.
     """
 
-    def __init__(self, max_experiments=None):
-        configuration = QasmBackendConfiguration(
-            backend_name="fake_backend",
-            backend_version="0",
-            n_qubits=int(1e6),
-            basis_gates=[],
-            gates=[],
-            local=True,
-            simulator=True,
-            conditional=False,
-            open_pulse=False,
-            memory=False,
-            max_shots=int(1e6),
-            max_experiments=max_experiments,
-            coupling_map=None,
-        )
-        super().__init__(configuration)
+    def __init__(self, **config):
+        default_config = {
+            "backend_name": "fake_backend",
+            "backend_version": "0",
+            "n_qubits": int(1e6),
+            "basis_gates": [],
+            "gates": [],
+            "local": True,
+            "simulator": True,
+            "conditional": False,
+            "open_pulse": False,
+            "memory": False,
+            "max_shots": int(1e6),
+            "max_experiments": None,
+            "coupling_map": None,
+        }
+        default_config.update(**config)
+        super().__init__(QasmBackendConfiguration(**default_config))
 
     @classmethod
     def _default_options(cls):

--- a/qiskit_experiments/test/fake_service.py
+++ b/qiskit_experiments/test/fake_service.py
@@ -166,7 +166,7 @@ class FakeService:
                             "start_datetime": datetime(2022, 1, 1)
                             + timedelta(hours=len(self.exps)),
                             "figure_names": [],
-                            "backend": FakeBackend(backend_name),
+                            "backend": FakeBackend(backend_name=backend_name),
                         }
                     ],
                     columns=self.exps.columns,

--- a/releasenotes/notes/separate-jobs-686711fba530820d.yaml
+++ b/releasenotes/notes/separate-jobs-686711fba530820d.yaml
@@ -1,4 +1,12 @@
 ---
 features:
   - |
-    A new experiment option for batch experiments, called `separate_jobs`. If set to `True`, then circuits of different sub-experiments are routed to different jobs. Default value is `False`.
+    A new experiment option for batch experiments, called `separate_jobs`. If set
+    to `True`, then circuits of different sub-experiments are routed to different
+    jobs. Default value is `False`.
+  - |
+    Adds a `max_circuits` experiment option to :class:`~.BaseExperiment` to allow
+    specifying the max number of circuits per job when running an experiment.
+    If set to None (default), the max circuits per job is determined by the
+    backend. If both the option value and backend value are not None, the
+    miniminum of the two values will be used for job splitting.

--- a/test/fake_experiment.py
+++ b/test/fake_experiment.py
@@ -39,7 +39,9 @@ class FakeExperiment(BaseExperiment):
 
     @classmethod
     def _default_experiment_options(cls) -> Options:
-        return Options(dummyoption=None)
+        options = super()._default_experiment_options()
+        options.dummyoption = None
+        return options
 
     def __init__(self, qubits=None):
         """Initialise the fake experiment."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add a `BaseExperiment.experiment_options` value for `max_circuits` (default None) that allows a user to specify the max number of circuits per job for custom job splitting as discussed in #920 .

### Details and comments

If both an experiment and backend also specify a non-default `max_experiments` or `max_circuits` value the minimum of the two will be used, if only one of the experiment or backend specifies a non-default value it will be used.