### PR TITLE
CI for linting docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,8 @@ jobs:
         run: python -m pip install -U tox
       - name: Run lint
         run: tox -elint
+      - name: Lint docs
+        run: tox -edocs-lint -- -W
   docs:
     name: docs
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,8 +227,8 @@ should look something like:
 ```yaml
 features:
   - |
-    Introduced a new feature foo, that adds support for doing something to
-    ``QuantumCircuit`` objects. It can be used by using the foo function,
+    Introduced a new feature foo that adds support for doing something to
+    :class:`~qiskit.circuit.QuantumCircuit` objects. It can be used by using the foo function,
     for example::
 
       from qiskit import foo
@@ -236,9 +236,9 @@ features:
       foo(QuantumCircuit())
 
   - |
-    The ``qiskit.QuantumCircuit`` module has a new method ``foo()``. This is
-    the equivalent of calling the ``qiskit.foo()`` to do something to your
-    QuantumCircuit. This is the equivalent of running ``qiskit.foo()`` on
+    The :class:`~qiskit.circuit.QuantumCircuit` class has a new method :meth:`.foo`. This is
+    the equivalent of calling :func:`qiskit.foo` to do something to your
+    QuantumCircuit. This is the equivalent of running :func:`qiskit.foo` on
     your circuit, but provides the convenience of running it natively on
     an object. For example::
 
@@ -249,11 +249,11 @@ features:
 
 deprecations:
   - |
-    The ``qiskit.bar`` module has been deprecated and will be removed in a
-    future release. Its sole function, ``foobar()`` has been superseded by the
-    ``qiskit.foo()`` function which provides similar functionality but with
+    The :mod:`qiskit.bar` module has been deprecated and will be removed in a
+    future release. Its sole function, :func:`foobar` has been superseded by the
+    :func:`qiskit.foo` function which provides similar functionality but with
     more accurate results and better performance. You should update your calls
-    ``qiskit.bar.foobar()`` calls to ``qiskit.foo()``.
+    :func:`qiskit.bar.foobar` calls to :func:`qiskit.foo`.
 ```
 
 You can also look at existing release notes for more examples.

--- a/docs/_ext/autoref.py
+++ b/docs/_ext/autoref.py
@@ -30,6 +30,7 @@ class WebSite(Directive):
         .. ref_website:: qiskit-experiments, https://github.com/Qiskit/qiskit-experiments
 
     """
+
     required_arguments = 1
     optional_arguments = 0
     final_argument_whitespace = True
@@ -67,6 +68,7 @@ class Arxiv(Directive):
     If an article is not found, no journal information will be shown.
 
     """
+
     required_arguments = 2
     optional_arguments = 0
     final_argument_whitespace = False
@@ -95,7 +97,7 @@ class Arxiv(Directive):
         if journal:
             ret_node += nodes.Text(journal)
         ret_node += nodes.Text(" ")
