### PR TITLE
Update `binomial_weights` function for tomo fitters

### DIFF
--- a/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
@@ -443,7 +443,7 @@ def cvxpy_gaussian_lstsq(
     """
     t_start = time.time()
 
-    weights = lstsq_utils.gaussian_weights(
+    weights = lstsq_utils.binomial_weights(
         outcome_data,
         shot_data=shot_data,
         outcome_prior=outcome_prior,

--- a/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/cvxpy_lstsq.py
@@ -365,6 +365,7 @@ def cvxpy_gaussian_lstsq(
     trace_preserving: Union[None, bool, str] = "auto",
     partial_trace: Optional[np.ndarray] = None,
     outcome_prior: Union[np.ndarray, int] = 0.5,
+    max_weight: float = 1e10,
     **kwargs,
 ) -> Dict:
     r"""Constrained Gaussian linear least-squares tomography fitter.
@@ -429,6 +430,8 @@ def cvxpy_gaussian_lstsq(
                        trace to POVM matrices.
         outcome_prior: The Baysian prior :math:`\alpha` to use computing Gaussian
             weights. See additional information.
+        max_weight: Set the maximum value allowed for weights vector computed from
+            tomography data variance.
         kwargs: kwargs for cvxpy solver.
 
     Raises:
@@ -440,13 +443,12 @@ def cvxpy_gaussian_lstsq(
     """
     t_start = time.time()
 
-    _, variance = lstsq_utils.dirichlet_mean_and_var(
+    weights = lstsq_utils.gaussian_weights(
         outcome_data,
         shot_data=shot_data,
         outcome_prior=outcome_prior,
+        max_weight=max_weight,
     )
-
-    weights = 1.0 / np.sqrt(variance)
 
     fits, metadata = cvxpy_linear_lstsq(
         outcome_data,

--- a/qiskit_experiments/library/tomography/fitters/lininv.py
+++ b/qiskit_experiments/library/tomography/fitters/lininv.py
@@ -38,6 +38,7 @@ def linear_inversion(
     preparation_qubits: Optional[Tuple[int, ...]] = None,
     conditional_measurement_indices: Optional[np.ndarray] = None,
     conditional_preparation_indices: Optional[np.ndarray] = None,
+    atol: float = 1e-8,
 ) -> Tuple[np.ndarray, Dict]:
     r"""Linear inversion tomography fitter.
 
@@ -106,6 +107,7 @@ def linear_inversion(
         conditional_preparation_indices: Optional, conditional preparation data
             indices. If set this will return a list of fitted states conditioned
             on a fixed basis preparation of these qubits.
+        atol: truncate any probabilities below this value to zero.
 
     Raises:
         AnalysisError: If the fitted vector is not a square matrix
@@ -242,10 +244,10 @@ def linear_inversion(
 
             # Get probabilities and optional measurement basis component
             for outcome, freq in enumerate(outcomes):
-                if freq == 0:
+                prob = freq / shots
+                if np.isclose(prob, 0, atol=atol):
                     # Skip component with zero probability
                     continue
-                prob = freq / shots
 
                 # Get component on non-conditional bits
                 outcome_meas = f_meas_outcome(outcome)

--- a/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
@@ -252,7 +252,7 @@ def scipy_gaussian_lstsq(
     """
     t_start = time.time()
 
-    weights = lstsq_utils.gaussian_weights(
+    weights = lstsq_utils.binomial_weights(
         outcome_data,
         shot_data=shot_data,
         outcome_prior=outcome_prior,

--- a/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
+++ b/qiskit_experiments/library/tomography/fitters/scipy_lstsq.py
@@ -190,6 +190,7 @@ def scipy_gaussian_lstsq(
     measurement_qubits: Optional[Tuple[int, ...]] = None,
     preparation_qubits: Optional[Tuple[int, ...]] = None,
     outcome_prior: Union[np.ndarray, int] = 0.5,
+    max_weight: float = 1e10,
     **kwargs,
 ) -> Dict:
     r"""Gaussian linear least-squares tomography fitter.
@@ -239,6 +240,8 @@ def scipy_gaussian_lstsq(
             If None they are assumed to be ``[0, ..., N-1]`` for N preparated qubits.
         outcome_prior: The Baysian prior :math:`\alpha` to use computing Gaussian
             weights. See additional information.
+        max_weight: Set the maximum value allowed for weights vector computed from
+            tomography data variance.
         kwargs: additional kwargs for :func:`scipy.linalg.lstsq`.
 
     Raises:
@@ -248,12 +251,14 @@ def scipy_gaussian_lstsq(
         The fitted matrix rho that maximizes the least-squares likelihood function.
     """
     t_start = time.time()
-    _, variance = lstsq_utils.dirichlet_mean_and_var(
+
+    weights = lstsq_utils.gaussian_weights(
         outcome_data,
         shot_data=shot_data,
         outcome_prior=outcome_prior,
+        max_weight=max_weight,
     )
-    weights = 1.0 / np.sqrt(variance)
+
     fits, metadata = scipy_linear_lstsq(
         outcome_data,
         shot_data,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates `binomial_weights` function to use the dirichlet distribution for computing weights, and to work with the conditional tomography experiment changes to allow weights being an array of the same shape as outcome data.

### Details and comments

