### PR TITLE
Change round in Rabi to avoid numpy int64 data type

### DIFF
--- a/qiskit_experiments/library/characterization/rabi.py
+++ b/qiskit_experiments/library/characterization/rabi.py
@@ -160,7 +160,7 @@ class Rabi(BaseExperiment, RestlessMixin):
         # Create the circuits to run
         circs = []
         for amp in self.experiment_options.amplitudes:
-            amp = np.round(amp, decimals=6)
+            amp = round(amp, ndigits=6)
             assigned_circ = circuit.assign_parameters({param: amp}, inplace=False)
             assigned_circ.metadata = {
                 "experiment_type": self._type,


### PR DESCRIPTION
### Summary

Change `np.round(amp, decimals=6)` to `round(amp, ndigits=6)` to avoid an error that occurs when scanning duration in `Rabi`.

### Details and comments

The default usage of `Rabi` is to scan the amplitude. However, the Rabi experiment can also be done by giving integer durations as amplitudes and a schedule with parameterised duration. Currently, we get the error `Object of type int64 is not JSON serializable` when doing so, because `np.round(amp, decimals=6)` changes the duration from a type 'int' to type `numpy.int64`. The PR avoids this error by changing this line of code to `round(amp, ndigits=6)`.

The `Rabi` experiment can later be improved to include the flexibility to scan duration instead of amplitude. In this case, the Rabi oscillation will be observed with time on the x axis. After this PR, this can be done by modifying the documentation and analysis class.

Closes #1125 