-        ret_node += nodes.reference(text="(open)", refuri=paper.pdf_url)
+        ret_node += nodes.reference(text="(open)", refuri=paper.entry_id)
 
         return [ret_node]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,7 +187,6 @@ if os.getenv("EXPERIMENTS_DEV_DOCS", None):
     rst_prolog = """
 .. raw:: html
 
-    <br><br><br>
 .. note::
     This is the documentation for the current state of the development branch
     of Qiskit Experiments. The documentation or APIs here can change prior to being

--- a/docs/howtos/new_experimentdata.rst
+++ b/docs/howtos/new_experimentdata.rst
@@ -84,4 +84,4 @@ first component experiment.
 See Also
 --------
 
-* `Saving and loading experiment data with the cloud service <cloud_service.html>`_
+* :doc:`cloud_service`

--- a/docs/lint/conf.py
+++ b/docs/lint/conf.py
@@ -1,17 +1,13 @@
-import sys, os
-
 # This is the configuration file to run sphinx linting for `tox -edocs-nitpick`.
 # It will output warnings for each missing reference.
+
+import sys, os
 
 sys.path.insert(0, os.path.abspath("../"))
 sys.path.append(os.path.abspath("../_ext"))
 sys.path.append(os.path.abspath("../../"))
 
 exclude_patterns = ["_build"]
-
-# # Set env flag so that we can doc functions that may otherwise not be loaded
-# # see for example interactive visualizations in qiskit.visualization.
-# os.environ["QISKIT_DOCS"] = "TRUE"
 
 project = "Qiskit Experiments"
 nitpicky = True
@@ -23,16 +19,15 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
-    "sphinx.ext.extlinks",
-    "jupyter_sphinx",
+    "reno.sphinxext",
     "sphinx_autodoc_typehints",
-    "sphinx_design",
     "sphinx.ext.intersphinx",
-    "nbsphinx",
     "autoref",
     "autodoc_experiment",
     "autodoc_analysis",
     "autodoc_visualization",
+    "sphinx_design",
+    "jupyter_sphinx",
     "jupyter_execute_custom",
 ]
 
@@ -41,9 +36,15 @@ nbsphinx_allow_errors = True
 # Ignore these objects
 nitpick_ignore_regex = [
     ("py:.*", "qiskit.*"),
+    ("py:.*", "numpy.*"),
+    ("py:.*", "sklearn.*"),
+    ("py:.*", "scipy.*"),
+    ("py:.*", "datetime.*"),
+    ("py:.*", "IBM.*"),
     ("py:.*", ".*\._.*"),
     ("py:.*", "_.*"),
-    ("py:.*", "numpy.*"),
+    ("py:.*", "lmfit.*"),
+    ("py:.*", "uncertainties.*"),
     ("py:.*", ".*__.*"),
     ("py:.*", "typing.*"),
     ("py:.*", ".*Error"),
@@ -52,6 +53,6 @@ nitpick_ignore_regex = [
 
 # Deprecated objects that should be ignored in the release notes
 nitpick_ignore_regex += [
-    ("py:class", "MplCurveDrawer"),
+    ("py:*", "MplCurveDrawer.*"),
     ("py:.*", "CliffordUtils.*"),
 ]

--- a/docs/lint/conf.py
+++ b/docs/lint/conf.py
@@ -1,0 +1,57 @@
+import sys, os
+
+# This is the configuration file to run sphinx linting for `tox -edocs-nitpick`.
+# It will output warnings for each missing reference.
+
+sys.path.insert(0, os.path.abspath("../"))
+sys.path.append(os.path.abspath("../_ext"))
+sys.path.append(os.path.abspath("../../"))
+
+exclude_patterns = ["_build"]
+
+# # Set env flag so that we can doc functions that may otherwise not be loaded
+# # see for example interactive visualizations in qiskit.visualization.
+# os.environ["QISKIT_DOCS"] = "TRUE"
+
+project = "Qiskit Experiments"
+nitpicky = True
+
+# within nit-picking build, do not refer to any intersphinx object
+intersphinx_mapping = {}
+
+extensions = [
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.extlinks",
+    "jupyter_sphinx",
+    "sphinx_autodoc_typehints",
+    "sphinx_design",
+    "sphinx.ext.intersphinx",
+    "nbsphinx",
+    "autoref",
+    "autodoc_experiment",
+    "autodoc_analysis",
+    "autodoc_visualization",
+    "jupyter_execute_custom",
+]
+
+nbsphinx_allow_errors = True
+
+# Ignore these objects
+nitpick_ignore_regex = [
+    ("py:.*", "qiskit.*"),
+    ("py:.*", ".*\._.*"),
+    ("py:.*", "_.*"),
+    ("py:.*", "numpy.*"),
+    ("py:.*", ".*__.*"),
+    ("py:.*", "typing.*"),
+    ("py:.*", ".*Error"),
+    ("py:.*", "Ellipsis"),
+]
+
+# Deprecated objects that should be ignored in the release notes
+nitpick_ignore_regex += [
+    ("py:class", "MplCurveDrawer"),
+    ("py:.*", "CliffordUtils.*"),
+]

--- a/docs/manuals/benchmarking/quantum_volume.rst
+++ b/docs/manuals/benchmarking/quantum_volume.rst
@@ -53,11 +53,11 @@ backend and on an ideal simulator:
 -  ``seed``: Seed or generator object for random number generation. If
    ``None`` then ``default_rng`` will be used.
 
--  ``simulation_backend``: The simulator backend to use to generate the
-   expected results. the simulator must have a ``save_probabilities``
-   method. If None ``AerSimulator`` simulator will be used (in case
-   ``AerSimulator`` is not installed ``qiskit.quantum_info.Statevector``
-   will be used).
+-  ``simulation_backend``: The simulator backend to use to generate the expected
+   results. the simulator must have a ``save_probabilities`` method. If None,
+   :class:`~qiskit_aer.AerSimulator` will be used (in case
+   :class:`~qiskit_aer.AerSimulator` is not installed,
+   :class:`~qiskit.quantum_info.Statevector` will be used).
 
 **Note:** In some cases, 100 trials are not enough to obtain a QV
 greater than 1 for the specified number of qubits. In this case, adding

--- a/docs/tutorials/curve_analysis.rst
+++ b/docs/tutorials/curve_analysis.rst
@@ -253,9 +253,9 @@ This code will give you identical fit model to the one defined in the following 
         )
 
 However, note that you can also inherit other features, e.g. the algorithm to
-generate initial guesses for parameters, from the :class:`AnalysisA` in the first example.
+generate initial guesses for parameters, from the ``AnalysisA`` class in the first example.
 On the other hand, in the latter case, you need to manually copy and paste
-every logic defined in the :class:`AnalysisA`.
+every logic defined in ``AnalysisA``.
 
 .. _curve_analysis_workflow:
 
@@ -268,7 +268,7 @@ This workflow is defined in the method :meth:`CurveAnalysis._run_analysis`.
 1. Initialization
 ^^^^^^^^^^^^^^^^^
 
-Curve analysis calls :meth:`_initialization` method where it initializes
+Curve analysis calls the :meth:`_initialization` method, where it initializes
 some internal states and optionally populate analysis options
 with the input experiment data.
 In some case it may train the data processor with fresh outcomes,

--- a/docs/tutorials/custom_experiment.rst
+++ b/docs/tutorials/custom_experiment.rst
@@ -10,7 +10,7 @@ the :class:`.BaseExperiment` class. We will discuss both cases in this tutorial.
 In general, to subclass :class:`.BaseExperiment` class, you should:
 
 - Implement the abstract :meth:`.BaseExperiment.circuits` method.
-  This should return a list of :class:`~qiskit.QuantumCircuit` objects defining
+  This should return a list of :class:`~qiskit.circuit.QuantumCircuit` objects defining
   the experiment payload.
 
 - Call the :meth:`.BaseExperiment.__init__` method during the subclass

--- a/qiskit_experiments/calibration_management/base_calibration_experiment.py
+++ b/qiskit_experiments/calibration_management/base_calibration_experiment.py
@@ -63,7 +63,7 @@ class BaseCalibrationExperiment(BaseExperiment, ABC):
 
         RoughFrequencyCal(BaseCalibrationExperiment, QubitSpectroscopy)
 
-    This ensures that the :meth:`run` method of :class:`.RoughFrequencyCal` will be the
+    This ensures that the ``run`` method of :class:`.RoughFrequencyCal` will be the
     run method of the :class:`.BaseCalibrationExperiment` class. Furthermore, developers
     must explicitly call the :meth:`__init__` methods of both parent classes.
 

--- a/qiskit_experiments/calibration_management/base_calibration_experiment.py
+++ b/qiskit_experiments/calibration_management/base_calibration_experiment.py
@@ -61,14 +61,14 @@ class BaseCalibrationExperiment(BaseExperiment, ABC):
 
     .. code-block:: python
 
-        RoughFrequency(BaseCalibrationExperiment, QubitSpectroscopy)
+        RoughFrequencyCal(BaseCalibrationExperiment, QubitSpectroscopy)
 
-    This ensures that the :meth:`run` method of :class:`.RoughFrequency` will be the
+    This ensures that the :meth:`run` method of :class:`.RoughFrequencyCal` will be the
     run method of the :class:`.BaseCalibrationExperiment` class. Furthermore, developers
     must explicitly call the :meth:`__init__` methods of both parent classes.
 
     Developers should strive to follow the convention that the first two arguments of
-    a calibration experiment are the qubit(s) and the :class:`.Calibration` instance.
+    a calibration experiment are the qubit(s) and the :class:`.Calibrations` instance.
 
     If the experiment uses custom schedules, which is typically the case, then
     developers may chose to use the :meth:`get_schedules` method when creating the
@@ -133,8 +133,8 @@ class BaseCalibrationExperiment(BaseExperiment, ABC):
             updater: The updater class that updates the Calibrations instance. Different
                 calibration experiments will use different updaters.
             auto_update: If set to True (the default) then the calibrations will automatically be
-                updated once the experiment has run and :meth:`block_for_results()` will be called.
-            kwargs: Key word arguments for the characterization class.
+                updated once the experiment has run and :meth:`.block_for_results` will be called.
+            kwargs: Keyword arguments for the characterization class.
         """
         super().__init__(*args, **kwargs)
         self._cals = calibrations

