### PR TITLE
Fix `MultiStateDiscrimination` output

### DIFF
--- a/qiskit_experiments/library/characterization/analysis/multi_state_discrimination_analysis.py
+++ b/qiskit_experiments/library/characterization/analysis/multi_state_discrimination_analysis.py
@@ -117,7 +117,7 @@ class MultiStateDiscriminationAnalysis(BaseAnalysis):
         for i in range(n_states):
             counts = [0] * n_states
             for point in predicted_data[i]:
-                counts[point] += 1
+                counts[int(point)] += 1
             for j in range(n_states):
                 if j != i:
                     prob_wrong += counts[j] / num_shots

--- a/qiskit_experiments/library/characterization/multi_state_discrimination.py
+++ b/qiskit_experiments/library/characterization/multi_state_discrimination.py
@@ -143,7 +143,7 @@ class MultiStateDiscrimination(BaseExperiment):
                         )
 
             # label the circuit
-            circuit.metadata = {"label": level}
+            circuit.metadata = {"label": str(level)}
 
             circuit.measure_all()
             circuits.append(circuit)

--- a/releasenotes/notes/fix-discriminator-exp-ff698816cea63099.yaml
+++ b/releasenotes/notes/fix-discriminator-exp-ff698816cea63099.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug where :class:`.MultiStateDiscrimination` outputted integer state labels rather than the
+    string labels expected by the :class:`.DiscriminatorNode`.

--- a/test/library/characterization/test_multi_state_discrimination.py
+++ b/test/library/characterization/test_multi_state_discrimination.py
@@ -52,7 +52,7 @@ class TestMultiStateDiscrimination(BaseDataProcessorTest):
         """Setup test variables."""
         super().setUp()
 
-        self.backend = SingleTransmonTestBackend(noise=False, lambda_2=0, seed=0)
+        self.backend = SingleTransmonTestBackend(noise=False, seed=0)
 
         # Build x12 schedule
         self.qubit = 0


### PR DESCRIPTION
### Summary

The discriminator configuration produced by `MultiStateDiscrimination` wasn't working with the discriminator node because its classes were integer state labels 0, 1,... instead of the expected strings "0", "1",... This PR changes the labels to strings and adds a test.
