### PR TITLE
Upgrade unittest equality method

### DIFF
--- a/releasenotes/notes/add-test-equality-checker-dbe5762d2b6a967f.yaml
+++ b/releasenotes/notes/add-test-equality-checker-dbe5762d2b6a967f.yaml
@@ -1,14 +1,14 @@
 ---
 developer:
   - |
-    Add :meth:`QiskitExperimentsTestCase.assertEqualExtended` method for generic equality check
+    Added the :meth:`QiskitExperimentsTestCase.assertEqualExtended` method for generic equality checks
     of Qiskit Experiments class instances in unittests. This is a drop-in replacement of 
     calling the assertTrue with :meth:`QiskitExperimentsTestCase.json_equiv`.
     Note that some Qiskit Experiments classes may not officially implement equality check logic,
     although objects may be compared during unittests. Extended equality check is used
     for such situations.
   - |
-    Following unittest test case methods will be deprecated:
+    The following unittest test case methods will be deprecated:
     
       * :meth:`QiskitExperimentsTestCase.json_equiv`
       * :meth:`QiskitExperimentsTestCase.ufloat_equiv`
@@ -16,10 +16,10 @@ developer:
       * :meth:`QiskitExperimentsTestCase.curve_fit_data_equiv`
       * :meth:`QiskitExperimentsTestCase.experiment_data_equiv`
     
-    One can now use :func:`~test.extended_equality.is_equivalent` method instead.
+    One can now use the :func:`~test.extended_equality.is_equivalent` function instead.
     This function internally dispatches the logic for equality check.
   - |
-    Default behavior of :meth:`QiskitExperimentsTestCase.assertRoundTripSerializable` and 
+    The default behavior of :meth:`QiskitExperimentsTestCase.assertRoundTripSerializable` and 
     :meth:`QiskitExperimentsTestCase.assertRoundTripPickle` when `check_func` is not 
     provided was upgraded. These methods now compare the decoded instance with
     :func:`~test.extended_equality.is_equivalent`, rather than 

--- a/releasenotes/notes/add-test-equality-checker-dbe5762d2b6a967f.yaml
+++ b/releasenotes/notes/add-test-equality-checker-dbe5762d2b6a967f.yaml
@@ -1,0 +1,27 @@
+---
+developer:
+  - |
+    Add :meth:`QiskitExperimentsTestCase.assertEqualExtended` method for generic equality check
+    of Qiskit Experiments class instances in unittests. This is a drop-in replacement of 
+    calling the assertTrue with :meth:`QiskitExperimentsTestCase.json_equiv`.
+    Note that some Qiskit Experiments classes may not officially implement equality check logic,
+    although objects may be compared during unittests. Extended equality check is used
+    for such situations.
+  - |
+    Following unittest test case methods will be deprecated:
+    
+      * :meth:`QiskitExperimentsTestCase.json_equiv`
+      * :meth:`QiskitExperimentsTestCase.ufloat_equiv`
+      * :meth:`QiskitExperimentsTestCase.analysis_result_equiv`
+      * :meth:`QiskitExperimentsTestCase.curve_fit_data_equiv`
+      * :meth:`QiskitExperimentsTestCase.experiment_data_equiv`
+    
+    One can now use :func:`~test.extended_equality.is_equivalent` method instead.
+    This function internally dispatches the logic for equality check.
+  - |
+    Default behavior of :meth:`QiskitExperimentsTestCase.assertRoundTripSerializable` and 
+    :meth:`QiskitExperimentsTestCase.assertRoundTripPickle` when `check_func` is not 
+    provided was upgraded. These methods now compare the decoded instance with
+    :func:`~test.extended_equality.is_equivalent`, rather than 
+    delegating to the native `assertEqual` unittest method.
+    One writing a unittest for serialization no longer need to explicitly set checker function.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,7 @@ qiskit-aer>=0.11.0
 pandas>=1.1.5
 cvxpy>=1.1.15
 pylatexenc
+multimethod
 scikit-learn
 sphinx-copybutton
 # Pin versions below because of build errors

--- a/test/base.py
+++ b/test/base.py
@@ -13,27 +13,22 @@
 Qiskit Experiments test case class
 """
 
-import dataclasses
 import json
 import pickle
 import warnings
 from typing import Any, Callable, Optional
 
-import numpy as np
 import uncertainties
-from lmfit import Model
 from qiskit.test import QiskitTestCase
-from qiskit_experiments.data_processing import DataAction, DataProcessor
-from qiskit_experiments.framework.experiment_data import ExperimentStatus
+from qiskit.utils.deprecation import deprecate_func
+
 from qiskit_experiments.framework import (
     ExperimentDecoder,
     ExperimentEncoder,
     ExperimentData,
-    BaseExperiment,
-    BaseAnalysis,
 )
-from qiskit_experiments.visualization import BaseDrawer
-from qiskit_experiments.curve_analysis.curve_data import CurveFitResult
+from qiskit_experiments.framework.experiment_data import ExperimentStatus
+from .extended_equality import is_equivalent
 
 
 class QiskitExperimentsTestCase(QiskitTestCase):
@@ -76,15 +71,38 @@ class QiskitExperimentsTestCase(QiskitTestCase):
             msg="All threads are executed but status is not DONE. " + experiment_data.errors(),
         )
 
+    def assertEqualExtended(
+        self,
+        first: Any,
+        second: Any,
+        msg: Optional[str] = None,
+    ):
+        """Extended equality assertion which covers Qiskit Experiments classes.
+
+        .. note::
+            Some Qiskit Experiments class may intentionally avoid implementing
+            the equality dunder method, or may be used in some unusual situations.
+            These are mainly caused by to JSON round trip situation, and some custom classes
+            doesn't guarantee object equality after round trip.
+            This assertion function forcibly compares input two objects with
+            the custom equality checker, which is implemented for unittest purpose.
+
+        Args:
+            first: First object to compare.
+            second: Second object to compare.
+            msg: Optional. Custom error message issued when first and second object are not equal.
+        """
+        default_msg = f"{first} != {second}"
+        self.assertTrue(is_equivalent(first, second), msg=msg or default_msg)
+
     def assertRoundTripSerializable(self, obj: Any, check_func: Optional[Callable] = None):
         """Assert that an object is round trip serializable.
 
         Args:
             obj: the object to be serialized.
             check_func: Optional, a custom function ``check_func(a, b) -> bool``
-                        to check equality of the original object with the decoded
-                        object. If None the ``__eq__`` method of the original
-                        object will be used.
+                to check equality of the original object with the decoded
+                object. If None :meth:`.assertEqualExtended` is called.
         """
         try:
             encoded = json.dumps(obj, cls=ExperimentEncoder)
@@ -94,10 +112,11 @@ class QiskitExperimentsTestCase(QiskitTestCase):
             decoded = json.loads(encoded, cls=ExperimentDecoder)
         except TypeError:
             self.fail("JSON deserialization raised unexpectedly.")
-        if check_func is None:
-            self.assertEqual(obj, decoded)
-        else:
+
+        if check_func is not None:
             self.assertTrue(check_func(obj, decoded), msg=f"{obj} != {decoded}")
+        else:
+            self.assertEqualExtended(obj, decoded)
 
     def assertRoundTripPickle(self, obj: Any, check_func: Optional[Callable] = None):
         """Assert that an object is round trip serializable using pickle module.
@@ -105,9 +124,8 @@ class QiskitExperimentsTestCase(QiskitTestCase):
         Args:
             obj: the object to be serialized.
             check_func: Optional, a custom function ``check_func(a, b) -> bool``