--- a/qiskit_experiments/calibration_management/basis_gate_library.py
+++ b/qiskit_experiments/calibration_management/basis_gate_library.py
@@ -120,8 +120,9 @@ class BasisGateLibrary(ABC, Mapping):
         """Return the default values for the parameters.
 
         Returns
-            A list of tuples is returned. These tuples are structured so that instances of
-            :class:`.Calibrations` can call :meth:`.add_parameter_value` on the tuples.
+            A list of tuples is returned. These tuples are structured so that instances
+            of :class:`.Calibrations` can call :meth:`.Calibrations.add_parameter_value`
+            on the tuples.
         """
 
     @abstractmethod
@@ -286,8 +287,9 @@ class FixedFrequencyTransmon(BasisGateLibrary):
         """Return the default values for the parameters.
 
         Returns
-            A list of tuples is returned. These tuples are structured so that instances of
-            :class:`.Calibrations` can call :meth:`.add_parameter_value` on the tuples.
+            A list of tuples is returned. These tuples are structured so that instances
+            of :class:`.Calibrations` can call :meth:`.Calibrations.add_parameter_value`
+            on the tuples.
         """
         defaults = []
         for name, schedule in self.items():

--- a/qiskit_experiments/database_service/__init__.py
+++ b/qiskit_experiments/database_service/__init__.py
@@ -18,7 +18,7 @@ Database Service (:mod:`qiskit_experiments.database_service`)
 .. currentmodule:: qiskit_experiments.database_service
 
 This subpackage provides database-specific utility functions and exceptions which
