### PR TITLE
Attach calibrations for gates used in calibration experiments

### DIFF
--- a/qiskit_experiments/calibration_management/calibrations.py
+++ b/qiskit_experiments/calibration_management/calibrations.py
@@ -599,6 +599,25 @@ class Calibrations:
         for param in params_to_register:
             self._register_parameter(param, qubits, schedule)
 
+    def has_template(self, schedule_name: str, qubits: Optional[Tuple[int, ...]] = None) -> bool:
+        """Test if a template schedule is defined
+
+        Args:
+            schedule_name: The name of the template schedule.
+            qubits: The qubits under which the template schedule was registered.
+
+        Returns:
+            True if a template exists for the schedule name for the given qubits
+        """
+        found = False
+        try:
+            self.get_template(schedule_name, qubits)
+            found = True
+        except CalibrationError:
+            pass
+
+        return found
+
     def get_template(
         self, schedule_name: str, qubits: Optional[Tuple[int, ...]] = None
     ) -> ScheduleBlock:

--- a/qiskit_experiments/library/calibration/fine_drag_cal.py
+++ b/qiskit_experiments/library/calibration/fine_drag_cal.py
@@ -108,6 +108,10 @@ class FineDragCal(BaseCalibrationExperiment, FineDrag):
         """Attach the calibrations to the circuit."""
         schedule = self._cals.get_schedule(self._sched_name, self.physical_qubits)
         circuit.add_calibration(self._sched_name, self.physical_qubits, schedule)
+        # FineDrag always uses sx so attach it if it is not sched_name
+        if self._sched_name != "sx":
+            schedule = self._cals.get_schedule("sx", self.physical_qubits)
+            circuit.add_calibration("sx", self.physical_qubits, schedule)
 
     def update_calibrations(self, experiment_data: ExperimentData):
         """Update the drag parameter of the pulse in the calibrations."""

--- a/qiskit_experiments/library/calibration/rough_amplitude_cal.py
+++ b/qiskit_experiments/library/calibration/rough_amplitude_cal.py
@@ -278,3 +278,9 @@ class EFRoughXSXAmplitudeCal(RoughAmplitudeCal):
         circ = QuantumCircuit(1)
         circ.x(0)
         return circ
+
+    def _attach_calibrations(self, circuit: QuantumCircuit):
+        """Attach an x calibration if it is defined."""
+        if self._cals.has_template("x", self.physical_qubits):
+            schedule = self._cals.get_schedule("x", self.physical_qubits)
+            circuit.add_calibration("x", self.physical_qubits, schedule)

--- a/qiskit_experiments/library/calibration/rough_amplitude_cal.py
+++ b/qiskit_experiments/library/calibration/rough_amplitude_cal.py
@@ -281,6 +281,9 @@ class EFRoughXSXAmplitudeCal(RoughAmplitudeCal):
 
     def _attach_calibrations(self, circuit: QuantumCircuit):
         """Attach an x calibration if it is defined."""
+        # Attach the x calibration as well if it is in self._cals. We allow for
+        # it not to be present in case a user wants to rely on the default x
+        # calibration and only calibrate the pulses between levels 1 and 2.
         if self._cals.has_template("x", self.physical_qubits):
             schedule = self._cals.get_schedule("x", self.physical_qubits)
             circuit.add_calibration("x", self.physical_qubits, schedule)

--- a/releasenotes/notes/attach-other-cals-2f539e7799ceb6c8.yaml
+++ b/releasenotes/notes/attach-other-cals-2f539e7799ceb6c8.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    A new method :meth:`.qiskit_experiments.calibration_management.Calibrations.has_template`
+    has been added to :class:`.qiskit_experiments.calibration_management.Calibrations`
+    to check if a template schedule exists for a particular set of qubits.
+fixes:
+  - |
+    :class:`.qiskit_experiments.library.FineXDragCal` and 
+    :class:`.qiskit_experiments.library.EFRoughXSXAmplitudeCal` were updated to
+    attach `"sx"` and `"x"` calibrations to their circuits, respectively.
+    Previously, they only attached the `"x"` and `"x12"` calibrations that they
+    were calibrating. See issue `#1158 <https://github.com/Qiskit/qiskit-experiments/issues/1158>`_.


### PR DESCRIPTION
### Summary

Previously `EFRoughXSXAmplitudeCal` and `FineXDragCal` only attached the
calibrations for the gates being calibrated by the experiments, not the
calibrations for the other gates used by the experiments.