### PR TITLE
Turn off parallel docs build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
           python -m pip install -U tox
           sudo apt-get install -y pandoc graphviz
       - name: Build Docs
-        run: tox -edocs-parallel -- -W
+        run: tox -edocs -- -W
       - name: Compress Artifacts
         run: |
           mkdir artifacts


### PR DESCRIPTION
### Summary

The docs build is suddenly breaking with 

```
  File "/home/runner/work/qiskit-experiments/qiskit-experiments/.tox/docs-parallel/lib/python3.8/site-packages/sphinx/util/parallel.py", line 126, in _join_one
    raise SphinxParallelError(*result)
sphinx.errors.SphinxParallelError: sphinx.errors.ExtensionError: Unable to find kernel (exception: No such kernel named python3)
```

Turning off the parallel flag until we can figure out what's happening.