### PR TITLE
Bump `qiskit-sphinx-theme` version

### DIFF
--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -1,4 +1,4 @@
-name: Docs Publish
+name: Dev Docs Publish
 on:
   push:
     branches: [ main ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ astroid~=2.14.2  # Must be kept aligned to what pylint wants
 jinja2==3.0.3
 sphinx~=5.0
 jupyter-sphinx>=0.4.0
-qiskit-sphinx-theme==1.11.0rc1
+qiskit-sphinx-theme~=1.11.0rc2
 sphinx-autodoc-typehints>=1.22.0
 sphinx-design==0.3.0
 pygments>=2.4


### PR DESCRIPTION

### Summary

Due to a many-hour outage of the `unpkg` CDN that broke our documentation top menu, the docs theme has switched over to `jsdelivr`. Our current docs have been redeployed with the updated `1.11.0rc2` theme, and this PR sets the version requirement to the highest compatible release instead of fixing the release version. It also changes the development branch docs workflow name so it's easily distinguished in the Actions tab.