### PR TITLE
Add Aer install instructions to documentation

### DIFF
--- a/docs/howtos/rerun_analysis.rst
+++ b/docs/howtos/rerun_analysis.rst
@@ -84,9 +84,11 @@ previously to create it. It may sometimes be helpful instead to save an experime
 restore it later with the following lines of code:
 
 .. jupyter-input::
+    
+    from qiskit_experiments.framework import ExperimentDecoder, ExperimentEncoder
 
-    serialized_exp = json.dumps(Experiment.config())
-    Experiment.from_config(json.loads(serialized_exp))
+    serialized_exp = json.dumps(Experiment.config(), cls=ExperimentEncoder)
+    Experiment.from_config(json.loads(serialized_exp), cls=ExperimentDecoder)
 
 Rerunning with different analysis options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/manuals/characterization/t1.rst
+++ b/docs/manuals/characterization/t1.rst
@@ -29,6 +29,10 @@ which we deduce from the probability estimates.
 The following code demonstrates a basic run of a :math:`T_1` experiment
 for qubit 0.
 
+.. note::
+    This manual requires the ``qiskit-aer`` package to run simulations.
+    You can install it with ``python -m pip install qiskit-aer``.
+
 .. jupyter-execute::
 
     import numpy as np

--- a/docs/manuals/characterization/t2ramsey.rst
+++ b/docs/manuals/characterization/t2ramsey.rst
@@ -57,6 +57,10 @@ resulting function, and can analytically extract the desired values.
 We run the experiment on a simulated backend using Qiskit Aer with a
 pure T1/T2 relaxation noise model.
 
+.. note::
+    This manual requires the ``qiskit-aer`` package to run simulations.
+    You can install it with ``python -m pip install qiskit-aer``.
+
 .. jupyter-execute::
 
     # A T1 simulator

--- a/docs/manuals/characterization/tphi.rst
+++ b/docs/manuals/characterization/tphi.rst
@@ -1,6 +1,10 @@
 Tφ Characterization
 ===================
 
+.. note::
+    This manual requires the ``qiskit-aer`` package to run simulations.
+    You can install it with ``python -m pip install qiskit-aer``.
+
 :math:`T_\varphi`, or :math:`1/\Gamma_\varphi`, is the pure dephasing time of
 depolarization in the :math:`x - y` plane of the Bloch sphere. We compute
 :math:`\Gamma_\varphi` by computing :math:`\Gamma_2`, the *transverse relaxation rate*,
@@ -19,6 +23,10 @@ superconducting qubits, :math:`T_2^*` tends to be significantly smaller than
 
 From the :math:`T_1` and :math:`T_2` estimates, we compute the results for
 :math:`T_\varphi.`
+
+.. note::
+    This manual requires the ``qiskit-aer`` package to run simulations.
+    You can install it with ``python -m pip install qiskit-aer``.
 
 .. jupyter-execute::
 

--- a/docs/manuals/characterization/tphi.rst
+++ b/docs/manuals/characterization/tphi.rst
@@ -1,10 +1,6 @@
 Tφ Characterization
 ===================
 
-.. note::
-    This manual requires the ``qiskit-aer`` package to run simulations.
-    You can install it with ``python -m pip install qiskit-aer``.
-
 :math:`T_\varphi`, or :math:`1/\Gamma_\varphi`, is the pure dephasing time of
 depolarization in the :math:`x - y` plane of the Bloch sphere. We compute
 :math:`\Gamma_\varphi` by computing :math:`\Gamma_2`, the *transverse relaxation rate*,

--- a/docs/manuals/index.rst
+++ b/docs/manuals/index.rst
@@ -3,7 +3,7 @@ Experiment Manuals
 
 These experiment manuals are in-depth dives into some individual experiments, their
 operational principles, and how to run them in Qiskit Experiments. Note that the
-experiments below is only a small fraction of the full list of experiments in
+experiments below are only a small fraction of the full list of experiments in
 the :doc:`package library <../apidocs/library>`.
 
 .. _verification manuals:

--- a/docs/manuals/index.rst
+++ b/docs/manuals/index.rst
@@ -1,8 +1,10 @@
 Experiment Manuals
 ==================
 
