### PR TITLE
Fix a bug of redoing DragCalAnalysis

### DIFF
--- a/qiskit_experiments/library/characterization/drag.py
+++ b/qiskit_experiments/library/characterization/drag.py
@@ -183,11 +183,6 @@ class RoughDrag(BaseExperiment, RestlessMixin):
 
         return circuits
 
-    def _finalize(self):
-        if isinstance(self.analysis, DragCalAnalysis):
-            # Set reps to analysis option to create proper model
-            self.analysis.set_options(reps=self.experiment_options.reps)
-
     def _metadata(self):
         metadata = super()._metadata()
         # Store measurement level and meas return if they have been
@@ -195,4 +190,5 @@ class RoughDrag(BaseExperiment, RestlessMixin):
         for run_opt in ["meas_level", "meas_return"]:
             if hasattr(self.run_options, run_opt):
                 metadata[run_opt] = getattr(self.run_options, run_opt)
+        metadata["nreps"] = self.experiment_options.reps
         return metadata

--- a/releasenotes/notes/fix-drag-reanalysis-46f4c6679555242d.yaml
+++ b/releasenotes/notes/fix-drag-reanalysis-46f4c6679555242d.yaml
@@ -1,0 +1,10 @@
+---
+deprecations:
+  - |
+    An analysis option `reps` in :class:`DragCalAnalysis` was deprecated.
+    Corresponding value must be provided by the experiment metadata
+    for the robustness of data analysis.
+fixes:
+  - |
+    A bug of redoing :class:`DragCalAnalysis.run` generates wrong fit models
+    was fixed.

--- a/test/library/calibration/test_drag.py
+++ b/test/library/calibration/test_drag.py
@@ -25,6 +25,7 @@ from qiskit.qobj.utils import MeasLevel
 from qiskit import transpile
 
 from qiskit_experiments.library import RoughDrag, RoughDragCal
+from qiskit_experiments.library.characterization.analysis import DragCalAnalysis
 from qiskit_experiments.test.mock_iq_backend import MockIQBackend
 from qiskit_experiments.test.mock_iq_helpers import MockIQDragHelper as DragHelper
 from qiskit_experiments.calibration_management.basis_gate_library import FixedFrequencyTransmon
@@ -119,6 +120,32 @@ class TestDragEndToEnd(QiskitExperimentsTestCase):
         # pylint: disable=no-member
         self.assertTrue(abs(result.value.n - backend.experiment_helper.ideal_beta) < tol)
         self.assertEqual(result.quality, "good")
+
+    def test_drag_reanalysis(self):
+        """Test edge case for re-analyzing DRAG result multiple times."""
+        drag_experiment_helper = DragHelper(gate_name="Drag(xp)")
+        backend = MockIQBackend(drag_experiment_helper)
+
+        drag = RoughDrag([1], self.x_plus)
+        drag.set_experiment_options(reps=[2, 4, 6])
+
+        expdata = drag.run(backend, analysis=None)
+        self.assertExperimentDone(expdata)
+
+        # Assume the situation we reloaded experiment data from server
+        # and prepared analysis class in the client machine.
+        # DRAG reps numbers might be different from the default value,
+        # but the client doesn't know the original setting.
+        analysis = DragCalAnalysis()
+        expdata1 = analysis.run(expdata.copy(), replace_results=True)
+        # Running experiment twice.
+        # Reported by https://github.com/Qiskit/qiskit-experiments/issues/1086.
+        expdata2 = analysis.run(expdata.copy(), replace_results=True)
+
+        self.assertAlmostEqual(
+            expdata1.analysis_results("beta").value.n,
+            expdata2.analysis_results("beta").value.n,
+        )
 
 
 class TestDragCircuits(QiskitExperimentsTestCase):


### PR DESCRIPTION
### Summary

This PR updates `DRAGCalAnalysis` to fix a bug of redoing analysis.

Fix #1086 

### Details and comments

- Move analysis option `reps` to experiment metadata.
- Completely replace model with one generated on the fly with `reps` value, rather than appending.

### PR checklist (delete when all criteria are met)

- [ ] I have read the contributing guide `CONTRIBUTING.md`.
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a release note file using `reno` if this change needs to be 
      documented in the release notes.
