### PR TITLE
Fixed calibration experiments failing on backends with no coupling map

### DIFF
--- a/qiskit_experiments/calibration_management/base_calibration_experiment.py
+++ b/qiskit_experiments/calibration_management/base_calibration_experiment.py
@@ -316,10 +316,14 @@ class BaseCalibrationExperiment(BaseExperiment, ABC):
         """
         initial_layout = Layout.from_intlist(list(self.physical_qubits), *circuit.qregs)
 
+        coupling_map = self._backend_data.coupling_map
+        if coupling_map is not None:
+            coupling_map = CouplingMap(self._backend_data.coupling_map)
+
         layout = PassManager(
             [
                 SetLayout(initial_layout),
-                FullAncillaAllocation(CouplingMap(self._backend_data.coupling_map)),
+                FullAncillaAllocation(coupling_map),
                 EnlargeWithAncilla(),
                 ApplyLayout(),
             ]

--- a/releasenotes/notes/cals-no-coupling-map-5114ae9faa2f9e69.yaml
+++ b/releasenotes/notes/cals-no-coupling-map-5114ae9faa2f9e69.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed error generating circuits for :class:`.BaseCalibrationExperiment`
+    subclasses when the backend instance had no coupling map. Fixed `#1116
+    <https://github.com/Qiskit/qiskit-experiments/issues/1116>`_.


### PR DESCRIPTION
On backends with no coupling map (such as one could configure with `DynamicsBackend` from qiskit-dynamics), calibration experiments failed because the `BaseCalibrationExperiment` tried to pass the backend's `coupling_map` (run through `BackendData`) to terra's `CouplingMap` which acceprts `None`. The transpiler pass `FullAncillaAllocation` behaves differently when passed `None` than when passed `CouplingMap(None)`.