### PR TITLE
Update calibration tests to test _transpiled_circuits

### DIFF
--- a/test/library/calibration/test_drag.py
+++ b/test/library/calibration/test_drag.py
@@ -180,10 +180,10 @@ class TestDragCircuits(QiskitExperimentsTestCase):
         drag = RoughDrag([0], self.x_plus)
         drag.set_experiment_options(reps=[2, 4, 8])
         drag.backend = MockIQBackend(DragHelper(gate_name="Drag(xp)"))
-        circuits = drag.circuits()
+        circuits = drag._transpiled_circuits()
 
         for idx, expected in enumerate([4, 8, 16]):
-            ops = transpile(circuits[idx * 51], backend).count_ops()
+            ops = circuits[idx * 51].count_ops()
             self.assertEqual(ops["Drag(xp)"], expected)
 
     def test_raise_multiple_parameter(self):

--- a/test/library/calibration/test_drag.py
+++ b/test/library/calibration/test_drag.py
@@ -22,7 +22,6 @@ from qiskit.circuit import Parameter
 from qiskit.exceptions import QiskitError
 from qiskit.pulse import DriveChannel, Drag
 from qiskit.qobj.utils import MeasLevel
-from qiskit import transpile
 
 from qiskit_experiments.library import RoughDrag, RoughDragCal
 from qiskit_experiments.library.characterization.analysis import DragCalAnalysis
@@ -176,7 +175,6 @@ class TestDragCircuits(QiskitExperimentsTestCase):
     def test_default_circuits(self):
         """Test the default circuit."""
 
-        backend = MockIQBackend(DragHelper(gate_name="Drag(xp)", frequency=0.005))
         drag = RoughDrag([0], self.x_plus)
         drag.set_experiment_options(reps=[2, 4, 8])
         drag.backend = MockIQBackend(DragHelper(gate_name="Drag(xp)"))

--- a/test/library/calibration/test_fine_amplitude.py
+++ b/test/library/calibration/test_fine_amplitude.py
@@ -15,7 +15,7 @@ from test.base import QiskitExperimentsTestCase
 import numpy as np
 from ddt import ddt, data
 
-from qiskit import pulse, transpile
+from qiskit import pulse
 from qiskit.circuit import Gate
 from qiskit.circuit.library import XGate, SXGate
 from qiskit.pulse import DriveChannel, Drag

--- a/test/library/calibration/test_fine_amplitude.py
+++ b/test/library/calibration/test_fine_amplitude.py
@@ -251,9 +251,9 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         # Initial pulse amplitude
         init_amp = 0.5
 
-        amp_cal = FineXAmplitudeCal([0], self.cals, "x")
+        amp_cal = FineXAmplitudeCal([0], self.cals, "x", backend=self.backend)
 
-        circs = transpile(amp_cal.circuits(), self.backend, inst_map=self.cals.default_inst_map)
+        circs = amp_cal._transpiled_circuits()
 
         with pulse.build(name="x") as expected_x:
             pulse.play(pulse.Drag(160, 0.5, 40, 0), pulse.DriveChannel(0))
@@ -265,12 +265,12 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         self.assertEqual(circs[5].calibrations["sx"][((0,), ())], expected_sx)
 
         # run the calibration experiment. This should update the amp parameter of x which we test.
-        exp_data = amp_cal.run(self.backend)
+        exp_data = amp_cal.run()
         self.assertExperimentDone(exp_data)
         d_theta = exp_data.analysis_results(1).value.n
         new_amp = init_amp * np.pi / (np.pi + d_theta)
 
-        circs = transpile(amp_cal.circuits(), self.backend, inst_map=self.cals.default_inst_map)
+        circs = amp_cal._transpiled_circuits()
 
         x_cal = circs[5].calibrations["x"][((0,), ())]
 
@@ -290,9 +290,10 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         # Initial pulse amplitude
         init_amp = 0.25
 
-        amp_cal = FineSXAmplitudeCal([0], self.cals, "sx")
+        backend = MockIQBackend(FineAmpHelper(-np.pi * 0.07, np.pi / 2, "sx"))
+        amp_cal = FineSXAmplitudeCal([0], self.cals, "sx", backend=backend)
 
-        circs = transpile(amp_cal.circuits(), self.backend, inst_map=self.cals.default_inst_map)
+        circs = amp_cal._transpiled_circuits()
 
         with pulse.build(name="sx") as expected_sx:
             pulse.play(pulse.Drag(160, 0.25, 40, 0), pulse.DriveChannel(0))
@@ -300,12 +301,12 @@ class TestFineAmplitudeCal(QiskitExperimentsTestCase):
         self.assertEqual(circs[5].calibrations["sx"][((0,), ())], expected_sx)
 
         # run the calibration experiment. This should update the amp parameter of x which we test.
