### PR TITLE
Changed fake backends to V2 and added seeds for docs

### DIFF
--- a/docs/manuals/characterization/t1.rst
+++ b/docs/manuals/characterization/t1.rst
@@ -38,7 +38,7 @@ for qubit 0.
     from qiskit_experiments.library.characterization.analysis.t1_analysis import T1KerneledAnalysis
 
     # A T1 simulator
-    from qiskit.providers.fake_provider import FakeVigo
+    from qiskit.providers.fake_provider import FakePerth
     from qiskit_aer import AerSimulator
     from qiskit_aer.noise import NoiseModel
 
@@ -48,14 +48,14 @@ for qubit 0.
     
     # Create a pure relaxation noise model for AerSimulator
     noise_model = NoiseModel.from_backend(
-        FakeVigo(), thermal_relaxation=True, gate_error=False, readout_error=False
+        FakePerth(), thermal_relaxation=True, gate_error=False, readout_error=False
     )
     
     # Create a fake backend simulator
-    backend = AerSimulator.from_backend(FakeVigo(), noise_model=noise_model)
+    backend = AerSimulator.from_backend(FakePerth(), noise_model=noise_model)
     
     # Look up target T1 of qubit-0 from device properties
-    qubit0_t1 = backend.properties().t1(0)
+    qubit0_t1 = FakePerth().qubit_properties(0).t1
     
     # Time intervals to wait before measurement
     delays = np.arange(1e-6, 3 * qubit0_t1, 3e-5)

--- a/docs/manuals/characterization/t2ramsey.rst
+++ b/docs/manuals/characterization/t2ramsey.rst
@@ -62,17 +62,17 @@ pure T1/T2 relaxation noise model.
 .. jupyter-execute::
 
     # A T1 simulator
-    from qiskit.providers.fake_provider import FakeVigo
+    from qiskit.providers.fake_provider import FakePerth
     from qiskit_aer import AerSimulator
     from qiskit_aer.noise import NoiseModel
     
     # Create a pure relaxation noise model for AerSimulator
     noise_model = NoiseModel.from_backend(
-        FakeVigo(), thermal_relaxation=True, gate_error=False, readout_error=False
+        FakePerth(), thermal_relaxation=True, gate_error=False, readout_error=False
     )
     
     # Create a fake backend simulator
-    backend = AerSimulator.from_backend(FakeVigo(), noise_model=noise_model)
+    backend = AerSimulator.from_backend(FakePerth(), noise_model=noise_model)
 
 The resulting graph will have the form:
 :math:`f(t) = a^{-t/T_2*} \cdot \cos(2 \pi f t + \phi) + b` where *t* is

--- a/docs/manuals/characterization/tphi.rst
+++ b/docs/manuals/characterization/tphi.rst
@@ -27,17 +27,17 @@ From the :math:`T_1` and :math:`T_2` estimates, we compute the results for
     from qiskit_experiments.library.characterization import Tphi
 
     # An Aer simulator
-    from qiskit.providers.fake_provider import FakeVigo
+    from qiskit.providers.fake_provider import FakePerth
     from qiskit_aer import AerSimulator
     from qiskit_aer.noise import NoiseModel
     
     # Create a pure relaxation noise model for AerSimulator
     noise_model = NoiseModel.from_backend(
-        FakeVigo(), thermal_relaxation=True, gate_error=False, readout_error=False
+        FakePerth(), thermal_relaxation=True, gate_error=False, readout_error=False
     )
     
     # Create a fake backend simulator
-    backend = AerSimulator.from_backend(FakeVigo(), noise_model=noise_model)
+    backend = AerSimulator.from_backend(FakePerth(), noise_model=noise_model)
     
     # Time intervals to wait before measurement for t1 and t2
     delays_t1 = np.arange(1e-6, 300e-6, 10e-6)