-                        to check equality of the original object with the decoded
-                        object. If None the ``__eq__`` method of the original
-                        object will be used.
+                to check equality of the original object with the decoded
+                object. If None :meth:`.assertEqualExtended` is called.
         """
         try:
             encoded = pickle.dumps(obj)
@@ -117,150 +135,63 @@ class QiskitExperimentsTestCase(QiskitTestCase):
             decoded = pickle.loads(encoded)
         except TypeError:
             self.fail("pickle deserialization raised unexpectedly.")
-        if check_func is None:
-            self.assertEqual(obj, decoded)
-        else:
+
+        if check_func is not None:
             self.assertTrue(check_func(obj, decoded), msg=f"{obj} != {decoded}")
+        else:
+            self.assertEqualExtended(obj, decoded)
 
     @classmethod
+    @deprecate_func(
+        since="0.6",
+        additional_msg="Use test.extended_equality.is_equivalent instead.",
+        pending=True,
+        package_name="qiskit-experiments",
+    )
     def json_equiv(cls, data1, data2) -> bool:
         """Check if two experiments are equivalent by comparing their configs"""
-        # pylint: disable = too-many-return-statements
-        configurable_type = (BaseExperiment, BaseAnalysis, BaseDrawer)
-        compare_repr = (DataAction, DataProcessor)
-        list_type = (list, tuple, set)
-        skipped = tuple()
-
-        if isinstance(data1, skipped) and isinstance(data2, skipped):
-            warnings.warn(f"Equivalence check for data {data1.__class__.__name__} is skipped.")
-            return True
-        elif isinstance(data1, configurable_type) and isinstance(data2, configurable_type):
-            return cls.json_equiv(data1.config(), data2.config())
-        elif dataclasses.is_dataclass(data1) and dataclasses.is_dataclass(data2):
-            # not using asdict. this copies all objects.
-            return cls.json_equiv(data1.__dict__, data2.__dict__)
-        elif isinstance(data1, dict) and isinstance(data2, dict):
-            if set(data1) != set(data2):
-                return False
-            return all(cls.json_equiv(data1[k], data2[k]) for k in data1.keys())
-        elif isinstance(data1, np.ndarray) or isinstance(data2, np.ndarray):
-            return np.allclose(data1, data2)
-        elif isinstance(data1, list_type) and isinstance(data2, list_type):
-            return all(cls.json_equiv(e1, e2) for e1, e2 in zip(data1, data2))
-        elif isinstance(data1, uncertainties.UFloat) and isinstance(data2, uncertainties.UFloat):
-            return cls.ufloat_equiv(data1, data2)
-        elif isinstance(data1, Model) and isinstance(data2, Model):
-            return cls.json_equiv(data1.dumps(), data2.dumps())
-        elif isinstance(data1, CurveFitResult) and isinstance(data2, CurveFitResult):
-            return cls.curve_fit_data_equiv(data1, data2)
-        elif isinstance(data1, compare_repr) and isinstance(data2, compare_repr):
-            # otherwise compare instance representation
-            return repr(data1) == repr(data2)
-
-        return data1 == data2
+        return is_equivalent(data1, data2)
 
     @staticmethod
+    @deprecate_func(
+        since="0.6",
+        additional_msg="Use test.extended_equality.is_equivalent instead.",
+        pending=True,
+        package_name="qiskit-experiments",
+    )
     def ufloat_equiv(data1: uncertainties.UFloat, data2: uncertainties.UFloat) -> bool:
         """Check if two values with uncertainties are equal. No correlation is considered."""
-        return data1.n == data2.n and data1.s == data2.s
+        return is_equivalent(data1, data2)
 
     @classmethod
+    @deprecate_func(
+        since="0.6",
+        additional_msg="Use test.extended_equality.is_equivalent instead.",
+        pending=True,
+        package_name="qiskit-experiments",
+    )
     def analysis_result_equiv(cls, result1, result2):
         """Test two analysis results are equivalent"""
-        # Check basic attributes skipping service which is not serializable
-        for att in [
-            "name",
-            "value",
-            "extra",
-            "device_components",
-            "result_id",
-            "experiment_id",
-            "chisq",
-            "quality",
-            "verified",
-            "tags",
-            "auto_save",
-            "source",
-        ]:
-            if not cls.json_equiv(getattr(result1, att), getattr(result2, att)):
-                return False
-        return True
+        return is_equivalent(result1, result2)
 
     @classmethod
+    @deprecate_func(
+        since="0.6",
+        additional_msg="Use test.extended_equality.is_equivalent instead.",
+        pending=True,
+        package_name="qiskit-experiments",
+    )
     def curve_fit_data_equiv(cls, data1, data2):
         """Test two curve fit result are equivalent."""
-        for att in [
-            "method",
-            "model_repr",
-            "success",
-            "nfev",
-            "message",
-            "dof",
-            "init_params",
-            "chisq",
-            "reduced_chisq",
-            "aic",
-            "bic",
-            "params",
-            "var_names",
-            "x_data",
-            "y_data",
-            "covar",
-        ]:
-            if not cls.json_equiv(getattr(data1, att), getattr(data2, att)):
-                return False
-        return True
+        return is_equivalent(data1, data2)
 
     @classmethod
+    @deprecate_func(
+        since="0.6",
+        additional_msg="Use test.extended_equality.is_equivalent instead.",
+        pending=True,
+        package_name="qiskit-experiments",
+    )
     def experiment_data_equiv(cls, data1, data2):
         """Check two experiment data containers are equivalent"""
-
-        # Check basic attributes
-        # Skip non-compatible backend
-        for att in [
-            "experiment_id",
-            "experiment_type",
-            "parent_id",
-            "tags",
-            "job_ids",
-            "figure_names",
-            "share_level",
-            "metadata",
-        ]:
-            if not cls.json_equiv(getattr(data1, att), getattr(data2, att)):
-                return False
-
-        # Check length of data, results, child_data
-        # check for child data attribute so this method still works for
-        # DbExperimentData
-        if hasattr(data1, "child_data"):
-            child_data1 = data1.child_data()
-        else:
-            child_data1 = []
-        if hasattr(data2, "child_data"):
-            child_data2 = data2.child_data()
-        else:
-            child_data2 = []
-
-        if (
-            len(data1.data()) != len(data2.data())
-            or len(data1.analysis_results()) != len(data2.analysis_results())
-            or len(child_data1) != len(child_data2)
-        ):
-            return False
-
-        # Check data
-        if not cls.json_equiv(data1.data(), data2.data()):
-            return False
-
-        # Check analysis results
-        for result1, result2 in zip(data1.analysis_results(), data2.analysis_results()):
-            if not cls.analysis_result_equiv(result1, result2):
-                return False
-
-        # Check child data
-        for child1, child2 in zip(child_data1, child_data2):
-            if not cls.experiment_data_equiv(child1, child2):
-                return False
-
-        return True
+        return is_equivalent(data1, data2)

--- a/test/base.py
+++ b/test/base.py
@@ -75,7 +75,9 @@ class QiskitExperimentsTestCase(QiskitTestCase):
         self,
         first: Any,
         second: Any,
+        *,
         msg: Optional[str] = None,
+        strict_type: bool = False,
     ):
         """Extended equality assertion which covers Qiskit Experiments classes.
 
@@ -91,11 +93,22 @@ class QiskitExperimentsTestCase(QiskitTestCase):
             first: First object to compare.
             second: Second object to compare.
             msg: Optional. Custom error message issued when first and second object are not equal.
+            strict_type: Set True to enforce type check before comparison.
         """
         default_msg = f"{first} != {second}"
-        self.assertTrue(is_equivalent(first, second), msg=msg or default_msg)
 
-    def assertRoundTripSerializable(self, obj: Any, check_func: Optional[Callable] = None):
+        self.assertTrue(
+            is_equivalent(first, second, strict_type=strict_type),
+            msg=msg or default_msg,
+        )
+
+    def assertRoundTripSerializable(
+        self,
+        obj: Any,
+        *,
+        check_func: Optional[Callable] = None,
+        strict_type: bool = False,
+    ):
         """Assert that an object is round trip serializable.
 
         Args:
@@ -103,6 +116,7 @@ class QiskitExperimentsTestCase(QiskitTestCase):
             check_func: Optional, a custom function ``check_func(a, b) -> bool``
                 to check equality of the original object with the decoded
                 object. If None :meth:`.assertEqualExtended` is called.
+            strict_type: Set True to enforce type check before comparison.
         """
         try:
             encoded = json.dumps(obj, cls=ExperimentEncoder)
@@ -116,9 +130,15 @@ class QiskitExperimentsTestCase(QiskitTestCase):
         if check_func is not None:
             self.assertTrue(check_func(obj, decoded), msg=f"{obj} != {decoded}")
         else:
-            self.assertEqualExtended(obj, decoded)
+            self.assertEqualExtended(obj, decoded, strict_type=strict_type)
 
-    def assertRoundTripPickle(self, obj: Any, check_func: Optional[Callable] = None):
+    def assertRoundTripPickle(
+        self,
+        obj: Any,
+        *,
+        check_func: Optional[Callable] = None,
+        strict_type: bool = False,
+    ):
         """Assert that an object is round trip serializable using pickle module.
 
         Args:
@@ -126,6 +146,7 @@ class QiskitExperimentsTestCase(QiskitTestCase):
             check_func: Optional, a custom function ``check_func(a, b) -> bool``
                 to check equality of the original object with the decoded
                 object. If None :meth:`.assertEqualExtended` is called.
+            strict_type: Set True to enforce type check before comparison.
         """
         try:
             encoded = pickle.dumps(obj)
@@ -139,7 +160,7 @@ class QiskitExperimentsTestCase(QiskitTestCase):
         if check_func is not None:
             self.assertTrue(check_func(obj, decoded), msg=f"{obj} != {decoded}")
         else:
-            self.assertEqualExtended(obj, decoded)
+            self.assertEqualExtended(obj, decoded, strict_type=strict_type)
 
     @classmethod
     @deprecate_func(

--- a/test/calibration/test_calibrations.py
+++ b/test/calibration/test_calibrations.py
@@ -1754,7 +1754,7 @@ class TestSerialization(QiskitExperimentsTestCase):
         cals = Calibrations.from_backend(backend, libraries=[library])
         cals.add_parameter_value(0.12345, "amp", 3, "x")
 
-        self.assertRoundTripSerializable(cals, self.json_equiv)
+        self.assertRoundTripSerializable(cals)
 
     def test_equality(self):
         """Test the equal method on calibrations."""

--- a/test/curve_analysis/test_baseclass.py
+++ b/test/curve_analysis/test_baseclass.py
@@ -85,7 +85,7 @@ class TestCurveAnalysis(CurveAnalysisTestCase):
     def test_roundtrip_serialize(self):
         """A testcase for serializing analysis instance."""
         analysis = CurveAnalysis(models=[ExpressionModel(expr="par0 * x + par1", name="test")])
-        self.assertRoundTripSerializable(analysis, check_func=self.json_equiv)
+        self.assertRoundTripSerializable(analysis)
 
     def test_parameters(self):
         """A testcase for getting fit parameters with attribute."""

--- a/test/data_processing/test_data_processing.py
+++ b/test/data_processing/test_data_processing.py
@@ -387,14 +387,14 @@ class TestDataProcessor(BaseDataProcessorTest):
         """Check if the data processor is serializable."""
         node = MinMaxNormalize()
         processor = DataProcessor("counts", [node])
-        self.assertRoundTripSerializable(processor, check_func=self.json_equiv)
+        self.assertRoundTripSerializable(processor)
 
     def test_json_multi_node(self):
         """Check if the data processor with multiple nodes is serializable."""
         node1 = MinMaxNormalize()
         node2 = AverageData(axis=2)
         processor = DataProcessor("counts", [node1, node2])
-        self.assertRoundTripSerializable(processor, check_func=self.json_equiv)
+        self.assertRoundTripSerializable(processor)
 
     def test_json_trained(self):
         """Check if trained data processor is serializable and still work."""
@@ -405,7 +405,7 @@ class TestDataProcessor(BaseDataProcessorTest):
             main_axes=np.array([[1, 0]]), scales=[1.0], i_means=[0.0], q_means=[0.0]
         )
         processor = DataProcessor("memory", data_actions=[node])
-        self.assertRoundTripSerializable(processor, check_func=self.json_equiv)
+        self.assertRoundTripSerializable(processor)
 
         serialized = json.dumps(processor, cls=ExperimentEncoder)
         loaded_processor = json.loads(serialized, cls=ExperimentDecoder)

--- a/test/data_processing/test_discriminator.py
+++ b/test/data_processing/test_discriminator.py
@@ -79,7 +79,7 @@ class TestDiscriminator(QiskitExperimentsTestCase):
 
             return True
 
-        self.assertRoundTripSerializable(lda, check_lda)
+        self.assertRoundTripSerializable(lda, check_func=check_lda)
 
     @requires_sklearn
     def test_qda_serialization(self):
@@ -119,4 +119,4 @@ class TestDiscriminator(QiskitExperimentsTestCase):
 
             return True
 
-        self.assertRoundTripSerializable(qda, check_qda)
+        self.assertRoundTripSerializable(qda, check_func=check_qda)

--- a/test/data_processing/test_nodes.py
+++ b/test/data_processing/test_nodes.py
@@ -154,7 +154,7 @@ class TestAveraging(BaseDataProcessorTest):
     def test_json(self):
         """Check if the node is serializable."""
         node = AverageData(axis=3)
-        self.assertRoundTripSerializable(node, check_func=self.json_equiv)
+        self.assertRoundTripSerializable(node)
 
 
 class TestToAbs(QiskitExperimentsTestCase):
@@ -228,7 +228,7 @@ class TestNormalize(QiskitExperimentsTestCase):
     def test_json(self):
         """Check if the node is serializable."""
         node = MinMaxNormalize()
-        self.assertRoundTripSerializable(node, check_func=self.json_equiv)
+        self.assertRoundTripSerializable(node)
 
 
 class TestSVD(BaseDataProcessorTest):
@@ -401,7 +401,7 @@ class TestSVD(BaseDataProcessorTest):
     def test_json(self):
         """Check if the node is serializable."""
         node = SVD()
-        self.assertRoundTripSerializable(node, check_func=self.json_equiv)
+        self.assertRoundTripSerializable(node)
 
     def test_json_trained(self):
         """Check if the trained node is serializable."""
@@ -409,7 +409,7 @@ class TestSVD(BaseDataProcessorTest):
         node.set_parameters(
             main_axes=np.array([[1.0, 2.0]]), scales=[1.0], i_means=[2.0], q_means=[3.0]
         )
-        self.assertRoundTripSerializable(node, check_func=self.json_equiv)
+        self.assertRoundTripSerializable(node)
 
         loaded_node = json.loads(json.dumps(node, cls=ExperimentEncoder), cls=ExperimentDecoder)
         self.assertTrue(loaded_node.is_trained)
@@ -643,7 +643,7 @@ class TestMarginalize(QiskitExperimentsTestCase):
     def test_json(self):
         """Check if the node is serializable."""
         node = MarginalizeCounts(qubits_to_keep={0, 1})
-        self.assertRoundTripSerializable(node, check_func=self.json_equiv)
+        self.assertRoundTripSerializable(node)
 
 
 class TestProbability(QiskitExperimentsTestCase):
@@ -675,7 +675,7 @@ class TestProbability(QiskitExperimentsTestCase):
     def test_json(self):
         """Check if the node is serializable."""
         node = Probability(outcome="00", alpha_prior=0.2)
-        self.assertRoundTripSerializable(node, check_func=self.json_equiv)
+        self.assertRoundTripSerializable(node)
 
 
 class TestRestless(QiskitExperimentsTestCase):

--- a/test/database_service/test_db_analysis_result.py
+++ b/test/database_service/test_db_analysis_result.py
@@ -202,11 +202,7 @@ class TestAnalysisResult(QiskitExperimentsTestCase):
         original_result = AnalysisResult(value=value, tags=["tag1", "tag2"], **attrs)
         copied_result = original_result.copy()
         if isinstance(value, uncertainties.UFloat):
-            # If the value is an uncertainties ufloat, compare using `ufloat_equiv`
-            self.assertTrue(
-                self.ufloat_equiv(original_result.value, copied_result.value),
-                f"{original_result.value}!={copied_result.value}",
-            )
+            self.assertEqualExtended(original_result.value, copied_result.value)
         else:
             self.assertEqual(
                 original_result.value,

--- a/test/database_service/test_json.py
+++ b/test/database_service/test_json.py
@@ -61,7 +61,7 @@ class TestJSON(QiskitExperimentsTestCase):
         obj = FakeExperiment([0])
         obj.set_transpile_options(optimization_level=3, basis_gates=["rx", "ry", "cz"])
         obj.set_run_options(shots=2000)
-        self.assertRoundTripSerializable(obj, self.json_equiv)
+        self.assertRoundTripSerializable(obj)
 
     @ddt.data(SXGate(), RZXGate(0.4), Barrier(5), Measure())
     def test_roundtrip_gate(self, instruction):

--- a/test/extended_equality.py
+++ b/test/extended_equality.py
@@ -132,7 +132,7 @@ def _check_floats(
     precision = kwargs.get("numerical_precision", 0.0)
     if precision == 0.0:
         return float(data1) == float(data2)
-    return np.isclose(np.abs(data1-data2), 0.0, atol=precision)
+    return np.isclose(np.abs(data1 - data2), 0.0, atol=precision)
 
 
 @_is_equivalent_dispatcher.register

--- a/test/extended_equality.py
+++ b/test/extended_equality.py
@@ -9,6 +9,9 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
+# pylint: disable=unused-argument
+
 """
 Utility for checking equality of data of Qiskit Experiments class which doesn't
 officially implement the equality dunder method.
