### PR TITLE
Updated PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,11 +8,16 @@ that this addresses, if any.
 Some details that should be in this section include:
 
 - Why this change was necessary
-- What alternative approaches were considered and why the current approach was chosen
+- What alternative solutions were considered and why the current solution was chosen
 - What tests and documentation have been added/updated
 - What do users and developers need to know about this change
 
-### PR checklist (delete when all critera are met)
+Note that this entire PR description field will be used as the commit message upon
+merge, so please keep it updated along with the PR. Secondary discussions, such as
+intermediate testing and bug statuses that do not affect the final PR, should be in the
+PR comments.
+
+### PR checklist (delete when all criteria are met)
 
 - [ ] I have read the contributing guide `CONTRIBUTING.md`.
 - [ ] I have added the tests to cover my changes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,21 @@
-<!--
-⚠️ If you do not respect this template, your pull request will be closed.
-⚠️ Your pull request title should be short detailed and understandable for all.
-⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
-⚠️ If your pull request fixes an open issue, please link to the issue.
-
-✅ I have added the tests to cover my changes.
-✅ I have updated the documentation accordingly.
-✅ I have read the CONTRIBUTING document.
--->
-
 ### Summary
 
-
+Please describe what this PR changes as concisely as possible. Link to the issue(s) 
+that this addresses, if any.
 
 ### Details and comments
 
+Some details that should be in this section include:
 
+- Why this change was necessary
+- What alternative approaches were considered and why the current approach was chosen
+- What tests and documentation have been added/updated
+- What do users and developers need to know about this change
+
+### PR checklist (delete when all critera are met)
+
+- [ ] I have read the contributing guide `CONTRIBUTING.md`.
+- [ ] I have added the tests to cover my changes.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added a release note file using `reno` if this change needs to be 
+      documented in the release notes.


### PR DESCRIPTION
Because we've set the merge queue to use the PR description as the commit message to `main`, it's not good to start the PR template with a commented block that PR makers don't have to remove. The new template makes the checklist visible at the end and indicates it should be deleted.