--- a/docs/manuals/measurement/readout_mitigation.rst
+++ b/docs/manuals/measurement/readout_mitigation.rst
@@ -39,7 +39,7 @@ experiments to generate the corresponding mitigators.
     from qiskit_experiments.library import LocalReadoutError, CorrelatedReadoutError
     # For simulation
     from qiskit_aer import AerSimulator
-    from qiskit.providers.fake_provider import FakeParis
+    from qiskit.providers.fake_provider import FakePerth
 
     from qiskit.result.mitigation.utils import (
         expval_with_stddev,
@@ -47,7 +47,7 @@ experiments to generate the corresponding mitigators.
         counts_probability_vector
     )
 
-    backend = AerSimulator.from_backend(FakeParis())
+    backend = AerSimulator.from_backend(FakePerth())
 
 .. jupyter-execute::
 

--- a/docs/manuals/measurement/restless_measurements.rst
+++ b/docs/manuals/measurement/restless_measurements.rst
@@ -184,7 +184,8 @@ using the code below.
     tau = sum(durations) * dt / (len(durations))
 
     n_circs = len(cal_drag.circuits())
-    # can be obtained from backend.default_rep_delay on a real backend
+    # can be obtained from backend.default_rep_delay on a backend from qiskit-ibm-provider
+
     delay_s = 0.0025
     delay_r = 1e-6  # restless delay
     reset = 4e-6  # Estimated reset duration

--- a/docs/manuals/measurement/restless_measurements.rst
+++ b/docs/manuals/measurement/restless_measurements.rst
@@ -66,10 +66,10 @@ they use always starts with the qubits in the ground state.
         FixedFrequencyTransmon,
     )
     from qiskit_experiments.data_processing.data_processor import DataProcessor
-    from qiskit.providers.fake_provider import FakeBogota
+    from qiskit.providers.fake_provider import FakePerth
 
     # replace this lines with an IBM Quantum backend to run the experiment.
-    backend = FakeBogota()
+    backend = FakePerth()
     cals = Calibrations.from_backend(backend, libraries=[FixedFrequencyTransmon()])
 
     # Define the experiment
@@ -158,9 +158,10 @@ using the code below.
 .. jupyter-execute::
 
     from qiskit import schedule, transpile
+    from qiskit_experiments.framework import BackendData
 
-    dt = backend.configuration().dt
-    inst_map = backend.defaults().instruction_schedule_map
+    dt = BackendData(backend).dt
+    inst_map = backend.instruction_schedule_map
     meas_length = inst_map.get("measure", (qubit, )).duration * dt
 
     # Compute the average duration of all circuits
@@ -183,7 +184,8 @@ using the code below.
     tau = sum(durations) * dt / (len(durations))
 
     n_circs = len(cal_drag.circuits())
-    delay_s = backend.configuration().default_rep_delay
+    # can be obtained from backend.default_rep_delay on a real backend
+    delay_s = 0.0025
     delay_r = 1e-6  # restless delay
     reset = 4e-6  # Estimated reset duration
     speed_up = (meas_length + reset + delay_s + tau) / (meas_length + delay_r + tau)

--- a/docs/manuals/verification/quantum_volume.rst
+++ b/docs/manuals/verification/quantum_volume.rst
@@ -33,9 +33,9 @@ z_value = 2), and at least 100 trials have been ran.
     from qiskit_aer import AerSimulator
     
     # For simulation
-    from qiskit.providers.fake_provider import FakeSydney
+    from qiskit.providers.fake_provider import FakeSydneyV2
     
-    backend = AerSimulator.from_backend(FakeSydney())
+    backend = AerSimulator.from_backend(FakeSydneyV2())
 
 QV experiment
 -------------

--- a/docs/manuals/verification/randomized_benchmarking.rst
+++ b/docs/manuals/verification/randomized_benchmarking.rst
@@ -20,9 +20,9 @@ explanation on the RB method, which is based on Refs. [1]_ [2]_.
     
     # For simulation
     from qiskit_aer import AerSimulator
