### PR TITLE
Restrict symengine pin to Python 3.7

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,4 +24,5 @@ sphinx-copybutton
 # Pin versions below because of build errors
 ipykernel<=6.21.3
 jupyter-client<=8.0.3
-symengine<=0.9.2
+# Pin symengine because there are no wheels for 0.10 for Python 3.7
+symengine<=0.9.2;python_version<'3.8'


### PR DESCRIPTION
#1103 restricted symengine to `<=0.9.2` to avoid errors in CI. Those errors are due to symengine 0.10.0 being published as compatible with Python 3.7 but without wheels for 3.7, so pip tries to install 0.10.0 from source and fails because the CI environment does not have all of symengine's build dependencies.

For reference, [here](https://github.com/symengine/symengine.py/blob/v0.10.0/setup.py#L233) we see that symengine is still compatible with 3.7 and [here](https://github.com/symengine/symengine-wheels/commit/f6c52a720b4aa7b97e8bfc00ea72fd9d67ffb0a4) symengine stopped building wheels for 3.7.