-These experiment manuals are in-depth dives into individual experiments, their
-operational principles, and how to run them in Qiskit Experiments.
+These experiment manuals are in-depth dives into some individual experiments, their
+operational principles, and how to run them in Qiskit Experiments. Note that the
+experiments below is only a small fraction of the full list of experiments in
+the :doc:`package library <../apidocs/library>`.
 
 .. _verification manuals:
 

--- a/docs/manuals/measurement/readout_mitigation.rst
+++ b/docs/manuals/measurement/readout_mitigation.rst
@@ -30,6 +30,10 @@ assignment matrix, meaning it can only be used for small values of
 This notebook demonstrates the usage of both the local and correlated
 experiments to generate the corresponding mitigators.
 
+.. note::
+    This manual requires the ``qiskit-aer`` package to run simulations.
+    You can install it with ``python -m pip install qiskit-aer``.
+
 .. jupyter-execute::
 
     import numpy as np
@@ -37,7 +41,7 @@ experiments to generate the corresponding mitigators.
     from qiskit import QuantumCircuit
     from qiskit.visualization import plot_histogram
     from qiskit_experiments.library import LocalReadoutError, CorrelatedReadoutError
-    # For simulation
+
     from qiskit_aer import AerSimulator
     from qiskit.providers.fake_provider import FakePerth
 

--- a/docs/manuals/verification/quantum_volume.rst
+++ b/docs/manuals/verification/quantum_volume.rst
@@ -25,6 +25,10 @@ A depth :math:`d` QV circuit is successful if it has ‘mean heavy-output
 probability’ > 2/3 with confidence level > 0.977 (corresponding to
 z_value = 2), and at least 100 trials have been ran.
 
+.. note::
+    This manual requires the ``qiskit-aer`` package to run simulations.
+    You can install it with ``python -m pip install qiskit-aer``.
+
 .. jupyter-execute::
 
     from qiskit_experiments.framework import BatchExperiment

--- a/docs/manuals/verification/state_tomography.rst
+++ b/docs/manuals/verification/state_tomography.rst
@@ -1,21 +1,24 @@
 Quantum State Tomography
 ========================
 
+Quantum tomography is an experimental procedure to reconstruct a description of
+part of quantum system from the measurement outcomes of a specific set of
+experiments. In particular, quantum state tomography makes measurements on many
+copies of a state, obtained by preparing a system using a defined preparation
+circuit, with the goal of reconstructing the density matrix of the state.
+
+.. note::
+    This tutorial requires the ``qiskit-aer`` package for simulations.
+    You can install it with ``python -m pip install qiskit-aer``.
+
+We first initialize a simulator to run the experiments on.
+
 .. jupyter-execute::
 
-    import qiskit
-    from qiskit_experiments.framework import ParallelExperiment
-    from qiskit_experiments.library import StateTomography
-    
-    # For simulation
     from qiskit_aer import AerSimulator
     from qiskit.providers.fake_provider import FakePerth
     
-    # Noisy simulator backend
     backend = AerSimulator.from_backend(FakePerth())
-
-State Tomography Experiment
----------------------------
 
 To run a state tomography experiment, we initialize the experiment with a circuit to
 prepare the state to be measured. We can also pass in an
@@ -24,8 +27,10 @@ to describe the preparation circuit.
 
 .. jupyter-execute::
 
-    # Run experiments
-    
+    import qiskit
+    from qiskit_experiments.framework import ParallelExperiment
+    from qiskit_experiments.library import StateTomography
+
     # GHZ State preparation circuit
     nq = 2
     qc_ghz = qiskit.QuantumCircuit(nq)

--- a/docs/manuals/verification/state_tomography.rst
+++ b/docs/manuals/verification/state_tomography.rst
@@ -2,10 +2,10 @@ Quantum State Tomography
 ========================
 
 Quantum tomography is an experimental procedure to reconstruct a description of
-part of quantum system from the measurement outcomes of a specific set of
-experiments. In particular, quantum state tomography makes measurements on many
-copies of a state, obtained by preparing a system using a defined preparation
-circuit, with the goal of reconstructing the density matrix of the state.
+part of a quantum system from the measurement outcomes of a specific set of
+experiments. In particular, quantum state tomography reconstructs the density matrix
+of a quantum state by preparing the state many times and measuring them in a tomographically 
+complete basis of measurement operators.
 
 .. note::
     This tutorial requires the ``qiskit-aer`` package for simulations.

