### PR TITLE
Avoid constructing mpl MarkerStyle with no arguments

### DIFF
--- a/qiskit_experiments/curve_analysis/visualization/mpl_drawer.py
+++ b/qiskit_experiments/curve_analysis/visualization/mpl_drawer.py
@@ -36,7 +36,7 @@ from .base_drawer import BaseCurveDrawer
 class MplCurveDrawer(BaseCurveDrawer):
     """Curve drawer for MatplotLib backend."""
 
-    DefaultMarkers = MarkerStyle().filled_markers
+    DefaultMarkers = MarkerStyle.filled_markers
     DefaultColors = tab10.colors
 
     class PrefixFormatter(Formatter):


### PR DESCRIPTION
### Summary

Avoid constructing mpl MarkerStyle with no arguments

### Details and comments

This behaviour has been deprecated and is raising warnings. In the one place we happen to do that, we actually only need a class attribute, so we can just avoid the construction. Otherwise, [the recommendation](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.6.0.html#positional-keyword-arguments) is to construct with an empty string. 