### PR TITLE
Fix doc build on Macs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
           python -m pip install -U tox
           sudo apt-get install -y pandoc graphviz
       - name: Build Docs
-        run: tox -edocs -- -W
+        run: tox -edocs
       - name: Compress Artifacts
         run: |
           mkdir artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ envdir = .tox/lint
 commands = black {posargs} qiskit_experiments test tools setup.py
 
 [testenv:docs]
+usedevelop = False
 passenv = EXPERIMENTS_DEV_DOCS
 commands =
   sphinx-build -T -W --keep-going -b html {posargs} docs/ docs/_build/html

--- a/tox.ini
+++ b/tox.ini
@@ -58,19 +58,21 @@ commands = black {posargs} qiskit_experiments test tools setup.py
 [testenv:docs]
 passenv = EXPERIMENTS_DEV_DOCS
 commands =
-  sphinx-build -T --keep-going -b html {posargs} docs/ docs/_build/html
+  sphinx-build -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 
 [testenv:docs-parallel]
+usedevelop = False
 passenv = EXPERIMENTS_DEV_DOCS
 commands =
-  sphinx-build -j auto -T --keep-going -b html {posargs} docs/ docs/_build/html
+  sphinx-build -j auto -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 
 [testenv:docs-minimal]
+usedevelop = False
 passenv = EXPERIMENTS_DEV_DOCS
 setenv = 
   QISKIT_DOCS_SKIP_EXECUTE = 1
 commands =
-  sphinx-build -T --keep-going -b html {posargs} docs/ docs/_build/html
+  sphinx-build -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 
 [pycodestyle]
 max-line-length = 100


### PR DESCRIPTION
### Summary

This PR follows https://github.com/Qiskit/qiskit-terra/pull/9765 and turns off development mode for tox doc builds because of a known issue on Macs where some pages output build warnings and don't build properly. Now Mac doc builds should work fully.