### PR TITLE
Update workflow to enable merge queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,11 @@
 name: Tests
 on:
   push:
-    branches: [ main, 'stable/*' ]
+    branches: [ 'stable/*' ]
   pull_request:
     branches: [ main, 'stable/*' ]
+  merge_group:
+    branches: [ main ]
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
   cancel-in-progress: true


### PR DESCRIPTION
The merge queue requires branch protection status checks to pass after a PR is added. This should mean that we don't have to rerun the tests on push, so this PR moves the main tests from `push` to `merge_group`.