-are used with the :class:`ExperimentData` and :class:`AnalysisResult` classes.
+are used with the :class:`.ExperimentData` and :class:`.AnalysisResult` classes.
 
 
 Exceptions

--- a/qiskit_experiments/framework/base_experiment.py
+++ b/qiskit_experiments/framework/base_experiment.py
@@ -298,12 +298,12 @@ class BaseExperiment(ABC, StoreInitArgs):
         """Return a list of experiment circuits.
 
         Returns:
-            A list of :class:`QuantumCircuit`.
+            A list of :class:`~qiskit.circuit.QuantumCircuit`.
 
         .. note::
             These circuits should be on qubits ``[0, .., N-1]`` for an
             *N*-qubit experiment. The circuits mapped to physical qubits
-            are obtained via the :meth:`transpiled_circuits` method.
+            are obtained via the internal :meth:`_transpiled_circuits` method.
         """
         # NOTE: Subclasses should override this method using the `options`
         # values for any explicit experiment options that affect circuit

--- a/qiskit_experiments/framework/composite/composite_analysis.py
+++ b/qiskit_experiments/framework/composite/composite_analysis.py
@@ -40,15 +40,15 @@ class CompositeAnalysis(BaseAnalysis):
 
     .. note::
 
-        If the composite :class:`ExperimentData` does not already contain
-        child experiment data containers for the component experiments
-        they will be initialized and added to the experiment data when :meth:`run`
-        is called on the composite data.
+        If the composite :class:`ExperimentData` does not already contain child
+        experiment data containers for the component experiments they will be
+        initialized and added to the experiment data when
+        :meth:`~.CompositeAnalysis.run` is called on the composite data.
 
-        When calling :meth:`run` on experiment data already containing
-        initialized component experiment data, any previously stored
-        circuit data will be cleared and replaced with the marginalized data
-        from the composite experiment data.
+        When calling :meth:`~.CompositeAnalysis.run` on experiment data already
+        containing initialized component experiment data, any previously stored circuit
+        data will be cleared and replaced with the marginalized data from the composite
+        experiment data.
     """
 
     def __init__(self, analyses: List[BaseAnalysis], flatten_results: bool = False):

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1709,21 +1709,20 @@ class ExperimentData:
     def job_status(self) -> JobStatus:
         """Return the experiment job execution status.
 
-        Possible return values for :class:`.JobStatus` are
+        Possible return values for :class:`qiskit.providers.jobstatus.JobStatus` are
 