--- a/docs/tutorials/custom_experiment.rst
+++ b/docs/tutorials/custom_experiment.rst
@@ -516,7 +516,12 @@ output if the Pauli corresponding to that bit has a nonzero signature.
           ))
 
 
-To test our code, we first simulate a noisy backend with asymmetric readout error in Aer:
+To test our code, we first simulate a noisy backend with asymmetric readout error.
+
+.. note::
+    This tutorial requires the ``qiskit-aer`` package for simulations.
+    You can install it with ``python -m pip install qiskit-aer``.
+
 
 .. jupyter-execute::
 

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -48,21 +48,18 @@ the experiment from the Qiskit Experiments library:
 
 Experiments must be run on a backend. We're going to use a simulator,
 :class:`~qiskit.providers.fake_provider.FakePerth`, for this example, but you can use any
-IBM backend, real or simulated, that you can access through Qiskit.
+backend, real or simulated, that you can access through Qiskit.
+
+.. note::
+    This tutorial requires the ``qiskit-aer`` package to run simulations.
+    You can install it with ``python -m pip install qiskit-aer``.
 
 .. jupyter-execute::
 
     from qiskit.providers.fake_provider import FakePerth
     from qiskit_aer import AerSimulator
-    from qiskit.providers.aer.noise import NoiseModel
-    import numpy as np
 
-    # Create a pure relaxation noise model for AerSimulator
-    noise_model = NoiseModel.from_backend(
-        FakePerth(), thermal_relaxation=True, gate_error=False, readout_error=False
-    )
-
-    backend = AerSimulator.from_backend(FakePerth(), noise_model=noise_model)
+    backend = AerSimulator.from_backend(FakePerth())
 
 All experiments require a ``physical_qubits`` parameter as input that specifies which
 physical qubit or qubits the circuits will be executed on. The qubits must be given as a
@@ -81,9 +78,11 @@ good estimate for the sweep range of the delays.
 
 .. jupyter-execute::
 
+    import numpy as np
+    
     qubit0_t1 = FakePerth().qubit_properties(0).t1
-
     delays = np.arange(1e-6, 3 * qubit0_t1, 3e-5)
+
     exp = T1(physical_qubits=(0,), delays=delays)
 
 The circuits encapsulated by the experiment can be accessed using the experiment's
@@ -225,7 +224,9 @@ These options are passed to the experiment's :meth:`~.BaseExperiment.run` method
 then to the ``run()`` method of your specified backend. Any run option that your backend
 supports can be set:
 
-.. jupyter-input::
+.. jupyter-execute::
+
+  from qiskit.qobj.utils import MeasLevel
 
   exp.set_run_options(shots=1000,
                       meas_level=MeasLevel.CLASSIFIED)
@@ -239,7 +240,7 @@ Transpile options
 These options are passed to the Terra transpiler to transpile the experiment circuits
 before execution:
 
-.. jupyter-input::
+.. jupyter-execute::
 
   exp.set_transpile_options(scheduling_method='asap',
                             optimization_level=3,

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -254,9 +254,10 @@ These options are unique to each experiment class. Many experiment options can b
 upon experiment instantiation, but can also be explicitly set via
 :meth:`~.BaseExperiment.set_experiment_options`:
 
-.. jupyter-input::
+.. jupyter-execute::
 
     exp = T1(physical_qubits=(i,), delays=delays)
+    new_delays=np.arange(1e-6, 600e-6, 50e-6)
     exp.set_experiment_options(delays=new_delays)
 
 Consult the :doc:`API documentation </apidocs/index>` for the options of each experiment

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -256,7 +256,7 @@ upon experiment instantiation, but can also be explicitly set via
 
 .. jupyter-execute::
 
-    exp = T1(physical_qubits=(i,), delays=delays)
+    exp = T1(physical_qubits=(0,), delays=delays)
     new_delays=np.arange(1e-6, 600e-6, 50e-6)
     exp.set_experiment_options(delays=new_delays)
 


### PR DESCRIPTION
### Summary

This PR addresses #1136 by adding Aer install instructions on tutorials and experiment manuals that use it. The rerun analysis how-to instructions for serializing an experiment has also been updated with the experiment encoder and decoder.

### Details and comments

Some additional changes include:

- Simplified the simulator used in the getting started tutorial since we want to focus on experiments
- Added an introduction for the QST manual
- Added a note to the manuals page to clarify that there are many more experiments in the library

