### PR TITLE
Bump minimum terra version to 0.24

### DIFF
--- a/qiskit_experiments/framework/composite/composite_analysis.py
+++ b/qiskit_experiments/framework/composite/composite_analysis.py
@@ -206,13 +206,10 @@ class CompositeAnalysis(BaseAnalysis):
                 sub_data = {"metadata": metadata["composite_metadata"][i]}
                 if "counts" in datum:
                     if composite_clbits is not None:
-                        # `marginal_distribution() doesn't support int64 values
-                        # so detect and cast to an int. This can be removed
-                        # when Qiskit/qiskit-terra#9976 is released
-                        counts = datum["counts"]
-                        if any(isinstance(x, np.integer) for x in counts.values()):
-                            counts = {k: int(v) for k, v in counts.items()}
-                        sub_data["counts"] = marginal_distribution(counts, composite_clbits[i])
+                        sub_data["counts"] = marginal_distribution(
+                            counts=datum["counts"],
+                            indices=composite_clbits[i],
+                        )
                     else:
                         sub_data["counts"] = datum["counts"]
                 if "memory" in datum:

--- a/releasenotes/notes/adjust-symbolic-pulses-amp-angle-representation-f5c40007416cf938.yaml
+++ b/releasenotes/notes/adjust-symbolic-pulses-amp-angle-representation-f5c40007416cf938.yaml
@@ -17,9 +17,6 @@ other:
     complex values.
 upgrade:
   - |
-    The minimal required Qiskit-Terra version was bumped to 0.23 in order to use 
-    the (``amp``, ``angle``) representation of library pulses in Qiskit Pulse.
-  - |
     The representation of pulses in the :class:`.FixedFrequencyTransmon` library 
     was changed from complex amplitude to (``amp``,``angle``) representation. All pulses
     now include an ``angle`` parameter, and the default values of ``amp`` are set

--- a/releasenotes/notes/dump-terra-0_24-47c5d4fb92f1d97b.yaml
+++ b/releasenotes/notes/dump-terra-0_24-47c5d4fb92f1d97b.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    The minimal required Qiskit-Terra version was bumped to 0.24. This version enables
+    new pulse amplitude representation of (``amp``, ``angle``) pair, 
+    improved user-communication for deprecated functionalities, 
+    and fast marginalization of the composite experiment result data.

--- a/releasenotes/notes/dump-terra-0_24-47c5d4fb92f1d97b.yaml
+++ b/releasenotes/notes/dump-terra-0_24-47c5d4fb92f1d97b.yaml
@@ -2,6 +2,5 @@
 upgrade:
   - |
     The minimal required Qiskit-Terra version was bumped to 0.24. This version enables
-    new pulse amplitude representation of (``amp``, ``angle``) pair, 
-    improved user-communication for deprecated functionalities, 
-    and fast marginalization of the composite experiment result data.
+    new pulse amplitude representation of (``amp``, ``angle``) pair
+    and improved user-communication for deprecated functionalities.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17
 scipy>=1.4
-qiskit-terra>=0.23
+qiskit-terra>=0.24
 qiskit-ibm-experiment>=0.2.5
 qiskit_dynamics>=0.3.0
 matplotlib>=3.4


### PR DESCRIPTION
### Summary

Use Terra 0.24 for several blocked PRs (mainly for new deprecation format).