### PR TITLE
Update release notes and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ For questions that are more suited for a forum we use the Qiskit tag in
 ## Authors and Citation
 
 Qiskit Experiments is the work of [many people](https://github.com/Qiskit/qiskit-experiments/graphs/contributors) who contribute
-to the project at different levels. If you use Qiskit, please cite as per the included [BibTeX file](https://github.com/Qiskit/qiskit/blob/master/Qiskit.bib).
+to the project at different levels. If you use Qiskit Experiments, please cite
+the following references:
+
+- Qiskit, as per the [BibTeX file](https://github.com/Qiskit/qiskit-metapackage/blob/master/Qiskit.bib).
+- Qiskit Experiments, as per the [DOI](https://doi.org/10.5281/zenodo.7737483).
 
 ## License
 

--- a/qiskit_experiments/calibration_management/basis_gate_library.py
+++ b/qiskit_experiments/calibration_management/basis_gate_library.py
@@ -220,8 +220,9 @@ class FixedFrequencyTransmon(BasisGateLibrary):
             default_values: Default values for the parameters this dictionary can contain
                 the following keys: "duration", "amp", "β", and "σ". If "σ" is not provided
                 this library will take one fourth of the pulse duration as default value.
-            link_parameters: If set to True then the amplitude and DRAG parameters of the
-                X and Y gates will be linked as well as those of the SX and SY gates.
+            link_parameters: If set to ``True``, then the amplitude and DRAG parameters of the
+                :math:`X` and :math:`Y` gates will be linked as well as those of
+                the :math:`SX` and :math:`SY` gates.
         """
         self._link_parameters = link_parameters
 

--- a/qiskit_experiments/library/__init__.py
+++ b/qiskit_experiments/library/__init__.py
@@ -123,6 +123,7 @@ See :doc:`/tutorials/calibrations` for examples.
     :template: autosummary/experiment.rst
 
     ~calibration.RoughFrequencyCal
+    ~calibration.RoughEFFrequencyCal
     ~calibration.FrequencyCal
     ~calibration.FineFrequencyCal
     ~calibration.RoughDragCal
@@ -150,6 +151,7 @@ from .calibration import (
     FineXAmplitudeCal,
     FineSXAmplitudeCal,
     RoughFrequencyCal,
+    RoughEFFrequencyCal,
     FrequencyCal,
     FineFrequencyCal,
     HalfAngleCal,

--- a/qiskit_experiments/library/calibration/__init__.py
+++ b/qiskit_experiments/library/calibration/__init__.py
@@ -55,7 +55,7 @@ Calibrations management
 See :mod:`.calibration_management`.
 """
 
-from .rough_frequency import RoughFrequencyCal
+from .rough_frequency import RoughFrequencyCal, RoughEFFrequencyCal
 from .rough_drag_cal import RoughDragCal
 from .rough_amplitude_cal import RoughAmplitudeCal, RoughXSXAmplitudeCal, EFRoughXSXAmplitudeCal
 from .fine_amplitude import FineAmplitudeCal, FineXAmplitudeCal, FineSXAmplitudeCal

--- a/qiskit_experiments/library/calibration/rough_amplitude_cal.py
+++ b/qiskit_experiments/library/calibration/rough_amplitude_cal.py
@@ -220,7 +220,9 @@ class RoughXSXAmplitudeCal(RoughAmplitudeCal):
 
 
 class EFRoughXSXAmplitudeCal(RoughAmplitudeCal):
-    """A rough amplitude calibration of x and sx gates on the 1<->2 transition."""
+    r"""A rough amplitude calibration of :math:`X` and :math:`SX` gates on the
+    :math:`|1\rangle` <-> :math:`|2\rangle` transition.
+    """
 
     __outcome__ = "rabi_rate_12"
 
@@ -233,7 +235,8 @@ class EFRoughXSXAmplitudeCal(RoughAmplitudeCal):
         backend: Optional[Backend] = None,
         ef_pulse_label: str = "12",
     ):
-        r"""A rough amplitude calibration that updates both the sx and x pulses on 1<->2.
+        r"""A rough amplitude calibration that updates both the sx and x pulses on the
+        :math:`|1\rangle` <-> :math:`|2\rangle` transition.
 
         Args:
             physical_qubits: Sequence containing the index of the qubit
@@ -243,7 +246,7 @@ class EFRoughXSXAmplitudeCal(RoughAmplitudeCal):
             backend: Optional, the backend to run the experiment on.
             ef_pulse_label: A label that is post-pended to "x" and "sx" to obtain the name
                 of the pulses that drive a :math:`\pi` and :math:`\pi/2` rotation on
-                the 1<->2 transition.
+                the :math:`|1\rangle` <-> :math:`|2\rangle` transition.
         """
         super().__init__(
             physical_qubits,

--- a/qiskit_experiments/library/calibration/rough_drag_cal.py
+++ b/qiskit_experiments/library/calibration/rough_drag_cal.py
@@ -28,7 +28,7 @@ from qiskit_experiments.warnings import qubit_deprecate
 
 
 class RoughDragCal(BaseCalibrationExperiment, RoughDrag):
-    """A calibration version of the Drag experiment.
+    """A calibration version of the :class:`.RoughDrag` experiment.
 
     # section: manual
         :ref:`DRAG Calibration`
@@ -47,15 +47,15 @@ class RoughDragCal(BaseCalibrationExperiment, RoughDrag):
         auto_update: bool = True,
         group: str = "default",
     ):
-        r"""see class :class:`RoughDrag` for details.
+        r"""see class :class:`.RoughDrag` for details.
 
         Args:
             physical_qubits: Sequence containing the qubit for which to run the
-                rough drag calibration.
+                rough DRAG calibration.
             calibrations: The calibrations instance with the schedules.
             backend: Optional, the backend to run the experiment on.
             schedule_name: The name of the schedule to calibrate. Defaults to "x".
-            betas: A list of drag parameter values to scan. If None is given 51 betas ranging
+            betas: A list of DRAG parameter values to scan. If None is given 51 betas ranging
                 from -5 to 5 will be scanned.
             cal_parameter_name: The name of the parameter in the schedule to update.
                 Defaults to "β".

--- a/qiskit_experiments/library/calibration/rough_frequency.py
+++ b/qiskit_experiments/library/calibration/rough_frequency.py
@@ -28,7 +28,8 @@ from qiskit_experiments.warnings import qubit_deprecate
 
 
 class RoughFrequencyCal(BaseCalibrationExperiment, QubitSpectroscopy):
-    """A calibration experiment that runs QubitSpectroscopy."""
+    """A calibration experiment that runs :class:`.QubitSpectroscopy` to calibrate the qubit
+    transition frequency."""
 
     @qubit_deprecate()
     def __init__(
@@ -40,7 +41,7 @@ class RoughFrequencyCal(BaseCalibrationExperiment, QubitSpectroscopy):
         auto_update: bool = True,
         absolute: bool = True,
     ):
-        """See :class:`QubitSpectroscopy` for detailed documentation.
+        """See :class:`.QubitSpectroscopy` for detailed documentation.
 
         Args:
             physical_qubits: List with the qubit on which to run spectroscopy.
@@ -73,7 +74,9 @@ class RoughFrequencyCal(BaseCalibrationExperiment, QubitSpectroscopy):
 
 
 class RoughEFFrequencyCal(BaseCalibrationExperiment, EFSpectroscopy):
-    """A calibration experiment that runs QubitSpectroscopy."""
+    r"""A calibration experiment that runs :class:`.QubitSpectroscopy` for the
+    :math:`|1\rangle` <-> :math:`|2\rangle` transition.
+    """
 
     __updater__ = Frequency
 
@@ -87,7 +90,7 @@ class RoughEFFrequencyCal(BaseCalibrationExperiment, EFSpectroscopy):
         auto_update: bool = True,
         absolute: bool = True,
     ):
-        """See :class:`QubitSpectroscopy` for detailed documentation.
+        """See :class:`.QubitSpectroscopy` for detailed documentation.
 
         Args:
             physical_qubits: List containing the qubit on which to run spectroscopy.

--- a/qiskit_experiments/library/characterization/fine_drag.py
+++ b/qiskit_experiments/library/characterization/fine_drag.py
@@ -90,7 +90,7 @@ class FineDrag(BaseExperiment, RestlessMixin):
             \bar\delta(t) = {\rm d}\beta\, \Omega^2_x(t)
 
 
-        We can integrate :math:`\bar{\delta}(t)`, i.e. the instantaneous Z-angle rotation error,
+        We can integrate :math:`\bar{\delta}(t)`, i.e. the instantaneous :math:`Z`-angle rotation error,
         to obtain the total rotation angle error per pulse, :math:`{\rm d}\theta`:
 
         .. math::
@@ -103,7 +103,7 @@ class FineDrag(BaseExperiment, RestlessMixin):
         :math:`A\sigma\sqrt{\pi/2}=\theta_\text{target}`, where :math:`\theta_\text{target}`
         is the target rotation angle, i.e. the area under the pulse. This last point allows
         us to rewrite :math:`A^2\sigma\sqrt{\pi}` as
-        :math:`\theta^2_\text{target}/(2\sigma\sqrt{\pi})`. The total Z angle error per pulse
+        :math:`\theta^2_\text{target}/(2\sigma\sqrt{\pi})`. The total :math:`Z` angle error per pulse
         is therefore
 
         .. math::
@@ -111,13 +111,13 @@ class FineDrag(BaseExperiment, RestlessMixin):
            {\rm d}\theta=
             \int\bar\delta(t){\rm d}t={\rm d}\beta\,\frac{\theta^2_\text{target}}{2\sigma\sqrt{\pi}}
 
-        Here, :math:`{\rm d}\theta` is the Z angle error per pulse. The qubit population produced by
-        the gate sequence shown above is used to measure :math:`{\rm d}\theta`. Indeed, each
-        gate pair Rp - Rm will produce a small unwanted Z - rotation out of the ZX plane with a
-        magnitude :math:`2\,{\rm d}\theta`. The total rotation out of the ZX plane is then mapped
-        to a qubit population by the final Post gate. Inverting the relation above after cancelling
-        out the factor of two due to the Rp - Rm pulse pair yields the error in :math:`\beta` that
-        produced the rotation error :math:`{\rm d}\theta` as
+        Here, :math:`{\rm d}\theta` is the :math:`Z` angle error per pulse. The qubit population
+        produced by the gate sequence shown above is used to measure :math:`{\rm d}\theta`. Indeed,
+        each gate pair Rp - Rm will produce a small unwanted :math:`Z`-rotation out of the
+        :math:`ZX` plane with a magnitude :math:`2\,{\rm d}\theta`. The total rotation out of the
+        :math:`ZX` plane is then mapped to a qubit population by the final Post gate. Inverting the
+        relation above after cancelling out the factor of two due to the Rp - Rm pulse pair yields
+        the error in :math:`\beta` that produced the rotation error :math:`{\rm d}\theta` as
 
         .. math::
 
@@ -268,7 +268,7 @@ class FineXDrag(FineDrag):
 
 
 class FineSXDrag(FineDrag):
-    """Class to fine characterize the DRAG parameter of an SX gate."""
+    """Class to fine characterize the DRAG parameter of an :math:`SX` gate."""
 
     @qubit_deprecate()
     def __init__(self, physical_qubits: Sequence[int], backend: Optional[Backend] = None):

--- a/qiskit_experiments/library/characterization/rabi.py
+++ b/qiskit_experiments/library/characterization/rabi.py
@@ -29,7 +29,8 @@ from qiskit_experiments.warnings import qubit_deprecate
 
 
 class Rabi(BaseExperiment, RestlessMixin):
-    """An experiment that scans a pulse amplitude to calibrate rotations between 0 and 1.
+    r"""An experiment that scans a pulse amplitude to calibrate rotations on the :math:`|0\rangle`
+    <-> :math:`|1\rangle` transition.
 
     # section: overview
 
@@ -185,16 +186,17 @@ class Rabi(BaseExperiment, RestlessMixin):
 
 
 class EFRabi(Rabi):
-    """An experiment that scans the amplitude of a pulse inducing rotations between 1 and 2.
+    r"""An experiment that scans the amplitude of a pulse inducing rotations on the
+     :math:`|1\rangle` <-> :math:`|2\rangle` transition.
 
     # section: overview
 
         This experiment is a subclass of the :class:`Rabi` experiment but takes place between
         the first and second excited state. An initial X gate populates the first excited state.
-        The Rabi pulse is applied on the 1 <-> 2 transition (sometimes also labeled the e <-> f
-        transition). The necessary frequency shift (typically the qubit anharmonicity) is given
-        through the pulse schedule given at initialization. The schedule is then also stored in
-        the experiment options. The circuits are of the form:
+        The Rabi pulse is applied on the :math:`|1\rangle` <-> :math:`|2\rangle` transition
+        (sometimes also labeled the e <-> f transition). The necessary frequency shift (typically
+        the qubit anharmonicity) is given through the pulse schedule given at initialization. The
+        schedule is then also stored in the experiment options. The circuits are of the form:
 
         .. parsed-literal::
 

--- a/releasenotes/notes/backend-in-rough-frequency-cal-8582610249e2327b.yaml
+++ b/releasenotes/notes/backend-in-rough-frequency-cal-8582610249e2327b.yaml
@@ -1,5 +1,6 @@
 ---
 fixes:
   - |
-    Added a missing `backend` parameter to :class:`~.RoughFrequencyCal`.
+    Added a missing `backend` parameter to :class:`~.RoughEFFrequencyCal` and
+    exposed it in the experiment library.
 

--- a/releasenotes/notes/backend-in-rough-frequency-cal-8582610249e2327b.yaml
+++ b/releasenotes/notes/backend-in-rough-frequency-cal-8582610249e2327b.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Added a missing `backend` parameter to :class:`~.RoughEFFrequencyCal` and
+    Added a missing ``backend`` parameter to :class:`~.RoughEFFrequencyCal` and
     exposed it in the experiment library.
 

--- a/setup.py
+++ b/setup.py
@@ -10,25 +10,24 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"The Qiskit Terra setup file."
+"The Qiskit Experiments setup file."
 
 import os
-import sys
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
+with open("requirements.txt", encoding="utf-8") as f:
     REQUIREMENTS = f.read().splitlines()
 
 
 version_path = os.path.abspath(
     os.path.join(os.path.join(os.path.dirname(__file__), "qiskit_experiments"), "VERSION.txt")
 )
-with open(version_path, "r") as fd:
+with open(version_path, "r", encoding="utf-8") as fd:
     version = fd.read().rstrip()
 
 # Read long description from README.
 README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md")
-with open(README_PATH) as readme_file:
+with open(README_PATH, encoding="utf-8") as readme_file:
     README = readme_file.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     python_requires=">=3.7",
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit-experiments/issues",
-        "Documentation": "https://qiskit.org/documentation/",
+        "Documentation": "https://qiskit.org/documentation/experiments",
         "Source Code": "https://github.com/Qiskit/qiskit-experiments",
     },
     zip_safe=False,

--- a/test/fake_experiment.py
+++ b/test/fake_experiment.py
@@ -43,11 +43,11 @@ class FakeExperiment(BaseExperiment):
         options.dummyoption = None
         return options
 
-    def __init__(self, qubits=None):
+    def __init__(self, physical_qubits=None):
         """Initialise the fake experiment."""
-        if qubits is None:
-            qubits = [0]
-        super().__init__(qubits, analysis=FakeAnalysis())
+        if physical_qubits is None:
+            physical_qubits = [0]
+        super().__init__(physical_qubits, analysis=FakeAnalysis())
 
     def circuits(self):
         """Fake circuits."""


### PR DESCRIPTION
### Summary

This PR formats the release notes for 0.5.1 and updates places in the `README` and `setup.py` that were still configured for Terra instead of Experiments, in addition to some formatting fixes and adding `RoughEFFrequencyCal` to the documentation. There will be another PR to the 0.5 branch to make the 0.5.1 release notes and bump the patch version.