-    from qiskit.providers.fake_provider import FakeParis
+    from qiskit.providers.fake_provider import FakePerth
     
-    backend = AerSimulator.from_backend(FakeParis())
+    backend = AerSimulator.from_backend(FakePerth())
 
 Standard RB experiment
 ----------------------
@@ -170,9 +170,9 @@ The EPGs of two-qubit RB are analyzed with the corrected EPC if available.
     lengths_1_qubit = np.arange(1, 800, 200)
     num_samples = 10
     seed = 1010
-    qubits = (1, 4)
+    qubits = (1, 2)
 
-    # Run a 1-qubit RB experiment on qubits 1, 4 to determine the error-per-gate of 1-qubit gates
+    # Run a 1-qubit RB experiment on qubits 1, 2 to determine the error-per-gate of 1-qubit gates
     single_exps = BatchExperiment(
         [
             StandardRB([qubit], lengths_1_qubit, num_samples=num_samples, seed=seed)
@@ -185,7 +185,7 @@ The EPGs of two-qubit RB are analyzed with the corrected EPC if available.
 
 .. jupyter-execute::
 
-    # Run an RB experiment on qubits 1, 4
+    # Run an RB experiment on qubits 1, 2
     exp_2q = StandardRB(qubits, lengths_2_qubit, num_samples=num_samples, seed=seed)
     
     # Use the EPG data of the 1-qubit runs to ensure correct 2-qubit EPG computation
@@ -267,14 +267,12 @@ Let's run an interleaved RB experiment on two qubits:
     lengths = np.arange(1, 200, 30)
     num_samples = 10
     seed = 1010
-    qubits = [1,4]
+    qubits = (1, 2)
     
-    # Run an Interleaved RB experiment on qubits 1, 4
-    # The interleaved gate is the cx gate
+    # The interleaved gate is the CX gate
     int_exp2 = InterleavedRB(
         circuits.CXGate(), qubits, lengths, num_samples=num_samples, seed=seed)
     
-    # Run
     int_expdata2 = int_exp2.run(backend).block_for_results()
     int_results2 = int_expdata2.analysis_results()
 

--- a/docs/manuals/verification/state_tomography.rst
+++ b/docs/manuals/verification/state_tomography.rst
@@ -9,10 +9,10 @@ Quantum State Tomography
     
     # For simulation
     from qiskit_aer import AerSimulator
-    from qiskit.providers.fake_provider import FakeParis
+    from qiskit.providers.fake_provider import FakePerth
     
     # Noisy simulator backend
-    backend = AerSimulator.from_backend(FakeParis())
+    backend = AerSimulator.from_backend(FakePerth())
 
 State Tomography Experiment
 ---------------------------

--- a/docs/tutorials/calibrations.rst
+++ b/docs/tutorials/calibrations.rst
@@ -42,7 +42,7 @@ This automatic updating can also be disabled using the ``auto_update`` flag.
 
 .. jupyter-execute::
 
-    backend = SingleTransmonTestBackend(5.2e9,-.25e9, 1e9, 0.8e9, noise=False)
+    backend = SingleTransmonTestBackend(5.2e9,-.25e9, 1e9, 0.8e9, noise=False, seed=100)
     qubit = 0 
     cals=Calibrations.from_backend(backend)
     print(cals.get_inst_map())
@@ -345,11 +345,6 @@ update calibrations with a calibration experiment.
 
     from qiskit.pulse import InstructionScheduleMap
     from qiskit_experiments.library import FineXAmplitude
-
-.. jupyter-execute::
-
-    backend = SingleTransmonTestBackend()
-    qubit = 0
 
 Detecting over- and under-rotated pulses
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/tutorials/data_processor.rst
+++ b/docs/tutorials/data_processor.rst
@@ -82,7 +82,7 @@ The code below sets up the Rabi experiment.
             pulse.DriveChannel(0)
         )
 
-    backend = SingleTransmonTestBackend()
+    backend = SingleTransmonTestBackend(seed=100)
 
     exp = Rabi(
         qubit=0,

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -47,22 +47,22 @@ the experiment from the Qiskit Experiments library:
     from qiskit_experiments.library import T1
 
 Experiments must be run on a backend. We're going to use a simulator,
-:class:`~qiskit.providers.fake_provider.FakeVigo`, for this example, but you can use any
+:class:`~qiskit.providers.fake_provider.FakePerth`, for this example, but you can use any
 IBM backend, real or simulated, that you can access through Qiskit.
 
 .. jupyter-execute::
 
-    from qiskit.providers.fake_provider import FakeVigo
+    from qiskit.providers.fake_provider import FakePerth
     from qiskit_aer import AerSimulator
     from qiskit.providers.aer.noise import NoiseModel
     import numpy as np
 
     # Create a pure relaxation noise model for AerSimulator
     noise_model = NoiseModel.from_backend(
-        FakeVigo(), thermal_relaxation=True, gate_error=False, readout_error=False
+        FakePerth(), thermal_relaxation=True, gate_error=False, readout_error=False
     )
 
-    backend = AerSimulator.from_backend(FakeVigo(), noise_model=noise_model)
+    backend = AerSimulator.from_backend(FakePerth(), noise_model=noise_model)
 
 All experiments require a ``physical_qubits`` parameter as input that specifies which
 physical qubit or qubits the circuits will be executed on. The qubits must be given as a
@@ -81,7 +81,7 @@ good estimate for the sweep range of the delays.
 
 .. jupyter-execute::
 
-    qubit0_t1 = backend.properties().t1(0)
+    qubit0_t1 = FakePerth().qubit_properties(0).t1
 
     delays = np.arange(1e-6, 3 * qubit0_t1, 3e-5)
     exp = T1(physical_qubits=(0,), delays=delays)

--- a/docs/tutorials/visualization.rst
+++ b/docs/tutorials/visualization.rst
@@ -52,13 +52,14 @@ First, we display the default figure from a :class:`.Rabi` experiment as a start
             pulse.DriveChannel(0)
         )
 
-    backend = SingleTransmonTestBackend()
-
+    seed = 100
+    backend = SingleTransmonTestBackend(seed=seed)
+    
     rabi = Rabi(
         physical_qubits=(0,),
         backend=backend,
         schedule=sched,
-        amplitudes=np.linspace(-0.1, 0.1, 21)
+        amplitudes=np.linspace(-0.1, 0.1, 21),
     )
 
     rabi_data = rabi.run().block_for_results()
@@ -128,7 +129,7 @@ to see what the default figure looks like:
         pulse.play(pulse.Drag(64, 0.66, 16, beta), pulse.DriveChannel(0))
 
     drag_experiment_helper = DragHelper(gate_name="Drag(xp)")
-    backend = MockIQBackend(drag_experiment_helper)
+    backend = MockIQBackend(drag_experiment_helper, rng_seed=seed)
 
     drag = RoughDrag((0,), xp, backend=backend)
 
@@ -214,8 +215,6 @@ series over the axis area.
 
 .. jupyter-input::
 
-    drag_experiment_helper = DragHelper(gate_name="Drag(xp)")
-    backend = MockIQBackend(drag_experiment_helper)
     with pulse.build(name="xp") as xp:
         pulse.play(Drag(duration=160, amp=0.208519, sigma=40, beta=beta), DriveChannel(0))
 


### PR DESCRIPTION
### Summary

Because visualization doc builds are continuing to throw warnings (see #1107), this PR fixes the simulator seed until we can replicate this error with a known seed and debug the problem. In addition, V1 simulator backends in docs have been replaced with ``FakePerth``, which mocks a currently available free backend.

### Details and comments

- Fake V2 backends are missing the `default_rep_delay` attribute, so the code that uses this in `restless_measurement.rst` has been replaced with a hardcoded value from the real backend and instructions for how to obtain it.