### PR TITLE
Expose HalfAngleCal

### DIFF
--- a/qiskit_experiments/library/__init__.py
+++ b/qiskit_experiments/library/__init__.py
@@ -131,6 +131,7 @@ See :doc:`/tutorials/calibrations` for examples.
     ~calibration.FineAmplitudeCal
     ~calibration.FineXAmplitudeCal
     ~calibration.FineSXAmplitudeCal
+    ~calibration.HalfAngleCal
     ~calibration.RoughAmplitudeCal
     ~calibration.RoughXSXAmplitudeCal
     ~calibration.EFRoughXSXAmplitudeCal
@@ -150,6 +151,7 @@ from .calibration import (
     RoughFrequencyCal,
     FrequencyCal,
     FineFrequencyCal,
+    HalfAngleCal,
 )
 from .characterization import (
     T1,

--- a/qiskit_experiments/library/calibration/__init__.py
+++ b/qiskit_experiments/library/calibration/__init__.py
@@ -49,6 +49,7 @@ module.
     FineAmplitudeCal
     FineXAmplitudeCal
     FineSXAmplitudeCal
+    HalfAngleCal
     RoughAmplitudeCal
     RoughXSXAmplitudeCal
     EFRoughXSXAmplitudeCal
@@ -66,3 +67,4 @@ from .fine_amplitude import FineAmplitudeCal, FineXAmplitudeCal, FineSXAmplitude
 from .fine_drag_cal import FineDragCal, FineXDragCal, FineSXDragCal
 from .frequency_cal import FrequencyCal
 from .fine_frequency_cal import FineFrequencyCal
+from .half_angle_cal import HalfAngleCal


### PR DESCRIPTION
### Summary

The Half Angle Calibration experiment was not exposed. This PR adds the necessary imports to correct this.