### PR TITLE
Fix T2Hahn delays when backend has `dt` set

### DIFF
--- a/qiskit_experiments/library/characterization/t2hahn.py
+++ b/qiskit_experiments/library/characterization/t2hahn.py
@@ -168,7 +168,9 @@ class T2Hahn(BaseExperiment):
                 single_delay = timing.delay_time(time=delay / num_echoes / 2)
                 total_delay = single_delay * num_echoes * 2
 
-            assigned = template.assign_parameters({delay_param: single_delay}, inplace=False)
+            assigned = template.assign_parameters(
+                {delay_param: timing.round_delay(time=single_delay)}, inplace=False
+            )
             assigned.metadata["xval"] = total_delay
             circuits.append(assigned)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ reno>=3.4.0
 sphinx-panels
 nbsphinx
 arxiv
-ddt~=1.4.2
+ddt>=1.6.0
 qiskit-aer>=0.11.0
 pandas>=1.1.5
 cvxpy>=1.1.15

--- a/test/library/calibration/test_ramsey_xy.py
+++ b/test/library/calibration/test_ramsey_xy.py
@@ -15,8 +15,9 @@
 import unittest
 from test.base import QiskitExperimentsTestCase
 
-from ddt import ddt, data
+from ddt import ddt, data, named_data
 from qiskit.providers.fake_provider import FakeArmonkV2
+from qiskit_aer import AerSimulator
 
 from qiskit_experiments.calibration_management.calibrations import Calibrations
 from qiskit_experiments.calibration_management.basis_gate_library import FixedFrequencyTransmon
@@ -36,6 +37,18 @@ class TestRamseyXY(QiskitExperimentsTestCase):
 
         library = FixedFrequencyTransmon()
         self.cals = Calibrations.from_backend(FakeArmonkV2(), libraries=[library])
+
+    @named_data(
+        ["no_backend", None], ["fake_backend", FakeArmonkV2()], ["aer_backend", AerSimulator()]
+    )
+    def test_circuits(self, backend: str):
+        """Test circuit generation does not error"""
+        delays = [1e-6, 5e-6, 10e-6]
+        circs = RamseyXY([0], delays=delays, backend=backend).circuits()
+        # Deduplicate xvals
+        xvals = sorted({c.metadata["xval"] for c in circs})
+        for delay, xval in zip(delays, xvals):
+            self.assertAlmostEqual(delay, xval)
 
     @data(2e6, -3e6, 1e3, 0.0, 0.2e6, 0.3e6)
     def test_end_to_end(self, freq_shift: float):

--- a/test/library/characterization/test_t2hahn.py
+++ b/test/library/characterization/test_t2hahn.py
@@ -13,6 +13,8 @@
 Test T2Hahn experiment
 """
 
+from test.base import QiskitExperimentsTestCase
+
 import numpy as np
 from ddt import ddt, data, named_data, unpack
 
@@ -23,8 +25,6 @@ from qiskit_experiments.framework import ParallelExperiment
 from qiskit_experiments.library.characterization.t2hahn import T2Hahn
 from qiskit_experiments.library.characterization import T2HahnAnalysis
 from qiskit_experiments.test.t2hahn_backend import T2HahnBackend
-
-from test.base import QiskitExperimentsTestCase
 
 
 @ddt

--- a/test/library/characterization/test_t2hahn.py
+++ b/test/library/characterization/test_t2hahn.py
@@ -13,13 +13,18 @@
 Test T2Hahn experiment
 """
 
-from test.base import QiskitExperimentsTestCase
 import numpy as np
-from ddt import ddt, data, unpack
+from ddt import ddt, data, named_data, unpack
+
+from qiskit.providers.fake_provider import FakeVigoV2
+from qiskit_aer import AerSimulator
+
 from qiskit_experiments.framework import ParallelExperiment
 from qiskit_experiments.library.characterization.t2hahn import T2Hahn
 from qiskit_experiments.library.characterization import T2HahnAnalysis
 from qiskit_experiments.test.t2hahn_backend import T2HahnBackend