-        * :attr:`~.JobStatus.ERROR` - if any job incurred an error
-        * :attr:`~.JobStatus.CANCELLED` - if any job is cancelled.
-        * :attr:`~.JobStatus.RUNNING` - if any job is still running.
-        * :attr:`~.JobStatus.QUEUED` - if any job is queued.
-        * :attr:`~.JobStatus.VALIDATING` - if any job is being validated.
-        * :attr:`~.JobStatus.INITIALIZING` - if any job is being initialized.
-        * :attr:`~.JobStatus.DONE` - if all jobs are finished.
+        * `ERROR`` - if any job incurred an error
+        * ``CANCELLED`` - if any job is cancelled.
+        * ``RUNNING`` - if any job is still running.
+        * ``QUEUED`` - if any job is queued.
+        * ``VALIDATING`` - if any job is being validated.
+        * ``INITIALIZING`` - if any job is being initialized.
+        * ``DONE`` - if all jobs are finished.
 
         .. note::
 
-            If an experiment has status :attr:`~.JobStatus.ERROR` or
-            :attr:`~.JobStatus.CANCELLED` there may still be pending or
-            running jobs. In these cases it may be beneficial to call
+            If an experiment has status ``ERROR`` or ``CANCELLED`` there may still be
+            pending or running jobs. In these cases it may be beneficial to call
             :meth:`cancel_jobs` to terminate these remaining jobs.
 
         Returns:

--- a/qiskit_experiments/library/__init__.py
+++ b/qiskit_experiments/library/__init__.py
@@ -36,6 +36,7 @@ Experiments for verification and validation of quantum devices.
 
     ~randomized_benchmarking.StandardRB
     ~randomized_benchmarking.InterleavedRB
+    ~tomography.TomographyExperiment
     ~tomography.StateTomography
     ~tomography.ProcessTomography
     ~tomography.MitigatedStateTomography
@@ -182,6 +183,7 @@ from .characterization import (
 )
 from .randomized_benchmarking import StandardRB, InterleavedRB
 from .tomography import (
+    TomographyExperiment,
     StateTomography,
     ProcessTomography,
     MitigatedStateTomography,

--- a/qiskit_experiments/library/characterization/multi_state_discrimination.py
+++ b/qiskit_experiments/library/characterization/multi_state_discrimination.py
@@ -55,8 +55,7 @@ class MultiStateDiscrimination(BaseExperiment):
         :class:`MultiStateDiscriminationAnalysis`
 
     # section: reference
-        `Qiskit Textbook <https://qiskit.org/textbook/ch-quantum-hardware/accessing\
-        _higher_energy_states.html>`_.
+        `Qiskit Textbook <https://qiskit.org/textbook/ch-quantum-hardware/accessing_higher_energy_states.html>`_.
 
     """
 

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
@@ -77,12 +77,12 @@ class InterleavedRBAnalysis(curve.CurveAnalysis):
             bounds: [0, 1]
         defpar \alpha:
             desc: Depolarizing parameter.
-            init_guess: Determined by :func:`~rb_decay` with standard RB curve.
+            init_guess: Determined by :meth:`.rb_decay` with standard RB curve.
             bounds: [0, 1]
         defpar \alpha_c:
-            desc: Ratio of the depolarizing parameter of interleaved RB to standard RB curve.
+            desc: Ratio of the depolarizing parameter of interleaved RB to standard RB.
             init_guess: Determined by alpha of interleaved RB curve divided by one of
-                standard RB curve. Both alpha values are estimated by :func:`~rb_decay`.
+                standard RB curve. Both alpha values are estimated by :meth:`.rb_decay`.
             bounds: [0, 1]
 
     # section: reference

--- a/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
@@ -60,7 +60,7 @@ class RBAnalysis(curve.CurveAnalysis):
             bounds: [0, 1]
         defpar \alpha:
             desc: Depolarizing parameter.
-            init_guess: Determined by :func:`~rb_decay`.
+            init_guess: Determined by :func:`~.guess.rb_decay`.
             bounds: [0, 1]
 
     # section: reference

--- a/qiskit_experiments/library/tomography/__init__.py
+++ b/qiskit_experiments/library/tomography/__init__.py
@@ -24,6 +24,7 @@ Experiments
     :toctree: ../stubs/
     :template: autosummary/experiment.rst
 
+    TomographyExperiment
     StateTomography
     ProcessTomography
     MitigatedStateTomography
@@ -37,6 +38,7 @@ Analysis
     :toctree: ../stubs/
     :template: autosummary/analysis.rst
 
+    TomographyAnalysis
     StateTomographyAnalysis
     ProcessTomographyAnalysis
     MitigatedTomographyAnalysis
@@ -90,10 +92,12 @@ Abstract base classes
 """
 
 # Experiment Classes
+from .tomography_experiment import TomographyExperiment
 from .qst_experiment import StateTomography, StateTomographyAnalysis
 from .qpt_experiment import ProcessTomography, ProcessTomographyAnalysis
 from .mit_qst_experiment import MitigatedStateTomography
 from .mit_qpt_experiment import MitigatedProcessTomography
+from .tomography_analysis import TomographyAnalysis
 from .mit_tomography_analysis import MitigatedTomographyAnalysis
 
 # Basis Classes

--- a/qiskit_experiments/library/tomography/basis/base_basis.py
+++ b/qiskit_experiments/library/tomography/basis/base_basis.py
@@ -94,7 +94,7 @@ class PreparationBasis(BaseBasis):
     * The :meth:`index_shape` method which returns the shape of allowed
       basis indices for the specified qubits, and their values.
 
