### PR TITLE
Fix barrier instructions in tomography experiments

### DIFF
--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -219,8 +219,7 @@ class TomographyExperiment(BaseExperiment):
             if prep_element:
                 # Add tomography preparation
                 prep_circ = self._prep_circ_basis.circuit(prep_element, self._prep_physical_qubits)
-                for qubit in self._prep_indices:
-                    circ.reset(qubit)
+                circ.reset(self._prep_indices)
                 circ.compose(prep_circ, self._prep_indices, inplace=True)
                 circ.barrier(*self._prep_indices)
 

--- a/qiskit_experiments/library/tomography/tomography_experiment.py
+++ b/qiskit_experiments/library/tomography/tomography_experiment.py
@@ -219,9 +219,10 @@ class TomographyExperiment(BaseExperiment):
             if prep_element:
                 # Add tomography preparation
                 prep_circ = self._prep_circ_basis.circuit(prep_element, self._prep_physical_qubits)
-                circ.reset(self._prep_indices)
+                for qubit in self._prep_indices:
+                    circ.reset(qubit)
                 circ.compose(prep_circ, self._prep_indices, inplace=True)
-                circ.barrier(self._prep_indices)
+                circ.barrier(*self._prep_indices)
 
             # Add target circuit
             # Have to use compose since circuit.to_instruction has a bug
@@ -231,7 +232,7 @@ class TomographyExperiment(BaseExperiment):
             # Add tomography measurement
             if meas_element:
                 meas_circ = self._meas_circ_basis.circuit(meas_element, self._meas_physical_qubits)
-                circ.barrier(self._meas_indices)
+                circ.barrier(*self._meas_indices)
                 circ.compose(meas_circ, self._meas_indices, meas_clbits, inplace=True)
 
             # Add metadata

--- a/releasenotes/notes/tomo-barriers-aae4aafedaca5c3d.yaml
+++ b/releasenotes/notes/tomo-barriers-aae4aafedaca5c3d.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fix qpy serialization and deserialization of tomography experiments. The
+    barrier instructions in tomography experiments were created with the wrong
+    Python type which qpy did not support. This issue was most acute when using
+    `qiskit-ibm-provider` which submits circuits to the provider using qpy.
+    There could have been subtler issues with circuit timing using a different
+    provider if the barriers were not separating important circuit
+    instructions. See `#1060 <https://github.com/Qiskit/qiskit-experiments/issues/1060>`_.


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix barrier instructions in tomography experiments

### Details and comments

`QuantumCircuit.barrier()` accepts many forms of input, but `tuple` is not one of them. The prep and measurement indices passed as tuples to the barrier method were causing qpy serialization/deserialization to fail. It is possible that there were other unnoticed consequences to the type of the barrier argument being incorrect.

Closes https://github.com/Qiskit/qiskit-experiments/issues/1060.

See also [this Slack thread](https://qiskit.slack.com/archives/CGZDF48EN/p1676934228659149).