+
+from test.base import QiskitExperimentsTestCase
 
 
 @ddt
@@ -27,6 +32,16 @@ class TestT2Hahn(QiskitExperimentsTestCase):
     """Test T2Hahn experiment"""
 
     __tolerance__ = 0.1
+
+    @named_data(
+        ["no_backend", None], ["fake_backend", FakeVigoV2()], ["aer_backend", AerSimulator()]
+    )
+    def test_circuits(self, backend: str):
+        """Test circuit generation does not error"""
+        delays = [1e-6, 5e-6, 10e-6]
+        circs = T2Hahn([0], delays, backend=backend).circuits()
+        for delay, circ in zip(delays, circs):
+            self.assertAlmostEqual(delay, circ.metadata["xval"])
 
     @data([0], [1], [2])
     @unpack

--- a/test/library/characterization/test_t2ramsey.py
+++ b/test/library/characterization/test_t2ramsey.py
@@ -13,19 +13,35 @@
 """
 Test T2Ramsey experiment
 """
-from test.base import QiskitExperimentsTestCase
 import numpy as np
+from ddt import ddt, named_data
+
+from qiskit.providers.fake_provider import FakeVigoV2
+from qiskit_aer import AerSimulator
 
 from qiskit_experiments.framework import ParallelExperiment
 from qiskit_experiments.library import T2Ramsey
 from qiskit_experiments.library.characterization import T2RamseyAnalysis
 from qiskit_experiments.test.noisy_delay_aer_simulator import NoisyDelayAerBackend
 
+from test.base import QiskitExperimentsTestCase
 
+
+@ddt
 class TestT2Ramsey(QiskitExperimentsTestCase):
     """Test T2Ramsey experiment"""
 
     __tolerance__ = 0.1
+
+    @named_data(
+        ["no_backend", None], ["fake_backend", FakeVigoV2()], ["aer_backend", AerSimulator()]
+    )
+    def test_circuits(self, backend: str):
+        """Test circuit generation does not error"""
+        delays = [1e-6, 5e-6, 10e-6]
+        circs = T2Ramsey([0], delays, backend=backend).circuits()
+        for delay, circ in zip(delays, circs):
+            self.assertAlmostEqual(delay, circ.metadata["xval"])
 
     def test_t2ramsey_run_end2end(self):
         """

--- a/test/library/characterization/test_t2ramsey.py
+++ b/test/library/characterization/test_t2ramsey.py
@@ -13,6 +13,8 @@
 """
 Test T2Ramsey experiment
 """
+from test.base import QiskitExperimentsTestCase
+
 import numpy as np
 from ddt import ddt, named_data
 
@@ -23,8 +25,6 @@ from qiskit_experiments.framework import ParallelExperiment
 from qiskit_experiments.library import T2Ramsey
 from qiskit_experiments.library.characterization import T2RamseyAnalysis
 from qiskit_experiments.test.noisy_delay_aer_simulator import NoisyDelayAerBackend
-
-from test.base import QiskitExperimentsTestCase
 
 
 @ddt


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes a bug in T2Hahn that was introduced in #1045. `T2Hahn.circuits()` would raise an exception when the backend was set to an instance with a `dt` value set.

### Details and comments

The delay parameter in the circuit was being assigned the output of `BackendTiming.delay_time` which is always a value in seconds. As such, it had the correct units for the unit tests which used backends without `dt` set and so used delays in units of seconds. Instead, it should have been using `BackendTiming.round_delay` which returns samples when the backend has `dt` set and seconds otherwise.

This PR also adds a test to call `.circuits()` on T2Hahn and similar experiments with scanned delays with no backend set, AerSimulator set, and a fake V2 backend set to try to catch this kind of error. The test was modeled on a test already in test_t1.