-    * The :meth:`matrix_shape` method which returns the shape of subsystem
+    * The :meth:`~.PreparationBasis.matrix_shape` method which returns the shape of subsystem
       dimensions of the density matrix state on the specified qubits.
     """
 
@@ -150,7 +150,7 @@ class MeasurementBasis(BaseBasis):
     * The :meth:`index_shape` method which returns the shape of allowed
       basis indices for the specified qubits, and their values.
 
-    * The :meth:`matrix_shape` method which returns the shape of subsystem
+    * The :meth:`~.PreparationBasis.matrix_shape` method which returns the shape of subsystem
       dimensions of the POVM element matrices on the specified qubits.
 
     * The :meth:`outcome_shape` method which returns the shape of allowed

--- a/qiskit_experiments/library/tomography/basis/base_basis.py
+++ b/qiskit_experiments/library/tomography/basis/base_basis.py
@@ -83,7 +83,7 @@ class PreparationBasis(BaseBasis):
     define a preparation basis:
 
     * The :meth:`circuit` method which returns the logical preparation
-      :class:`.QuantumCircuit` for basis element index on the specified
+      :class:`~qiskit.circuit.QuantumCircuit` for basis element index on the specified
       qubits. This circuit should be a logical circuit on the specified
       number of qubits and will be remapped to the corresponding physical
       qubits during transpilation.
@@ -135,17 +135,17 @@ class MeasurementBasis(BaseBasis):
     define a preparation basis:
 
     * The :meth:`circuit` method which returns the logical measurement
-      :class:`.QuantumCircuit` for basis element index on the specified
+      :class:`~qiskit.circuit.QuantumCircuit` for basis element index on the specified
       physical qubits. This circuit should be a logical circuit on the
       specified number of qubits and will be remapped to the corresponding
       physical qubits during transpilation. It should include classical
       bits and the measure instructions for the basis measurement storing
       the outcome value in these bits.
 
-    * The :meth:`matrix` method which returns the POVM element corresponding
-      to the basis element index and measurement outcome on the specified
-      qubits. This should return either a :class:`.Statevector` for a PVM
-      element, or :class:`.DensityMatrix` for a general POVM element.
+    * The :meth:`matrix` method which returns the POVM element corresponding to the
+      basis element index and measurement outcome on the specified qubits. This should
+      return either a :class:`~qiskit.quantum_info.Statevector` for a PVM element, or
+      :class:`~qiskit.quantum_info.DensityMatrix` for a general POVM element.
 
     * The :meth:`index_shape` method which returns the shape of allowed
       basis indices for the specified qubits, and their values.

--- a/qiskit_experiments/test/__init__.py
+++ b/qiskit_experiments/test/__init__.py
@@ -42,6 +42,8 @@ Mock backends for running simulated jobs.
     MockIQParallelBackend
     T2HahnBackend
     NoisyDelayAerBackend
+    PulseBackend
+    SingleTransmonTestBackend
 
 """
 
@@ -50,3 +52,4 @@ from .mock_iq_backend import MockIQBackend, MockIQParallelBackend
 from .noisy_delay_aer_simulator import NoisyDelayAerBackend
 from .t2hahn_backend import T2HahnBackend
 from .fake_service import FakeService
+from .pulse_backend import PulseBackend

--- a/qiskit_experiments/test/__init__.py
+++ b/qiskit_experiments/test/__init__.py
@@ -52,4 +52,4 @@ from .mock_iq_backend import MockIQBackend, MockIQParallelBackend
 from .noisy_delay_aer_simulator import NoisyDelayAerBackend
 from .t2hahn_backend import T2HahnBackend
 from .fake_service import FakeService
-from .pulse_backend import PulseBackend
+from .pulse_backend import PulseBackend, SingleTransmonTestBackend

--- a/qiskit_experiments/visualization/__init__.py
+++ b/qiskit_experiments/visualization/__init__.py
@@ -20,7 +20,7 @@ The visualization module provides plotting functionality for creating figures fr
 experiment and analysis results. This includes plotter and drawer classes to plot data
 in :class:`.CurveAnalysis` and its subclasses. Plotters inherit from
 :class:`BasePlotter` and define a type of figure that may be generated from experiment
-or analysis data. For example, the results from :class:`CurveAnalysis`---or any other
+or analysis data. For example, the results from :class:`.CurveAnalysis`---or any other
 experiment where results are plotted against a single parameter (i.e., :math:`x`)---can
 be plotted using the :class:`CurvePlotter` class, which plots X-Y-like values.
 

--- a/releasenotes/notes/0.3/cleanup-rb-experiment-f17b6e674ae4e473.yaml
+++ b/releasenotes/notes/0.3/cleanup-rb-experiment-f17b6e674ae4e473.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    The curve fit parameter guess function :func:`~rb_decay` has been added. 
+    The curve fit parameter guess function :func:`~.guess.rb_decay` has been added. 
     This improves the initial parameter estimation of randomized benchmark experiments.
 upgrade:
   - |

--- a/releasenotes/notes/0.3/curve-analysis-fixed-parameters-5915a29db1e2628b.yaml
+++ b/releasenotes/notes/0.3/curve-analysis-fixed-parameters-5915a29db1e2628b.yaml
@@ -13,11 +13,11 @@ deprecations:
     has been deprecated. Please set `fixed_parameters` option instead.
     This is a python dictionary of fixed parameter values keyed on the fit parameter names.
   - |
-    Analysis class :class:`FineDragAnalysis` has been deprecated. Now you can directly
-    set fixed parameters to the :class:`ErrorAmplificationAnalysis` instance as an analysis option.
+    Analysis class ``FineDragAnalysis`` has been deprecated. Now you can directly
+    set fixed parameters to the :class:`.ErrorAmplificationAnalysis` instance as an analysis option.
   - |
-    Analysis class :class:`FineFrequencyAnalysis` has been deprecated. Now you can directly
-    set fixed parameters to the :class:`ErrorAmplificationAnalysis` instance as an analysis option.
+    Analysis class ``FineFrequencyAnalysis`` has been deprecated. Now you can directly
+    set fixed parameters to the :class:`.ErrorAmplificationAnalysis` instance as an analysis option.
   - |