@@ -36,10 +39,54 @@ from qiskit_experiments.framework import (
 from qiskit_experiments.visualization import BaseDrawer
 
 
-@multimethod
 def is_equivalent(
+    data1: Any,
+    data2: Any,
+    *,
+    strict_type: bool = True,
+    numerical_precision: float = 1e-8,
+) -> bool:
+    """Check if two input data are equivalent.
+
+    This function is used for custom equivalence evaluation only for unittest purpose.
+    Some third party class may not preserve equivalence after JSON round-trip with
+    Qiskit Experiments JSON Encoder/Decoder, or some Qiskit Experiments class doesn't
+    define the equality dunder method intentionally.
+
+    Args:
+        data1: First data to compare.
+        data2: Second data to compare.
+        strict_type: Set True to enforce type check before comparison. Note that serialization
+            and deserialization round-trip may not preserve data type.
+            If the data type doesn't matter and only behavioral equivalence is considered,
+            e.g. iterator with the same element; tuple vs list,
+            you can turn off this flag to relax the constraint for data type.
+        numerical_precision: Tolerance of difference between two real numbers.
+
+    Returns:
+        True when two objects are equivalent.
+    """
+    if strict_type and type(data1) is not type(data2):
+        return False
+    evaluated = _is_equivalent_dispatcher(
+        data1,
+        data2,
+        strict_type=strict_type,
+        numerical_precision=numerical_precision,
+    )
+    if not isinstance(evaluated, (bool, np.bool_)):
+        # When either one of input is numpy array type, it may broadcast equality check
+        # and return ndarray of dtype=bool. e.g. np.array([]) == 123
+        # The input values should not be equal in this case.
+        return False
+    return evaluated
+
+
+@multimethod
+def _is_equivalent_dispatcher(
     data1: object,
     data2: object,
+    **kwargs,
 ):
     """Equality check finally falls into this function."""
     if data1 is None and data2 is None:
@@ -50,33 +97,28 @@ def is_equivalent(
         return is_equivalent(
             data1.__dict__,
             data2.__dict__,
+            **kwargs,
         )
-    evaluated = data1 == data2
-    if not isinstance(evaluated, bool):
-        # When either one of input is numpy array type, it may broadcast equality check
-        # and return ndarray of dtype=bool. e.g. np.array([]) == 123
-        # The input values should not be equal in this case.
-        return False
-
-    # Return the outcome of native equivalence check.
-    return evaluated
+    return data1 == data2
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_dicts(
     data1: Union[dict, ThreadSafeOrderedDict],
     data2: Union[dict, ThreadSafeOrderedDict],
+    **kwargs,
 ):
     """Check equality of dictionary which may involve Qiskit Experiments classes."""
     if set(data1) != set(data2):
         return False
-    return all(is_equivalent(data1[k], data2[k]) for k in data1.keys())
+    return all(is_equivalent(data1[k], data2[k], **kwargs) for k in data1.keys())
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_floats(
     data1: Union[float, np.floating],
     data2: Union[float, np.floating],
+    **kwargs,
 ):
     """Check equality of float.
 
@@ -86,13 +128,18 @@ def _check_floats(
     if np.isnan(data1) and np.isnan(data2):
         # Special case
         return True
-    return float(data1) == float(data2)
+
+    precision = kwargs.get("numerical_precision", 0.0)
+    if precision == 0.0:
+        return float(data1) == float(data2)
+    return np.isclose(np.abs(data1-data2), 0.0, atol=precision)
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_integer(
     data1: Union[int, np.integer],
     data2: Union[int, np.integer],
+    **kwargs,
 ):
     """Check equality of integer.
 
@@ -101,59 +148,65 @@ def _check_integer(
     return int(data1) == int(data2)
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_sequences(
     data1: Union[list, tuple, np.ndarray, ThreadSafeList],
     data2: Union[list, tuple, np.ndarray, ThreadSafeList],
+    **kwargs,
 ):
     """Check equality of sequence."""
     if len(data1) != len(data2):
         return False
-    return all(is_equivalent(e1, e2) for e1, e2 in zip(data1, data2))
+    return all(is_equivalent(e1, e2, **kwargs) for e1, e2 in zip(data1, data2))
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_unordered_sequences(
     data1: set,
     data2: set,
+    **kwargs,
 ):
     """Check equality of sequence after sorting."""
     if len(data1) != len(data2):
         return False
-    return all(is_equivalent(e1, e2) for e1, e2 in zip(sorted(data1), sorted(data2)))
+    return all(is_equivalent(e1, e2, **kwargs) for e1, e2 in zip(sorted(data1), sorted(data2)))
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_ufloats(
     data1: uncertainties.UFloat,
     data2: uncertainties.UFloat,
+    **kwargs,
 ):
     """Check equality of UFloat instance. Correlations are ignored."""
-    return data1.n == data2.n and data1.s == data2.s
+    return is_equivalent(data1.n, data2.n, **kwargs) and is_equivalent(data1.s, data2.s, **kwargs)
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_lmfit_models(
     data1: Model,
     data2: Model,
+    **kwargs,
 ):
     """Check equality of LMFIT model."""
-    return is_equivalent(data1.dumps(), data2.dumps())
+    return is_equivalent(data1.dumps(), data2.dumps(), **kwargs)
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_dataprocessing_instances(
     data1: Union[DataAction, DataProcessor],
     data2: Union[DataAction, DataProcessor],
+    **kwargs,
 ):
     """Check equality of classes in the data_processing module."""
     return repr(data1) == repr(data2)
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_curvefit_results(
     data1: CurveFitResult,
     data2: CurveFitResult,
+    **kwargs,
 ):
     """Check equality of curve fit result."""
     return _check_all_attributes(
@@ -177,13 +230,15 @@ def _check_curvefit_results(
         ],
         data1=data1,
         data2=data2,
+        **kwargs,
     )
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_service_analysis_results(
     data1: AnalysisResult,
     data2: AnalysisResult,
+    **kwargs,
 ):
     """Check equality of AnalysisResult class which is payload for experiment service."""
     return _check_all_attributes(
@@ -203,22 +258,25 @@ def _check_service_analysis_results(
         ],
         data1=data1,
         data2=data2,
+        **kwargs,
     )
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_configurable_classes(
     data1: Union[BaseExperiment, BaseAnalysis, BaseDrawer],
     data2: Union[BaseExperiment, BaseAnalysis, BaseDrawer],
+    **kwargs,
 ):
     """Check equality of Qiskit Experiments class with config method."""
-    return is_equivalent(data1.config(), data2.config())
+    return is_equivalent(data1.config(), data2.config(), **kwargs)
 
 
-@is_equivalent.register
+@_is_equivalent_dispatcher.register
 def _check_experiment_data(
     data1: ExperimentData,
     data2: ExperimentData,
+    **kwargs,
 ):
     """Check equality of ExperimentData."""
     attributes_equiv = _check_all_attributes(
@@ -234,18 +292,22 @@ def _check_experiment_data(
         ],
         data1=data1,
         data2=data2,
+        **kwargs,
     )
     data_equiv = is_equivalent(
         data1.data(),
         data2.data(),
+        **kwargs,
     )
     analysis_results_equiv = is_equivalent(
         data1._analysis_results,
         data2._analysis_results,
+        **kwargs,
     )
     child_equiv = is_equivalent(
         data1.child_data(),
         data2.child_data(),
+        **kwargs,
     )
     return all([attributes_equiv, data_equiv, analysis_results_equiv, child_equiv])
 
@@ -254,6 +316,7 @@ def _check_all_attributes(
     attrs: List[str],
     data1: Any,
     data2: Any,
+    **kwargs,
 ):
     """Helper function to check all attributes."""
-    return all(is_equivalent(getattr(data1, att), getattr(data2, att)) for att in attrs)
+    return all(is_equivalent(getattr(data1, att), getattr(data2, att), **kwargs) for att in attrs)

--- a/test/extended_equality.py
+++ b/test/extended_equality.py
@@ -1,0 +1,244 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Utility for checking equality of data of Qiskit Experiments class which doesn't
+officially implement the equality dunder method.
+"""
+
+import dataclasses
+from typing import Any, List, Union
+
+import numpy as np
+import uncertainties
+from lmfit import Model
+from multimethod import multimethod
+from qiskit_experiments.curve_analysis.curve_data import CurveFitResult
+from qiskit_experiments.data_processing import DataAction, DataProcessor
+from qiskit_experiments.database_service.utils import (
+    ThreadSafeList,
+    ThreadSafeOrderedDict,
+)
+from qiskit_experiments.framework import (
+    ExperimentData,
+    BaseExperiment,
+    BaseAnalysis,
+    AnalysisResult,
+)
+from qiskit_experiments.visualization import BaseDrawer
+
+
+@multimethod
+def is_equivalent(
+    data1: object,
+    data2: object,
+):
+    """Equality check finally falls into this function."""
+    if data1 is None and data2 is None:
+        return True
+    if dataclasses.is_dataclass(data1) and dataclasses.is_dataclass(data2):
+        # Avoid dataclass asdict. This copies dictionary but experiment config dataclass
+        # may include type information which cannot be copied.
+        return is_equivalent(
+            data1.__dict__,
+            data2.__dict__,
+        )
+    return data1 == data2
+
+
+@is_equivalent.register
+def _check_dicts(
+    data1: Union[dict, ThreadSafeOrderedDict],
+    data2: Union[dict, ThreadSafeOrderedDict],
+):
+    """Check equality of dictionary which may involve Qiskit Experiments classes."""
+    if set(data1) != set(data2):
+        return False
+    return all(is_equivalent(data1[k], data2[k]) for k in data1.keys())
+
+
+@is_equivalent.register
+def _check_floats(
+    data1: float,
+    data2: float,
+):
+    """Check equality of float. This function supports float("nan")."""
+    if np.isnan(data1) and np.isnan(data2):
+        # Special case
+        return True
+    return data1 == data2
+
+
+@is_equivalent.register
+def _check_ndarrays(
+    data1: np.ndarray,
+    data2: np.ndarray,
+):
+    """Check equality of numpy ndarray."""
+    return np.allclose(data1, data2)
+
+
+@is_equivalent.register
+def _check_sequences(
+    data1: Union[list, tuple, ThreadSafeList],
+    data2: Union[list, tuple, ThreadSafeList],
+):
+    """Check equality of sequence."""
+    if len(data1) != len(data2):
+        return False
+    return all(is_equivalent(e1, e2) for e1, e2 in zip(data1, data2))
+
+
+@is_equivalent.register
+def _check_unordered_sequences(
+    data1: set,
+    data2: set,
+):
+    """Check equality of sequence after sorting."""
+    if len(data1) != len(data2):
+        return False
+    return all(is_equivalent(e1, e2) for e1, e2 in zip(sorted(data1), sorted(data2)))
+
+
+@is_equivalent.register
+def _check_ufloats(
+    data1: uncertainties.UFloat,
+    data2: uncertainties.UFloat,
+):
+    """Check equality of UFloat instance. Correlations are ignored."""
+    return data1.n == data2.n and data1.s == data2.s
+
+
+@is_equivalent.register
+def _check_lmfit_models(
+    data1: Model,
+    data2: Model,
+):
+    """Check equality of LMFIT model."""
+    return is_equivalent(data1.dumps(), data2.dumps())
+
+
+@is_equivalent.register
+def _check_dataprocessing_instances(
+    data1: Union[DataAction, DataProcessor],
+    data2: Union[DataAction, DataProcessor],
+):
+    """Check equality of classes in the data_processing module."""
+    return repr(data1) == repr(data2)
+
+
+@is_equivalent.register
+def _check_curvefit_results(
+    data1: CurveFitResult,
+    data2: CurveFitResult,
+):
+    """Check equality of curve fit result."""
+    return _check_all_attributes(
+        attrs=[
+            "method",
+            "model_repr",
+            "success",
+            "nfev",
+            "message",
+            "dof",
+            "init_params",
+            "chisq",
+            "reduced_chisq",
+            "aic",
+            "bic",
+            "params",
+            "var_names",
+            "x_data",
+            "y_data",
+            "covar",
+        ],
+        data1=data1,
+        data2=data2,
+    )
+
+
+@is_equivalent.register
+def _check_service_analysis_results(
+    data1: AnalysisResult,
+    data2: AnalysisResult,
+):
+    """Check equality of AnalysisResult class which is payload for experiment service."""
+    return _check_all_attributes(
+        attrs=[
+            "name",
+            "value",
+            "extra",
+            "device_components",
+            "result_id",
+            "experiment_id",
+            "chisq",
+            "quality",
+            "verified",
+            "tags",
+            "auto_save",
+            "source",
+        ],
+        data1=data1,
+        data2=data2,
+    )
+
+
+@is_equivalent.register
+def _check_configurable_classes(
+    data1: Union[BaseExperiment, BaseAnalysis, BaseDrawer],
+    data2: Union[BaseExperiment, BaseAnalysis, BaseDrawer],
+):
+    """Check equality of Qiskit Experiments class with config method."""
+    return is_equivalent(data1.config(), data2.config())
+
+
+@is_equivalent.register
+def _check_experiment_data(
+    data1: ExperimentData,
+    data2: ExperimentData,
+):
+    """Check equality of ExperimentData."""
+    attributes_equiv = _check_all_attributes(
+        attrs=[
+            "experiment_id",
+            "experiment_type",
+            "parent_id",
+            "tags",
+            "job_ids",
+            "figure_names",
+            "share_level",
+            "metadata",
+        ],
+        data1=data1,
+        data2=data2,
+    )
+    data_equiv = is_equivalent(
+        data1.data(),
+        data2.data(),
+    )
+    analysis_results_equiv = is_equivalent(
+        data1._analysis_results,
+        data2._analysis_results,
+    )
+    child_equiv = is_equivalent(
+        data1.child_data(),
+        data2.child_data(),
+    )
+    return all([attributes_equiv, data_equiv, analysis_results_equiv, child_equiv])
+
+
+def _check_all_attributes(
+    attrs: List[str],
+    data1: Any,
+    data2: Any,
+):
+    """Helper function to check all attributes."""
+    return all(is_equivalent(getattr(data1, att), getattr(data2, att)) for att in attrs)

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -130,7 +130,7 @@ class TestComposite(QiskitExperimentsTestCase):
 
         loaded_exp = BatchExperiment.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
@@ -141,7 +141,7 @@ class TestComposite(QiskitExperimentsTestCase):
 
         exp = BatchExperiment([exp1, exp2])
 
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
 
 @ddt

--- a/test/library/calibration/test_drag.py
+++ b/test/library/calibration/test_drag.py
@@ -230,13 +230,13 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
         exp = RoughDragCal([0], self.cals, backend=self.backend)
         loaded_exp = RoughDragCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     @unittest.skip("Calibration experiments are not yet JSON serializable")
     def test_dragcal_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = RoughDragCal([0], self.cals)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
     def test_drag_experiment_config(self):
         """Test RoughDrag config can roundtrip"""
@@ -245,7 +245,7 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
         exp = RoughDrag([0], backend=self.backend, schedule=sched)
         loaded_exp = RoughDrag.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     @unittest.skip("Schedules are not yet JSON serializable")
     def test_drag_roundtrip_serializable(self):
@@ -253,4 +253,4 @@ class TestRoughDragCalUpdate(QiskitExperimentsTestCase):
         with pulse.build(name="xp") as sched:
             pulse.play(pulse.Drag(160, 0.5, 40, Parameter("β")), pulse.DriveChannel(0))
         exp = RoughDrag([0], backend=self.backend, schedule=sched)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)

--- a/test/library/calibration/test_fine_amplitude.py
+++ b/test/library/calibration/test_fine_amplitude.py
@@ -107,7 +107,7 @@ class TestFineZXAmpEndToEnd(QiskitExperimentsTestCase):
         exp = FineZXAmplitude((0, 1))
         loaded_exp = FineZXAmplitude.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
 
 class TestFineAmplitudeCircuits(QiskitExperimentsTestCase):
@@ -168,7 +168,7 @@ class TestSpecializations(QiskitExperimentsTestCase):
     def test_x_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = FineXAmplitude([0])
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
     def test_fine_sx_amp(self):
         """Test the fine SX amplitude."""
@@ -188,7 +188,7 @@ class TestSpecializations(QiskitExperimentsTestCase):
     def test_sx_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = FineSXAmplitude([0])
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
     @data((2, 3), (3, 1), (0, 1))
     def test_measure_qubits(self, qubits):
@@ -319,9 +319,9 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         exp = FineSXAmplitudeCal([0], self.cals, "sx")
         loaded_exp = FineSXAmplitudeCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = FineSXAmplitudeCal([0], self.cals, "sx")
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)

--- a/test/library/calibration/test_fine_frequency.py
+++ b/test/library/calibration/test_fine_frequency.py
@@ -97,9 +97,9 @@ class TestFineFreqEndToEnd(QiskitExperimentsTestCase):
         exp = FineFrequency([0], 160)
         loaded_exp = FineFrequency.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = FineFrequency([0], 160)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)

--- a/test/library/calibration/test_rabi.py
+++ b/test/library/calibration/test_rabi.py
@@ -83,13 +83,13 @@ class TestRabiEndToEnd(QiskitExperimentsTestCase):
         exp = Rabi([self.qubit], self.sched)
         loaded_exp = Rabi.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     @unittest.skip("Schedules are not yet JSON serializable")
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = Rabi([self.qubit], self.sched)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
 
 class TestEFRabi(QiskitExperimentsTestCase):
@@ -154,13 +154,13 @@ class TestEFRabi(QiskitExperimentsTestCase):
         exp = EFRabi([0], self.sched)
         loaded_exp = EFRabi.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     @unittest.skip("Schedules are not yet JSON serializable")
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = EFRabi([0], self.sched)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
 
 class TestRabiCircuits(QiskitExperimentsTestCase):

--- a/test/library/calibration/test_ramsey_xy.py
+++ b/test/library/calibration/test_ramsey_xy.py
@@ -122,22 +122,22 @@ class TestRamseyXY(QiskitExperimentsTestCase):
         exp = RamseyXY([0])
         loaded_exp = RamseyXY.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_ramseyxy_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = RamseyXY([0])
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
     def test_cal_experiment_config(self):
         """Test FrequencyCal config roundtrips"""
         exp = FrequencyCal([0], self.cals)
         loaded_exp = FrequencyCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     @unittest.skip("Cal experiments are not yet JSON serializable")
     def test_freqcal_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = FrequencyCal([0], self.cals)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)

--- a/test/library/calibration/test_rough_frequency.py
+++ b/test/library/calibration/test_rough_frequency.py
@@ -79,4 +79,4 @@ class TestRoughFrequency(QiskitExperimentsTestCase):
         exp = RoughFrequencyCal([0], cals, frequencies)
         loaded_exp = RoughFrequencyCal.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)

--- a/test/library/characterization/test_cross_resonance_hamiltonian.py
+++ b/test/library/characterization/test_cross_resonance_hamiltonian.py
@@ -179,7 +179,7 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
         # Thus at least one of these values should be round-trip tested.
         res_ix = exp_data.analysis_results("omega_ix")
         self.assertAlmostEqual(res_ix.value.n, ix, delta=delta)
-        self.assertRoundTripSerializable(res_ix.value, check_func=self.ufloat_equiv)
+        self.assertRoundTripSerializable(res_ix.value)
         self.assertEqual(res_ix.extra["unit"], "Hz")
 
         self.assertAlmostEqual(exp_data.analysis_results("omega_iy").value.n, iy, delta=delta)
@@ -249,7 +249,7 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
         )
         loaded_exp = cr_hamiltonian.CrossResonanceHamiltonian.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
@@ -260,4 +260,4 @@ class TestCrossResonanceHamiltonian(QiskitExperimentsTestCase):
             sigma=64,
             risefall=2,
         )
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)

--- a/test/library/characterization/test_qubit_spectroscopy.py
+++ b/test/library/characterization/test_qubit_spectroscopy.py
@@ -52,7 +52,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
         result = expdata.analysis_results(1)
-        self.assertRoundTripSerializable(result.value, check_func=self.ufloat_equiv)
+        self.assertRoundTripSerializable(result.value)
 
         self.assertAlmostEqual(result.value.n, freq01, delta=1e6)
         self.assertEqual(result.quality, "good")
@@ -65,7 +65,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
         result = expdata.analysis_results(1)
-        self.assertRoundTripSerializable(result.value, check_func=self.ufloat_equiv)
+        self.assertRoundTripSerializable(result.value)
 
         self.assertAlmostEqual(result.value.n, freq01 + 5e6, delta=1e6)
         self.assertEqual(result.quality, "good")
@@ -91,7 +91,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
         result = expdata.analysis_results(1)
-        self.assertRoundTripSerializable(result.value, check_func=self.ufloat_equiv)
+        self.assertRoundTripSerializable(result.value)
 
         self.assertTrue(freq01 - 2e6 < result.value.n < freq01 + 2e6)
         self.assertEqual(result.quality, "good")
@@ -103,7 +103,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
         result = expdata.analysis_results(1)
-        self.assertRoundTripSerializable(result.value, check_func=self.ufloat_equiv)
+        self.assertRoundTripSerializable(result.value)
 
         self.assertTrue(freq01 + 3e6 < result.value.n < freq01 + 8e6)
         self.assertEqual(result.quality, "good")
@@ -112,7 +112,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
         result = expdata.analysis_results(1)
-        self.assertRoundTripSerializable(result.value, check_func=self.ufloat_equiv)
+        self.assertRoundTripSerializable(result.value)
 
         self.assertTrue(freq01 + 3e6 < result.value.n < freq01 + 8e6)
         self.assertEqual(result.quality, "good")
@@ -140,7 +140,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
         result = expdata.analysis_results(1)
-        self.assertRoundTripSerializable(result.value, check_func=self.ufloat_equiv)
+        self.assertRoundTripSerializable(result.value)
 
         self.assertTrue(freq01 - 2e6 < result.value.n < freq01 + 2e6)
         self.assertEqual(result.quality, "good")
@@ -155,13 +155,13 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         exp = QubitSpectroscopy([1], np.linspace(100, 150, 20) * 1e6)
         loaded_exp = QubitSpectroscopy.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = QubitSpectroscopy([1], np.linspace(int(100e6), int(150e6), int(20e6)))
         # Checking serialization of the experiment
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
     def test_expdata_serialization(self):
         """Test experiment data and analysis data JSON serialization"""
@@ -185,10 +185,10 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         self.assertExperimentDone(expdata)
 
         # Checking serialization of the experiment data
-        self.assertRoundTripSerializable(expdata, self.experiment_data_equiv)
+        self.assertRoundTripSerializable(expdata)
 
         # Checking serialization of the analysis
-        self.assertRoundTripSerializable(expdata.analysis_results(1), self.analysis_result_equiv)
+        self.assertRoundTripSerializable(expdata.analysis_results(1))
 
     def test_kerneled_expdata_serialization(self):
         """Test experiment data and analysis data JSON serialization"""
@@ -212,10 +212,10 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         self.assertExperimentDone(expdata)
 
         # Checking serialization of the experiment data
-        self.assertRoundTripSerializable(expdata, self.experiment_data_equiv)
+        self.assertRoundTripSerializable(expdata)
 
         # Checking serialization of the analysis
-        self.assertRoundTripSerializable(expdata.analysis_results(1), self.analysis_result_equiv)
+        self.assertRoundTripSerializable(expdata.analysis_results(1))
 
     def test_parallel_experiment(self):
         """Test for parallel experiment"""
@@ -275,7 +275,7 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         # since under _experiment in kwargs there is an argument of the backend which isn't serializable.
         par_data._experiment = None
         # Checking serialization of the experiment data
-        self.assertRoundTripSerializable(par_data, self.experiment_data_equiv)
+        self.assertRoundTripSerializable(par_data)
 
         for child_data in par_data.child_data():
-            self.assertRoundTripSerializable(child_data, self.experiment_data_equiv)
+            self.assertRoundTripSerializable(child_data)

--- a/test/library/characterization/test_readout_angle.py
+++ b/test/library/characterization/test_readout_angle.py
@@ -63,7 +63,7 @@ class TestReadoutAngle(QiskitExperimentsTestCase):
         self.assertExperimentDone(expdata)
 
         # Checking serialization of the experiment data
-        self.assertRoundTripSerializable(expdata, self.experiment_data_equiv)
+        self.assertRoundTripSerializable(expdata)
 
         # Checking serialization of the analysis
-        self.assertRoundTripSerializable(expdata.analysis_results(0), self.analysis_result_equiv)
+        self.assertRoundTripSerializable(expdata.analysis_results(0))

--- a/test/library/characterization/test_resonator_spectroscopy.py
+++ b/test/library/characterization/test_resonator_spectroscopy.py
@@ -125,7 +125,7 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         expdata = spec.run(backend)
         self.assertExperimentDone(expdata)
         result = expdata.analysis_results(1)
-        self.assertRoundTripSerializable(result.value, check_func=self.ufloat_equiv)
+        self.assertRoundTripSerializable(result.value)
 
         self.assertAlmostEqual(result.value.n, res_freq + freq_shift, delta=0.1e6)
         self.assertEqual(str(result.device_components[0]), f"R{qubit}")
@@ -135,12 +135,12 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         exp = ResonatorSpectroscopy([1], frequencies=np.linspace(100, 150, 20) * 1e6)
         loaded_exp = ResonatorSpectroscopy.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = ResonatorSpectroscopy([1], frequencies=np.linspace(int(100e6), int(150e6), int(20e6)))
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
     @data(-5e6, 0, 3e6)
     def test_kerneled_expdata_serialization(self, freq_shift):
@@ -166,10 +166,10 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         # since under _experiment in kwargs there is an argument of the backend which isn't serializable.
         expdata._experiment = None
         # Checking serialization of the experiment data
-        self.assertRoundTripSerializable(expdata, self.experiment_data_equiv)
+        self.assertRoundTripSerializable(expdata)
 
         # Checking serialization of the analysis
-        self.assertRoundTripSerializable(expdata.analysis_results(1), self.analysis_result_equiv)
+        self.assertRoundTripSerializable(expdata.analysis_results(1))
 
     def test_parallel_experiment(self):
         """Test for parallel experiment"""
@@ -233,12 +233,12 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         # since under _experiment in kwargs there is an argument of the backend which isn't serializable.
         par_data._experiment = None
         # Checking serialization of the experiment data
-        self.assertRoundTripSerializable(par_data, self.experiment_data_equiv)
+        self.assertRoundTripSerializable(par_data)
 
         for child_data in par_data.child_data():
-            self.assertRoundTripSerializable(child_data, self.experiment_data_equiv)
+            self.assertRoundTripSerializable(child_data)
             for analysis_result in child_data.analysis_results():
-                self.assertRoundTripSerializable(analysis_result, self.analysis_result_equiv)
+                self.assertRoundTripSerializable(analysis_result)
 
     def test_initial_circuit_transpiled(self):
         """Test that the initial circuit is added to the experiment circuits correctly."""

--- a/test/library/characterization/test_t2hahn.py
+++ b/test/library/characterization/test_t2hahn.py
@@ -69,8 +69,8 @@ class TestT2Hahn(QiskitExperimentsTestCase):
         exp.analysis.set_options(p0={"amp": 0.5, "tau": estimated_t2hahn, "base": 0.5}, plot=True)
         expdata = exp.run(backend=backend, shots=1000)
         self.assertExperimentDone(expdata, timeout=300)
-        self.assertRoundTripSerializable(expdata, check_func=self.experiment_data_equiv)
-        self.assertRoundTripPickle(expdata, check_func=self.experiment_data_equiv)
+        self.assertRoundTripSerializable(expdata)
+        self.assertRoundTripPickle(expdata)
         result = expdata.analysis_results("T2")
         fitval = result.value
         if num_of_echoes != 0:
@@ -172,7 +172,7 @@ class TestT2Hahn(QiskitExperimentsTestCase):
         exp = T2Hahn([0], [1, 2, 3, 4, 5])
         loaded_exp = T2Hahn.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
@@ -180,7 +180,7 @@ class TestT2Hahn(QiskitExperimentsTestCase):
         delays0 = list(range(1, 60, 2))
 
         exp = T2Hahn([0], delays0)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
         osc_freq = 0.08
         estimated_t2hahn = 30
@@ -196,10 +196,10 @@ class TestT2Hahn(QiskitExperimentsTestCase):
         self.assertExperimentDone(expdata)
 
         # Checking serialization of the experiment data
-        self.assertRoundTripSerializable(expdata, self.experiment_data_equiv)
+        self.assertRoundTripSerializable(expdata)
 
         # Checking serialization of the analysis
-        self.assertRoundTripSerializable(expdata.analysis_results(1), self.analysis_result_equiv)
+        self.assertRoundTripSerializable(expdata.analysis_results(1))
 
     def test_analysis_config(self):
         """ "Test converting analysis to and from config works"""

--- a/test/library/characterization/test_t2ramsey.py
+++ b/test/library/characterization/test_t2ramsey.py
@@ -77,8 +77,8 @@ class TestT2Ramsey(QiskitExperimentsTestCase):
             exp.analysis.set_options(p0=user_p0)
             expdata = exp.run(backend=backend, shots=2000, seed_simulator=1).block_for_results()
             self.assertExperimentDone(expdata)
-            self.assertRoundTripSerializable(expdata, check_func=self.experiment_data_equiv)
-            self.assertRoundTripPickle(expdata, check_func=self.experiment_data_equiv)
+            self.assertRoundTripSerializable(expdata)
+            self.assertRoundTripPickle(expdata)
 
             result = expdata.analysis_results("T2star")
             self.assertAlmostEqual(
@@ -218,12 +218,12 @@ class TestT2Ramsey(QiskitExperimentsTestCase):
         exp = T2Ramsey([0], [1, 2, 3, 4, 5])
         loaded_exp = T2Ramsey.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = T2Ramsey([0], [1, 2, 3, 4, 5])
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
     def test_analysis_config(self):
         """ "Test converting analysis to and from config works"""

--- a/test/library/characterization/test_tphi.py
+++ b/test/library/characterization/test_tphi.py
@@ -47,8 +47,8 @@ class TestTphi(QiskitExperimentsTestCase):
         backend = NoisyDelayAerBackend([t1], [t2ramsey])
         expdata = exp.run(backend=backend, seed_simulator=1)
         self.assertExperimentDone(expdata)
-        self.assertRoundTripSerializable(expdata, check_func=self.experiment_data_equiv)
-        self.assertRoundTripPickle(expdata, check_func=self.experiment_data_equiv)
+        self.assertRoundTripSerializable(expdata)
+        self.assertRoundTripPickle(expdata)
         result = expdata.analysis_results("T_phi")
         estimated_tphi = 1 / ((1 / t2ramsey) - (1 / (2 * t1)))
         self.assertAlmostEqual(
@@ -138,11 +138,11 @@ class TestTphi(QiskitExperimentsTestCase):
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = Tphi([0], [1], [2])
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
         exp = Tphi([0], [1], [2], "hahn", 3)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
         exp = Tphi([0], [1], [2], "ramsey", 0)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
     def test_analysis_config(self):
         """Test converting analysis to and from config works"""

--- a/test/library/characterization/test_zz_ramsey.py
+++ b/test/library/characterization/test_zz_ramsey.py
@@ -118,9 +118,9 @@ class TestZZRamsey(QiskitExperimentsTestCase):
         exp = ZZRamsey((0, 1))
         loaded_exp = ZZRamsey.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = ZZRamsey((0, 1))
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)

--- a/test/library/quantum_volume/test_qv.py
+++ b/test/library/quantum_volume/test_qv.py
@@ -266,9 +266,9 @@ class TestQuantumVolume(QiskitExperimentsTestCase):
         exp = QuantumVolume([0, 1, 2], seed=42)
         loaded_exp = QuantumVolume.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = QuantumVolume([0, 1, 2], seed=42)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)

--- a/test/library/randomized_benchmarking/test_interleaved_rb.py
+++ b/test/library/randomized_benchmarking/test_interleaved_rb.py
@@ -67,14 +67,14 @@ class TestInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
         )
         loaded_exp = rb.InterleavedRB.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = rb.InterleavedRB(
             interleaved_element=SXGate(), physical_qubits=(0,), lengths=[10, 20, 30], seed=123
         )
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
     def test_analysis_config(self):
         """ "Test converting analysis to and from config works"""
@@ -387,5 +387,5 @@ class TestRunInterleavedRB(QiskitExperimentsTestCase, RBTestMixin):
         exp.set_transpile_options(**self.transpiler_options)
         expdata = exp.run()
         self.assertExperimentDone(expdata)
-        self.assertRoundTripSerializable(expdata, check_func=self.experiment_data_equiv)
-        self.assertRoundTripPickle(expdata, check_func=self.experiment_data_equiv)
+        self.assertRoundTripSerializable(expdata)
+        self.assertRoundTripPickle(expdata)

--- a/test/library/randomized_benchmarking/test_standard_rb.py
+++ b/test/library/randomized_benchmarking/test_standard_rb.py
@@ -53,12 +53,12 @@ class TestStandardRB(QiskitExperimentsTestCase, RBTestMixin):
         exp = rb.StandardRB(physical_qubits=(0,), lengths=[10, 20, 30], seed=123)
         loaded_exp = rb.StandardRB.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_roundtrip_serializable(self):
         """Test round trip JSON serialization"""
         exp = rb.StandardRB(physical_qubits=(0,), lengths=[10, 20, 30], seed=123)
-        self.assertRoundTripSerializable(exp, self.json_equiv)
+        self.assertRoundTripSerializable(exp)
 
     def test_analysis_config(self):
         """ "Test converting analysis to and from config works"""
@@ -384,8 +384,8 @@ class TestRunStandardRB(QiskitExperimentsTestCase, RBTestMixin):
         exp.set_transpile_options(**self.transpiler_options)
         expdata = exp.run()
         self.assertExperimentDone(expdata)
-        self.assertRoundTripSerializable(expdata, check_func=self.experiment_data_equiv)
-        self.assertRoundTripPickle(expdata, check_func=self.experiment_data_equiv)
+        self.assertRoundTripSerializable(expdata)
+        self.assertRoundTripPickle(expdata)
 
     def test_single_qubit_parallel(self):
         """Test single qubit RB in parallel."""

--- a/test/library/tomography/test_process_tomography.py
+++ b/test/library/tomography/test_process_tomography.py
@@ -352,7 +352,7 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         )
         loaded_exp = ProcessTomography.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_analysis_config(self):
         """ "Test converting analysis to and from config works"""
@@ -367,8 +367,8 @@ class TestProcessTomography(QiskitExperimentsTestCase):
         exp = ProcessTomography(XGate())
         expdata = exp.run(backend)
         self.assertExperimentDone(expdata)
-        self.assertRoundTripPickle(expdata, check_func=self.experiment_data_equiv)
-        self.assertRoundTripSerializable(expdata, check_func=self.experiment_data_equiv)
+        self.assertRoundTripPickle(expdata)
+        self.assertRoundTripSerializable(expdata)
 
     def test_target_none(self):
         """Test setting target=None disables fidelity calculation."""

--- a/test/library/tomography/test_state_tomography.py
+++ b/test/library/tomography/test_state_tomography.py
@@ -262,8 +262,8 @@ class TestStateTomography(QiskitExperimentsTestCase):
         exp = StateTomography(XGate())
         expdata = exp.run(backend)
         self.assertExperimentDone(expdata)
-        self.assertRoundTripSerializable(expdata, check_func=self.experiment_data_equiv)
-        self.assertRoundTripPickle(expdata, check_func=self.experiment_data_equiv)
+        self.assertRoundTripSerializable(expdata)
+        self.assertRoundTripPickle(expdata)
 
     def test_experiment_config(self):
         """Test converting to and from config works"""
@@ -272,7 +272,7 @@ class TestStateTomography(QiskitExperimentsTestCase):
         )
         loaded_exp = StateTomography.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
-        self.assertTrue(self.json_equiv(exp, loaded_exp))
+        self.assertEqualExtended(exp, loaded_exp)
 
     def test_analysis_config(self):
         """Test converting analysis to and from config works"""


### PR DESCRIPTION
### Summary

Current implementation of equality check, i.e. `QiskitExperimentsTestCase.json_equiv`, is not readable and scalable because it implements equality check logic for different types in a single method. This PR adds new test module `test/extended_equality.py` which implements new equality check dispatcher `is_equivalent`. 

Developers no longer need to specify `check_func` in the `assertRoundTripSerializable` and `assertRoundTripPickle` methods unless they define custom class for a specific unittest. This simplifies unittests and improves readability of equality check logic (and test becomes more trustable).

This PR adds new software dependency in develop; [multimethod](https://pypi.org/project/multimethod/)

Among several similar packages, this is chosen in favor of
- its license type (Apache License, Version 2.0) 
- syntax compatibility with `functools.singledispatch`
- support for subscripted generics in `typings`, e.g. `Union`