### PR TITLE
Update FakeBackend to use BackendV2

### DIFF
--- a/qiskit_experiments/test/fake_backend.py
+++ b/qiskit_experiments/test/fake_backend.py
@@ -12,7 +12,7 @@
 
 """Fake backend class for tests."""
 import uuid
-from qiskit.circuit.library import CXGate, Measure
+from qiskit.circuit.library import Measure
 from qiskit.providers.backend import BackendV2
 from qiskit.providers.options import Options
 from qiskit.transpiler import Target

--- a/qiskit_experiments/test/fake_backend.py
+++ b/qiskit_experiments/test/fake_backend.py
@@ -27,11 +27,9 @@ class FakeBackend(BackendV2):
     Fake backend for test purposes only.
     """
 
-    target = None
-
     def __init__(self, backend_name="fake_backend", num_qubits=1, max_experiments=100):
         super().__init__(name=backend_name)
-        self.target = Target(num_qubits=num_qubits)
+        self._target = Target(num_qubits=num_qubits)
         # Add a measure for each qubit so a simple measure circuit works
         self.target.add_instruction(Measure())
         self._max_circuits = max_experiments
@@ -44,6 +42,10 @@ class FakeBackend(BackendV2):
     @classmethod
     def _default_options(cls):
         return Options()
+
+    @property
+    def target(self) -> Target:
+        return self._target
 
     def run(self, run_input, **options):
         result = {

--- a/qiskit_experiments/test/fake_backend.py
+++ b/qiskit_experiments/test/fake_backend.py
@@ -12,38 +12,34 @@
 
 """Fake backend class for tests."""
 import uuid
-from qiskit.providers.backend import BackendV1
-from qiskit.providers.models import QasmBackendConfiguration
+from qiskit.circuit.library import CXGate, Measure
+from qiskit.providers.backend import BackendV2
+from qiskit.providers.options import Options
+from qiskit.transpiler import Target
 
 from qiskit.result import Result
 
-from qiskit_experiments.framework import Options
 from qiskit_experiments.test.utils import FakeJob
 
 
-class FakeBackend(BackendV1):
+class FakeBackend(BackendV2):
     """
     Fake backend for test purposes only.
     """
 
-    def __init__(self, **config):
-        default_config = {
-            "backend_name": "fake_backend",
-            "backend_version": "0",
-            "n_qubits": int(1e6),
-            "basis_gates": [],
-            "gates": [],
-            "local": True,
-            "simulator": True,
-            "conditional": False,
-            "open_pulse": False,
-            "memory": False,
-            "max_shots": int(1e6),
-            "max_experiments": None,
-            "coupling_map": None,
-        }
-        default_config.update(**config)
-        super().__init__(QasmBackendConfiguration(**default_config))
+    target = None
+
+    def __init__(self, backend_name="fake_backend", num_qubits=1, max_experiments=100):
+        super().__init__(name=backend_name)
+        self.target = Target(num_qubits=num_qubits)
+        # Add a measure for each qubit so a simple measure circuit works
+        self.target.add_instruction(Measure())
+        self._max_circuits = max_experiments
+
+    @property
+    def max_circuits(self):
+        """Maximum circuits to run at once"""
+        return self._max_circuits
 
     @classmethod
     def _default_options(cls):

--- a/test/calibration/test_calibrations.py
+++ b/test/calibration/test_calibrations.py
@@ -51,11 +51,9 @@ from qiskit_experiments.exceptions import CalibrationError
 class MinimalBackend(BackendV2):
     """Class for testing a backend with minimal data"""
 
-    target = None
-
-    def __init__(self):
+    def __init__(self, num_qubits=1):
         super().__init__()
-        self.target = Target()
+        self._target = Target(num_qubits=num_qubits)
 
     @property
     def max_circuits(self):
@@ -65,6 +63,11 @@ class MinimalBackend(BackendV2):
     @classmethod
     def _default_options(cls):
         return Options()
+
+    @property
+    def target(self) -> Target:
+        """Target instance for the backend"""
+        return self._target
 
     def run(self, run_input, **options):
         """Empty method to satisfy abstract base class"""
@@ -342,8 +345,7 @@ class TestCalibrationsBasic(QiskitExperimentsTestCase):
         else:
             gate = None
 
-        backend = MinimalBackend()
-        backend.target = Target(num_qubits=num_qubits)
+        backend = MinimalBackend(num_qubits=num_qubits)
         if gate is not None:
             backend.target.add_instruction(gate, properties=properties)
         Calibrations.from_backend(backend)

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -493,7 +493,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         par_exp = ParallelExperiment(
             [exp1, BatchExperiment([ParallelExperiment([exp2, exp3]), exp4])]
         )
-        expdata = par_exp.run(Backend())
+        expdata = par_exp.run(Backend(num_qubits=4))
         self.assertExperimentDone(expdata)
 
         self.assertEqual(len(expdata.data()), len(counts))


### PR DESCRIPTION
### Summary

This change set updates the `FakeBackend` used by some tests to derive from `BackendV2` rather than `BackendV1`

### Details and comments

When combined with [#900](https://github.com/Qiskit/qiskit-experiments/pull/900) which updates some calibration tests and [#1040](https://github.com/Qiskit/qiskit-experiments/pull/1040) which updates `T2HahnBackend`, this change results in almost all the tests in the test suite using `BackendV2`. The remaining tests using a `Backend` that is not `BackendV2` use the `AerSimulator` which will be updated to `BackendV2` in the future (tracked in https://github.com/Qiskit/qiskit-aer/issues/1681). The check for backend type was performed by merging the calibration and `T2HahnBackend` branches into this branch and running the tests with `BaseExperiment.run()`, `BaseExperiment._set_backend()`, and `Calibrations.from_backend()` updated to error if the `backend` argument was not `BackendV2` or `AerSimulator` and confirming that all the tests passed.