### PR TITLE
Pin ipython version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,4 +21,4 @@ sphinx-copybutton
 # Pin versions below because of build errors
 ipykernel<=6.21.3
 jupyter-client<=8.0.3
-
+ipython<8.13.0 # for python 3.8 compatibility

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,4 +21,4 @@ sphinx-copybutton
 # Pin versions below because of build errors
 ipykernel<=6.21.3
 jupyter-client<=8.0.3
-ipython<8.13.0 # for python 3.8 compatibility
+ipython<8.13.0 ; python_version<"3.9"  # for python 3.8 compatibility


### PR DESCRIPTION
### Summary

IPython 8.13.0 was just released and dropped Python 3.8 support, so this PR pins the version for docs builds.