-    Analysis class :class:`FineHalfAngleAnalysis` has been deprecated. Now you can directly
-    set fixed parameters to the :class:`ErrorAmplificationAnalysis` instance as an analysis option.
+    Analysis class ``FineHalfAngleAnalysis`` has been deprecated. Now you can directly
+    set fixed parameters to the :class:`.ErrorAmplificationAnalysis` instance as an analysis option.

--- a/releasenotes/notes/0.3/experiment_service_fixes-94730fd6bab83956.yaml
+++ b/releasenotes/notes/0.3/experiment_service_fixes-94730fd6bab83956.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    :meth:`.ExperimentData.save()` should now fail gracefully when experiment metadata failed to save instead of crashing.
+    :meth:`.ExperimentData.save` should now fail gracefully when experiment metadata failed to save instead of crashing.
   - |
     The link to the experiment entry in the database service shown after saving is now by default obtained from the service, not hard-coded.

--- a/releasenotes/notes/0.3/upgrade-curve-fit-4dc01b1db55ee398.yaml
+++ b/releasenotes/notes/0.3/upgrade-curve-fit-4dc01b1db55ee398.yaml
@@ -1,7 +1,7 @@
 ---
 upgrade:
   - |
-    The :class:`CurveAnalysis` class has been updated to use the covariance between fit
+    The :class:`.CurveAnalysis` class has been updated to use the covariance between fit
     parameters in the error propagation. This will provide more accurate standard
     error for your fit values.
   - |

--- a/releasenotes/notes/0.4/curve-analysis-02a702a81e014adf.yaml
+++ b/releasenotes/notes/0.4/curve-analysis-02a702a81e014adf.yaml
@@ -41,7 +41,7 @@ features:
 
   - |
     ``plot_options`` has been added. This was conventionally included
-    in the :class:`SeriesDef` dataclass, which was static and not configurable. 
+    in the :class:`.SeriesDef` dataclass, which was static and not configurable. 
     Now end-user can update visual representation of curves through this option.
     This option is a dictionary that defines three properties, for example,
     

--- a/releasenotes/notes/0.4/randomized_benchmarking-de55fda43765c34c.yaml
+++ b/releasenotes/notes/0.4/randomized_benchmarking-de55fda43765c34c.yaml
@@ -1,5 +1,6 @@
 ---
 fixes:
   - |
-    Initial guess function for the randomized benchmarking analysis :func:`.rb_decay` has been
-    upgraded to give accurate estimate of the decay function base.
+    Initial guess function for the randomized benchmarking analysis
+    :func:`~.guess.rb_decay` has been upgraded to give accurate estimate of the decay
+    function base.

--- a/releasenotes/notes/curve-analysis-4bcc10cf3a39a85d.yaml
+++ b/releasenotes/notes/curve-analysis-4bcc10cf3a39a85d.yaml
@@ -8,13 +8,13 @@ features:
     and no statistical difference has been introduced with introduction of this option.
 deprecations:
   - |
-    Providing data_sort_key directly to the LMFIT model to instantiate :class:`CurveAnalysis` 
+    Providing data_sort_key directly to the LMFIT model to instantiate :class:`.CurveAnalysis` 
     has been deprecated. This option is not officially supported by the LMFIT,
     and thus curve analysis cannot guarantee this option is properly managed 
     in all LMFIT model subclasses.
 developer:
   - |
-    To map experiment result data to a particular LMFIT model in the :class:`CurveAnalysis`,
+    To map experiment result data to a particular LMFIT model in the :class:`.CurveAnalysis`,
     an author must provide the data_subfit_map analysis option rather than directly binding 
     data_sort_key with the target LMFIT model. 
     The data_subfit_map option is a dictionary keyed on the model name. For example,

--- a/releasenotes/notes/ecr_lib-381cb18885e81abd.yaml
+++ b/releasenotes/notes/ecr_lib-381cb18885e81abd.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    A new basis gate library called :class:`EchoedCrossResonance` is been added.
+    A new basis gate library called :class:`.EchoedCrossResonance` is been added.
 upgrade:
   - |
     The :class:`.Calibrations` class has been updated to use the reference

--- a/releasenotes/notes/fix-matplotlib-3.6.0-failing-test-5a747f61a9c357b4.yaml
+++ b/releasenotes/notes/fix-matplotlib-3.6.0-failing-test-5a747f61a9c357b4.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Fix a bug where :class:`CurveAnalysis` tests would fail with matplotlib 3.6.0 owing to a deprecated
-    function call used in :class:`MplCurveDrawer`. The new :class:`MplCurveDrawer` no-longer uses the
+    Fix a bug where :class:`.CurveAnalysis` tests would fail with matplotlib 3.6.0 owing to a deprecated
+    function call used in :class:`MplCurveDrawer`. The new :class:`MplCurveDrawer` no longer uses the
     deprecated function.

