### PR TITLE
Fix IFS setting in doc deploy script

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -27,9 +27,9 @@ echo "show current dir: "
 pwd
 
 CURRENT_TAG=`git describe --abbrev=0`
-IFS='.'
-read -ra VERSION <<< "$CURRENT_TAG"
+IFS=. read -ra VERSION <<< "$CURRENT_TAG"
 STABLE_VERSION=${VERSION[0]}.${VERSION[1]}
+echo "Building for stable version $STABLE_VERSION"
 
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d


### PR DESCRIPTION
### Summary

The 0.5.0 docs publishing job resulted in failure because the openssl command to decrypt the credentials file for uploading the docs errored. The IFS (internal field separator) variable was getting set too broadly at the the level of the entire script instead of just the tag parsing. This was causing the passing of the secrets for decrypting the credential files to fail. This commit updates the IFS usage so it's not affecting the other commands after we split the tag version. This should fix the deploy job for future releases.

### Details and comments