### PR TITLE
Delay scikit-learn import until first use

### DIFF
--- a/qiskit_experiments/data_processing/sklearn_discriminators.py
+++ b/qiskit_experiments/data_processing/sklearn_discriminators.py
@@ -12,20 +12,17 @@
 
 """Discriminators that wrap SKLearn."""
 
-from typing import Any, List, Dict
+from typing import Any, List, Dict, TYPE_CHECKING
 
 from qiskit_experiments.data_processing.discriminator import BaseDiscriminator
 from qiskit_experiments.data_processing.exceptions import DataProcessorError
+from qiskit_experiments.warnings import HAS_SKLEARN
 
-try:
+if TYPE_CHECKING:
     from sklearn.discriminant_analysis import (
         LinearDiscriminantAnalysis,
         QuadraticDiscriminantAnalysis,
     )
-
-    HAS_SKLEARN = True
-except ImportError:
-    HAS_SKLEARN = False
 
 
 class SkLDA(BaseDiscriminator):
@@ -40,11 +37,6 @@ class SkLDA(BaseDiscriminator):
         Raises:
             DataProcessorError: if SKlearn could not be imported.
         """
-        if not HAS_SKLEARN:
-            raise DataProcessorError(
-                f"SKlearn is needed to initialize an {self.__class__.__name__}."
-            )
-
         self._lda = lda
         self.attributes = [
             "coef_",
@@ -88,11 +80,10 @@ class SkLDA(BaseDiscriminator):
         return {"params": self._lda.get_params(), "attributes": attr_conf}
 
     @classmethod
+    @HAS_SKLEARN.require_in_call
     def from_config(cls, config: Dict[str, Any]) -> "SkLDA":
         """Deserialize from an object."""
-
-        if not HAS_SKLEARN:
-            raise DataProcessorError(f"SKlearn is needed to initialize an {cls.__name__}.")
+        from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 
         lda = LinearDiscriminantAnalysis()
         lda.set_params(**config["params"])
@@ -116,11 +107,6 @@ class SkQDA(BaseDiscriminator):
         Raises:
             DataProcessorError: if SKlearn could not be imported.
         """