-        exp_data = amp_cal.run(MockIQBackend(FineAmpHelper(-np.pi * 0.07, np.pi / 2, "sx")))
+        exp_data = amp_cal.run()
         self.assertExperimentDone(exp_data)
         d_theta = exp_data.analysis_results(1).value.n
         new_amp = init_amp * (np.pi / 2) / (np.pi / 2 + d_theta)
 
-        circs = transpile(amp_cal.circuits(), self.backend, inst_map=self.cals.default_inst_map)
+        circs = amp_cal._transpiled_circuits()
 
         sx_cal = circs[5].calibrations["sx"][((0,), ())]
 

--- a/test/library/calibration/test_fine_drag.py
+++ b/test/library/calibration/test_fine_drag.py
@@ -13,10 +13,9 @@
 """Test fine drag calibration experiment."""
 
 from test.base import QiskitExperimentsTestCase
-import copy
 import numpy as np
 
-from qiskit import pulse, transpile
+from qiskit import pulse
 from qiskit.circuit import Gate
 from qiskit.providers.fake_provider import FakeArmonkV2
 

--- a/test/library/calibration/test_fine_drag.py
+++ b/test/library/calibration/test_fine_drag.py
@@ -102,13 +102,7 @@ class TestFineDragCal(QiskitExperimentsTestCase):
 
         drag_cal = FineDragCal([0], self.cals, "x", self.backend)
 
-        transpile_opts = copy.copy(drag_cal.transpile_options.__dict__)
-        transpile_opts["initial_layout"] = list(drag_cal.physical_qubits)
-        transpile_opts["optimization_level"] = 0
-
-        circs = transpile(
-            drag_cal.circuits(), inst_map=self.cals.default_inst_map, **transpile_opts
-        )
+        circs = drag_cal._transpiled_circuits()
 
         with pulse.build(name="x") as expected_x:
             pulse.play(pulse.Drag(160, 0.5, 40, 0), pulse.DriveChannel(0))
@@ -127,13 +121,7 @@ class TestFineDragCal(QiskitExperimentsTestCase):
         target_angle = np.pi
         new_beta = -np.sqrt(np.pi) * d_theta * sigma / target_angle**2
 
-        transpile_opts = copy.copy(drag_cal.transpile_options.__dict__)
-        transpile_opts["initial_layout"] = list(drag_cal.physical_qubits)
-        transpile_opts["optimization_level"] = 0
-
-        circs = transpile(
-            drag_cal.circuits(), inst_map=self.cals.default_inst_map, **transpile_opts
-        )
+        circs = drag_cal._transpiled_circuits()
 
         x_cal = circs[5].calibrations["x"][((0,), ())]
 

--- a/test/library/calibration/test_rough_amplitude.py
+++ b/test/library/calibration/test_rough_amplitude.py
@@ -38,9 +38,9 @@ class TestRoughAmpCal(QiskitExperimentsTestCase):
     def test_circuits(self):
         """Test the quantum circuits."""
         test_amps = [-0.5, 0, 0.5]
-        rabi = RoughXSXAmplitudeCal([0], self.cals, amplitudes=test_amps)
+        rabi = RoughXSXAmplitudeCal([0], self.cals, amplitudes=test_amps, backend=self.backend)
 
-        circs = transpile(rabi.circuits(), self.backend, inst_map=self.cals.default_inst_map)
+        circs = rabi._transpiled_circuits()
 
         for circ, amp in zip(circs, test_amps):
             self.assertEqual(circ.count_ops()["Rabi"], 1)
@@ -124,9 +124,9 @@ class TestSpecializations(QiskitExperimentsTestCase):
         """Test that we get the expected circuits with calibrations for the EF experiment."""
 
         test_amps = [-0.5, 0, 0.5]
-        rabi_ef = EFRoughXSXAmplitudeCal([0], self.cals, amplitudes=test_amps)
+        rabi_ef = EFRoughXSXAmplitudeCal([0], self.cals, amplitudes=test_amps, backend=self.backend)
 
-        circs = transpile(rabi_ef.circuits(), self.backend, inst_map=self.cals.default_inst_map)
+        circs = rabi_ef._transpiled_circuits()
 
         for circ, amp in zip(circs, test_amps):
 

--- a/test/library/calibration/test_rough_amplitude.py
+++ b/test/library/calibration/test_rough_amplitude.py
@@ -15,7 +15,7 @@
 from test.base import QiskitExperimentsTestCase
 import numpy as np
 
-from qiskit import pulse, transpile
+from qiskit import pulse
 from qiskit.circuit import Parameter
 
 from qiskit_experiments.calibration_management.basis_gate_library import FixedFrequencyTransmon


### PR DESCRIPTION
### Summary

Previously, the tests were calling `transpile()` on the output of `experiment.circuits()` even though
`BaseCalibrationExperiment._transpiled_circuits()` uses a custom pass manager and does not call `transpile()` itself.
