### PR TITLE
Remove `sphinx-autodoc-typehints` and minor doc fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,7 @@ nbsphinx_thumbnails = {
     "manuals/characterization/t2ramsey": "_images/t2ramsey_4_0.png",
     "manuals/characterization/tphi": "_images/tphi_5_1.png",
     "manuals/characterization/t2hahn": "_images/t2hahn_5_0.png",
+    "**": "_static/no_image.png",
 }
 
 # Add `data keys` and `style parameters` alias. Needed for `expected_*_data_keys` methods in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,6 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx_copybutton",
     "jupyter_sphinx",
-    "sphinx_autodoc_typehints",
     "reno.sphinxext",
     "sphinx_design",
     "sphinx.ext.intersphinx",
@@ -94,6 +93,13 @@ nbsphinx_thumbnails = {
 # Add `data keys` and `style parameters` alias. Needed for `expected_*_data_keys` methods in
 # visualization module and `default_style` method in `PlotStyle` respectively.
 napoleon_custom_sections = [("data keys", "params_style"), ("style parameters", "params_style")]
+
+# Move type hints from signatures to the parameter descriptions (except in overload cases, where
+# that's not possible).
+autodoc_typehints = "description"
+# Only add type hints from signature to description body if the parameter has documentation.  The
+# return type is always added to the description (if in the signature).
+autodoc_typehints_description_target = "documented_params"
 
 autosummary_generate = True
 

--- a/docs/manuals/characterization/t2hahn.rst
+++ b/docs/manuals/characterization/t2hahn.rst
@@ -50,8 +50,6 @@ following components:
 #. :math:`R_x \left(\pm \frac{\pi}{2} \right)` gate (sign depends on the number of echoes)
 #. Measurement gate
 
-|
-
 The user provides as input a series of delays in seconds. During the
 delay, we expect the qubit to precess about the z-axis. Because of the
 echo gate (:math:`R_x(\pi)`) for each echo, the angle after the delay

--- a/docs/manuals/characterization/t2ramsey.rst
+++ b/docs/manuals/characterization/t2ramsey.rst
@@ -31,8 +31,6 @@ The circuits used for the experiment comprise the following steps:
 #. Hadamard gate
 #. Measurement
 
-|
-
 The user provides as input a series of delays (in seconds) and the
 oscillation frequency (in Hz). During the delay, we expect the qubit to
 precess about the z-axis. If the p gate and the precession offset each

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -152,8 +152,6 @@ class ExperimentData:
     2. Managing jobs and adding data from jobs automatically
     3. Saving and loading data from the database service
 
-    |
-
     The field ``db_data`` is a dataclass (``ExperimentDataclass``) containing
     all the data that can be stored in the database and loaded from it, and
     as such is subject to strict conventions.

--- a/qiskit_experiments/framework/restless_mixin.py
+++ b/qiskit_experiments/framework/restless_mixin.py
@@ -53,6 +53,10 @@ class RestlessMixin:
     complex restless data processing such as two-qubit calibrations. In addition, this
     class makes it easy to determine if restless measurements are supported for a given
     experiment.
+
+    User Manual
+        :doc:`/manuals/measurement/restless_measurements`
+
     """
 
     analysis: BaseAnalysis

--- a/qiskit_experiments/library/characterization/correlated_readout_error.py
+++ b/qiskit_experiments/library/characterization/correlated_readout_error.py
@@ -74,6 +74,9 @@ class CorrelatedReadoutError(BaseExperiment):
     # section: analysis_ref
         :class:`CorrelatedReadoutErrorAnalysis`
 
+    # section: manual
+        :doc:`/manuals/measurement/readout_mitigation`
+
     # section: reference
         .. ref_arxiv:: 1 2006.14044
     """

--- a/qiskit_experiments/library/characterization/local_readout_error.py
+++ b/qiskit_experiments/library/characterization/local_readout_error.py
@@ -63,6 +63,9 @@ class LocalReadoutError(BaseExperiment):
     # section: analysis_ref
         :class:`LocalReadoutErrorAnalysis`
 
+    # section: manual
+        :doc:`/manuals/measurement/readout_mitigation`
+
     # section: reference
         .. ref_arxiv:: 1 2006.14044
     """

--- a/qiskit_experiments/library/characterization/readout_angle.py
+++ b/qiskit_experiments/library/characterization/readout_angle.py
@@ -47,8 +47,6 @@ class ReadoutAngle(BaseExperiment):
            the cluster centers of the ground and excited states.
         3. Analysis of results: return the average of the angles of the two centers.
 
-        |
-
     # section: analysis_ref
         :class:`ReadoutAngleAnalysis`
     """

--- a/qiskit_experiments/library/quantum_volume/qv_experiment.py
+++ b/qiskit_experiments/library/quantum_volume/qv_experiment.py
@@ -65,6 +65,9 @@ class QuantumVolume(BaseExperiment):
     # section: analysis_ref
         :class:`QuantumVolumeAnalysis`
 
+    # section: manual
+        :doc:`/manuals/verification/quantum_volume`
+
     # section: reference
         .. ref_arxiv:: 1 1811.12926
         .. ref_arxiv:: 2 2008.08571

--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_experiment.py
@@ -48,6 +48,9 @@ class InterleavedRB(StandardRB):
     # section: analysis_ref
         :class:`InterleavedRBAnalysis`
 
+    # section: manual
+        :doc:`/manuals/verification/randomized_benchmarking`
+
     # section: reference
         .. ref_arxiv:: 1 1203.4550
 

--- a/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
+++ b/qiskit_experiments/library/randomized_benchmarking/standard_rb.py
@@ -78,6 +78,9 @@ class StandardRB(BaseExperiment, RestlessMixin):
     # section: analysis_ref
         :class:`RBAnalysis`
 
+    # section: manual
+        :doc:`/manuals/verification/randomized_benchmarking`
+
     # section: reference
         .. ref_arxiv:: 1 1009.3639
         .. ref_arxiv:: 2 1109.6887

--- a/qiskit_experiments/library/tomography/qst_experiment.py
+++ b/qiskit_experiments/library/tomography/qst_experiment.py
@@ -45,6 +45,9 @@ class StateTomography(TomographyExperiment):
     # section: analysis_ref
         :class:`StateTomographyAnalysis`
 
+    # section: manual
+        :doc:`/manuals/verification/state_tomography`
+
     """
 
     @deprecate_arguments(

--- a/qiskit_experiments/visualization/drawers/base_drawer.py
+++ b/qiskit_experiments/visualization/drawers/base_drawer.py
@@ -111,8 +111,6 @@ class BaseDrawer(ABC):
        the scatter points as the legend graphics for the given series.
     4. Format the canvas and call :meth:`figure` to get the figure.
 
-    |
-
     .. rubric:: Options and Figure Options
 
     Drawers have both :attr:`options` and :attr:`figure_options` available to set

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@ jinja2==3.0.3
 sphinx~=5.0
 jupyter-sphinx>=0.4.0
 qiskit-sphinx-theme==1.11.0rc1
-sphinx-autodoc-typehints>=1.22.0
 sphinx-design==0.3.0
 pygments>=2.4
 reno>=4.0.0


### PR DESCRIPTION
### Summary

This PR follows https://github.com/Qiskit/qiskit-terra/pull/9705 to remove the dependency on `sphinx-autodoc-typehints` and https://github.com/Qiskit/qiskit-metapackage/issues/1707 to use the default Qiskit icon when the experiment manual isn't explicitly provided.

### Details and comments

In addition, some experiment classes that didn't link to their manuals have been updated with the link. Manual line breaks added after numbered lists have been removed now that https://github.com/Qiskit/qiskit_sphinx_theme/pull/218 has been merged.