--- a/releasenotes/notes/tomography-b091ce13d6983bc1.yaml
+++ b/releasenotes/notes/tomography-b091ce13d6983bc1.yaml
@@ -22,12 +22,12 @@ features:
   - |
     Adds an optional ``mitigator`` kwarg to :class:`.PauliMeasurementBasis`
     which can be used to initialize the basis with a
-    :class:`.LocalReadoutMitigator` to construct a readout error mitigated
+    :class:`~qiskit.result.LocalReadoutMitigator` to construct a readout error mitigated
     basis for use with :class:`.StateTomography` and
     :class:`.ProcessTomography` experiments.
   
     The :class:`.LocalReadoutError` experiment can be run to obtain the 
-    :class:`.LocalReadoutMitigator` from its analysis results.
+    :class:`~qiskit.result.LocalReadoutMitigator` from its analysis results.
   - |
     Adds readout error mitigated tomography experiments
     :class:`.MitigatedStateTomography` and :class:`.MitigatedProcessTomography`.
@@ -74,7 +74,7 @@ fixes:
     experiments where if the input circuit contained conditional instructions
     with multiple classical registers the tomography measurement circuits
     would contain incorrect conditionals due to a bug in the
-    :meth:`.QuantumCircuit.compose` method.
+    :meth:`qiskit.circuit.QuantumCircuit.compose` method.
 
     See Issue #942 <https://github.com/Qiskit/qiskit-experiments/issues/943>`_
     for additional details.
@@ -82,7 +82,7 @@ upgrade:
   - |
     Renames the ``qubits``, ``measurement_qubits``, and ``preparation_qubits``
     init kwargs of :class:`~.StateTomography`,
-    :class:`~.ProcessTomography`, and :class:`~.TomographyExperiment` to
+    :class:`~.ProcessTomography`, and :class:`.TomographyExperiment` to
     ``physical_qubits``, ``measurement_indices`` and ``preparation_indices``
     respectively. This is to make the intended use of these kwargs more clear
     as the measurement and preparation args refer to the index of circuit
@@ -101,7 +101,7 @@ deprecations:
   - |
     Renames the ``qubits``, ``measurement_qubits``, and ``preparation_qubits``
     init kwargs of :class:`~.StateTomography`,
-    :class:`~.ProcessTomography`, and :class:`~.TomographyExperiment` have
+    :class:`~.ProcessTomography`, and :class:`.TomographyExperiment` have
     been deprecated. They have been replaced with kwargs ``physical_qubits``,
     ``measurement_indices`` and ``preparation_indices`` respectively. The
     renamed kwargs have the same functionality as the deprecated kwargs.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,11 +5,11 @@ pylint==2.7.1
 jinja2==3.0.3
 sphinx~=5.0
 jupyter-sphinx>=0.4.0
-qiskit-sphinx-theme==1.11.0rc1
-sphinx-autodoc-typehints<=1.20.2
+qiskit-sphinx-theme>=1.11.0rc1
+sphinx-autodoc-typehints>=1.22.0
 sphinx-design==0.3.0
 pygments>=2.4
-reno>=3.4.0
+reno>=4.0.0
 nbsphinx
 arxiv
 ddt>=1.6.0
@@ -21,3 +21,4 @@ pylatexenc
 importlib-metadata==4.13.0;python_version<'3.8'
 scikit-learn
 sphinx-copybutton
+sphinxcontrib-jupyter

--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,13 @@ setenv =
 commands =
   sphinx-build -T --keep-going -b html {posargs} docs/ docs/_build/html
 
+[testenv:docs-nitpick]
+passenv = EXPERIMENTS_DEV_DOCS
+setenv = 
+  QISKIT_DOCS_SKIP_EXECUTE = 1
+commands =
+  sphinx-build -c docs/lint -n -T --keep-going -b linkcheck {posargs} docs/ docs/_build/html
+
 [pycodestyle]
 max-line-length = 100
 

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ setenv =
 commands =
   sphinx-build -T --keep-going -b html {posargs} docs/ docs/_build/html
 
-[testenv:docs-nitpick]
+[testenv:docs-lint]
 passenv = EXPERIMENTS_DEV_DOCS
 setenv = 
   QISKIT_DOCS_SKIP_EXECUTE = 1


### PR DESCRIPTION
### Summary

Added linting of Sphinx docs to the lint CI job with the tox environment `docs-lint`. The job will fail on broken references and links.

### Details and comments

- A new `docs/lint/conf.py` is added for this linting setting. It currently has a manual list of regex objects to ignore, because there are a lot of deprecated objects in the release notes that need to be manually updated or added to the ignore list.
- The arxiv autolink in docstrings has been changed to the abstract instead of the PDF for user friendliness.
- The docs are no longer incompatible with the newest sphinx-autodoc-typehints so the version pin from #1017 has been removed. This closes #1018.
- Actual format linting like [sphinx-lint](https://github.com/sphinx-contrib/sphinx-lint) is not yet included.