-        if not HAS_SKLEARN:
-            raise DataProcessorError(
-                f"SKlearn is needed to initialize an {self.__class__.__name__}."
-            )
-
         self._qda = qda
         self.attributes = [
             "coef_",
@@ -165,11 +151,10 @@ class SkQDA(BaseDiscriminator):
         return {"params": self._qda.get_params(), "attributes": attr_conf}
 
     @classmethod
+    @HAS_SKLEARN.require_in_call
     def from_config(cls, config: Dict[str, Any]) -> "SkQDA":
         """Deserialize from an object."""
-
-        if not HAS_SKLEARN:
-            raise DataProcessorError(f"SKlearn is needed to initialize an {cls.__name__}.")
+        from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
 
         qda = QuadraticDiscriminantAnalysis()
         qda.set_params(**config["params"])

--- a/qiskit_experiments/data_processing/sklearn_discriminators.py
+++ b/qiskit_experiments/data_processing/sklearn_discriminators.py
@@ -15,7 +15,6 @@
 from typing import Any, List, Dict, TYPE_CHECKING
 
 from qiskit_experiments.data_processing.discriminator import BaseDiscriminator
-from qiskit_experiments.data_processing.exceptions import DataProcessorError
 from qiskit_experiments.warnings import HAS_SKLEARN
 
 if TYPE_CHECKING:

--- a/qiskit_experiments/data_processing/sklearn_discriminators.py
+++ b/qiskit_experiments/data_processing/sklearn_discriminators.py
@@ -25,7 +25,11 @@ if TYPE_CHECKING:
 
 
 class SkLDA(BaseDiscriminator):
-    """A wrapper for the SKlearn linear discriminant analysis."""
+    """A wrapper for the scikit-learn linear discriminant analysis.
+
+    .. note::
+        This class requires that scikit-learn is installed.
+    """
 
     def __init__(self, lda: "LinearDiscriminantAnalysis"):
         """
@@ -95,7 +99,11 @@ class SkLDA(BaseDiscriminator):
 
 
 class SkQDA(BaseDiscriminator):
-    """A wrapper for the SKlearn quadratic discriminant analysis."""
+    """A wrapper for the SKlearn quadratic discriminant analysis.
+
+    .. note::
+        This class requires that scikit-learn is installed.
+    """
 
     def __init__(self, qda: "QuadraticDiscriminantAnalysis"):
         """

--- a/qiskit_experiments/library/characterization/analysis/multi_state_discrimination_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/multi_state_discrimination_analysis.py
@@ -39,6 +39,9 @@ class MultiStateDiscriminationAnalysis(BaseAnalysis):
 
     Here, :math:`d` is the number of levels that were discriminated while :math:`P(i|j)` is the
     probability of measuring outcome :math:`i` given that state :math:`j` was prepared.
+
+    .. note::
+        This class requires that scikit-learn is installed.
     """
 
     @classmethod

--- a/qiskit_experiments/library/characterization/analysis/multi_state_discrimination_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/multi_state_discrimination_analysis.py
@@ -12,7 +12,7 @@
 
 """Multi state discrimination analysis."""
 
-from typing import List, Tuple
+from typing import List, Tuple, TYPE_CHECKING
 
 import matplotlib
 import numpy as np
@@ -22,13 +22,10 @@ from qiskit_experiments.framework import BaseAnalysis, AnalysisResultData, Exper
 from qiskit_experiments.data_processing import SkQDA
 from qiskit_experiments.data_processing.exceptions import DataProcessorError
 from qiskit_experiments.visualization import BasePlotter, IQPlotter, MplDrawer, PlotStyle
+from qiskit_experiments.warnings import HAS_SKLEARN
 
-try:
+if TYPE_CHECKING:
     from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
-
-    HAS_SKLEARN = True
-except ImportError:
-    HAS_SKLEARN = False
 
 
 class MultiStateDiscriminationAnalysis(BaseAnalysis):
@@ -51,14 +48,10 @@ class MultiStateDiscriminationAnalysis(BaseAnalysis):
         Raises:
             DataProcessorError: if sklearn is not installed.
         """
-        if not HAS_SKLEARN:
-            raise DataProcessorError(
-                f"SKlearn is needed to initialize an {self.__class__.__name__}."
-            )
-
         super().__init__()
 
     @classmethod
+    @HAS_SKLEARN.require_in_call
     def _default_options(cls) -> Options:
         """Return default analysis options.
 
@@ -76,6 +69,8 @@ class MultiStateDiscriminationAnalysis(BaseAnalysis):
         )
         options.plot = True
         options.ax = None
+        from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
+
         options.discriminator = SkQDA(QuadraticDiscriminantAnalysis())
         return options
 

--- a/qiskit_experiments/library/characterization/analysis/multi_state_discrimination_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/multi_state_discrimination_analysis.py
@@ -20,7 +20,6 @@ import numpy as np
 from qiskit.providers.options import Options
 from qiskit_experiments.framework import BaseAnalysis, AnalysisResultData, ExperimentData
 from qiskit_experiments.data_processing import SkQDA
-from qiskit_experiments.data_processing.exceptions import DataProcessorError
 from qiskit_experiments.visualization import BasePlotter, IQPlotter, MplDrawer, PlotStyle
 from qiskit_experiments.warnings import HAS_SKLEARN
 
@@ -41,14 +40,6 @@ class MultiStateDiscriminationAnalysis(BaseAnalysis):
     Here, :math:`d` is the number of levels that were discriminated while :math:`P(i|j)` is the
     probability of measuring outcome :math:`i` given that state :math:`j` was prepared.
     """
-
-    def __init__(self):
-        """Setup the analysis.
-
-        Raises:
-            DataProcessorError: if sklearn is not installed.
-        """
-        super().__init__()
 
     @classmethod
     @HAS_SKLEARN.require_in_call

--- a/qiskit_experiments/warnings.py
+++ b/qiskit_experiments/warnings.py
@@ -16,7 +16,6 @@ import functools
 import warnings
 from typing import Callable, Optional, Type, Dict
 
-from qiskit.exceptions import QiskitError
 from qiskit.utils.lazy_tester import LazyImportTester
 
 

--- a/qiskit_experiments/warnings.py
+++ b/qiskit_experiments/warnings.py
@@ -16,6 +16,9 @@ import functools
 import warnings
 from typing import Callable, Optional, Type, Dict
 
+from qiskit.exceptions import QiskitError
+from qiskit.utils.lazy_tester import LazyImportTester
+
 
 def deprecated_function(
     last_version: Optional[str] = None,
@@ -240,3 +243,15 @@ def qubit_deprecate() -> Callable:
         return wrapper
 
     return decorator
+
+
+HAS_SKLEARN = LazyImportTester(
+    {
+        "sklearn.discriminant_analysis": (
+            "LinearDiscriminantAnalysis",
+            "QuadraticDiscriminantAnalysis",
+        )
+    },
+    name="scikit-learn",
+    install="pip install scikit-learn",
+)

--- a/releasenotes/notes/sklearn-imports-c82155c0a2c81811.yaml
+++ b/releasenotes/notes/sklearn-imports-c82155c0a2c81811.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The importing of ``scikit-learn`` was moved from module-level imports
+    inside of ``try`` blocks to dynamic imports at first usage of the
+    ``scikit-learn`` specific feature. This change should avoid errors in the
+    installation of ``scikit-learn`` from preventing a user using features of
+    ``qiskit-experiments`` that do not require ``scikit-learn``. See `#1050
+    <https://github.com/Qiskit/qiskit-experiments/issues/1050>`_.

--- a/test/data_processing/test_discriminator.py
+++ b/test/data_processing/test_discriminator.py
@@ -17,17 +17,10 @@ from functools import wraps
 from unittest import SkipTest
 import numpy as np
 
+from qiskit.exceptions import MissingOptionalLibraryError
+
 from qiskit_experiments.data_processing import SkLDA, SkQDA
-
-try:
-    from sklearn.discriminant_analysis import (
-        LinearDiscriminantAnalysis,
-        QuadraticDiscriminantAnalysis,
-    )
-
-    HAS_SKLEARN = True
-except ImportError:
-    HAS_SKLEARN = False
+from qiskit_experiments.warnings import HAS_SKLEARN
 
 
 def requires_sklearn(func):
@@ -35,7 +28,9 @@ def requires_sklearn(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if not HAS_SKLEARN:
+        try:
+            HAS_SKLEARN.require_now("SKLearn disciminator testing")
+        except MissingOptionalLibraryError:
             raise SkipTest("SKLearn is required for test.")
 
         func(*args, **kwargs)
@@ -49,6 +44,8 @@ class TestDiscriminator(QiskitExperimentsTestCase):
     @requires_sklearn
     def test_lda_serialization(self):
         """Test the serialization of a lda."""
+
+        from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 
         sk_lda = LinearDiscriminantAnalysis()
         sk_lda.fit([[-1, 0], [1, 0], [-1.1, 0], [0.9, 0.1]], [0, 1, 0, 1])
@@ -87,6 +84,8 @@ class TestDiscriminator(QiskitExperimentsTestCase):
     @requires_sklearn
     def test_qda_serialization(self):
         """Test the serialization of a qda."""
+
+        from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
 
         sk_qda = QuadraticDiscriminantAnalysis()
         sk_qda.fit([[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]], [0, 0, 0, 1, 1, 1])

--- a/test/data_processing/test_discriminator.py
+++ b/test/data_processing/test_discriminator.py
@@ -30,8 +30,8 @@ def requires_sklearn(func):
     def wrapper(*args, **kwargs):
         try:
             HAS_SKLEARN.require_now("SKLearn disciminator testing")
-        except MissingOptionalLibraryError:
-            raise SkipTest("SKLearn is required for test.")
+        except MissingOptionalLibraryError as exc:
+            raise SkipTest("SKLearn is required for test.") from exc
 
         func(*args, **kwargs)
 

--- a/test/data_processing/test_discriminator.py
+++ b/test/data_processing/test_discriminator.py
@@ -29,7 +29,7 @@ def requires_sklearn(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
-            HAS_SKLEARN.require_now("SKLearn disciminator testing")
+            HAS_SKLEARN.require_now("SKLearn discriminator testing")
         except MissingOptionalLibraryError as exc:
             raise SkipTest("SKLearn is required for test.") from exc
 

--- a/test/library/characterization/test_multi_state_discrimination.py
+++ b/test/library/characterization/test_multi_state_discrimination.py
@@ -11,12 +11,34 @@
 # that they have been altered from the originals.
 
 """Test the multi state discrimination experiments."""
+from functools import wraps
 from test.base import QiskitExperimentsTestCase
+from unittest import SkipTest
+
 from ddt import ddt, data
 
 from qiskit import pulse
+from qiskit.exceptions import MissingOptionalLibraryError
+
 from qiskit_experiments.library import MultiStateDiscrimination
 from qiskit_experiments.test.pulse_backend import SingleTransmonTestBackend
+
+from qiskit_experiments.warnings import HAS_SKLEARN
+
+
+def requires_sklearn(func):
+    """Decorator to check for SKLearn."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            HAS_SKLEARN.require_now("SKLearn disciminator testing")
+        except MissingOptionalLibraryError:
+            raise SkipTest("SKLearn is required for test.")
+
+        func(*args, **kwargs)
+
+    return wrapper
 
 
 @ddt
@@ -52,6 +74,7 @@ class TestMultiStateDiscrimination(QiskitExperimentsTestCase):
         self.schedules = {"x12": x12}
 
     @data(2, 3)
+    @requires_sklearn
     def test_circuit_generation(self, n_states):
         """Test the experiment circuit generation"""
         exp = MultiStateDiscrimination(
@@ -63,6 +86,7 @@ class TestMultiStateDiscrimination(QiskitExperimentsTestCase):
         self.assertEqual(exp.circuits()[-1].metadata["label"], n_states - 1)
 
     @data(2, 3)
+    @requires_sklearn
     def test_discrimination_analysis(self, n_states):
         """Test the discrimination analysis"""
         exp = MultiStateDiscrimination(

--- a/test/library/characterization/test_multi_state_discrimination.py
+++ b/test/library/characterization/test_multi_state_discrimination.py
@@ -32,7 +32,7 @@ def requires_sklearn(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
-            HAS_SKLEARN.require_now("SKLearn disciminator testing")
+            HAS_SKLEARN.require_now("SKLearn discriminator testing")
         except MissingOptionalLibraryError as exc:
             raise SkipTest("SKLearn is required for test.") from exc
 

--- a/test/library/characterization/test_multi_state_discrimination.py
+++ b/test/library/characterization/test_multi_state_discrimination.py
@@ -33,8 +33,8 @@ def requires_sklearn(func):
     def wrapper(*args, **kwargs):
         try:
             HAS_SKLEARN.require_now("SKLearn disciminator testing")
-        except MissingOptionalLibraryError:
-            raise SkipTest("SKLearn is required for test.")
+        except MissingOptionalLibraryError as exc:
+            raise SkipTest("SKLearn is required for test.") from exc
 
         func(*args, **kwargs)
 


### PR DESCRIPTION
### Summary

This commit pushes the import of scikit-learn lower into the code, so that it does not occur until first usage.

### Details and comments

Previously, scikit-learn was in a `try` block which allowed for code that did not use scikit-learn to work fine when it was not installed. However, sometimes scikit-learn can be installed but have errors (like in #1050) which were not caught by the `try` block. Further delaying the import can help in this case. Additionally, scikit-learn is a little bit of a slow import, so not importing it when it is not needed gives a little bit of efficiency (maybe; mostly it imports scipy modules but those might get imported any way by other analysis code).