### PR TITLE
Prep for change default value of flatten_results

### DIFF
--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -309,7 +309,7 @@ simultaneously on the same device:
 
     child_exp1 = T1(physical_qubits=(2,), delays=delays)
     child_exp2 = StandardRB(physical_qubits=(3,1), lengths=np.arange(1,100,10), num_samples=2)
-    parallel_exp = ParallelExperiment([child_exp1, child_exp2])
+    parallel_exp = ParallelExperiment([child_exp1, child_exp2], flatten_results=False)
 
 Note that when the transpile and run options are set for a composite experiment, the
 child experiments's options are also set to the same options recursively. Let's examine
@@ -326,7 +326,7 @@ child experiments can be accessed via the
     parallel_exp.component_experiment(1).circuits()[0].draw(output='mpl')
 
 The circuits of all experiments assume they're acting on virtual qubits starting from
-index 0. In the case of a parallel experiment, the child experiment 
+index 0. In the case of a parallel experiment, the child experiment
 circuits are composed together and then reassigned virtual qubit indices:
 
 .. jupyter-execute::
@@ -336,7 +336,7 @@ circuits are composed together and then reassigned virtual qubit indices:
 During experiment transpilation, a mapping is performed to place these circuits on the
 physical layout. We can see its effects by looking at the transpiled
 circuit, which is accessed via the internal method ``_transpiled_circuits()``. After
-transpilation, the :class:`.T1` experiment is correctly placed on physical qubit 2 
+transpilation, the :class:`.T1` experiment is correctly placed on physical qubit 2
 and the :class:`.StandardRB` experiment's gates are on physical qubits 3 and 1.
 
 .. jupyter-execute::
@@ -356,6 +356,12 @@ The experiment data returned from a composite experiment contains individual ana
 results for each child experiment that can be accessed using
 :meth:`~.ExperimentData.child_data`. By default, the parent data object does not contain
 analysis results.
+
+.. note::
+
+    This behavior will be updated in Qiskit Experiments 0.7.
+    By default, all analysis results will be stored in the parent data object,
+    and you need to explicitly set ``flatten_results=False`` to generate child data objects.
 
 .. jupyter-execute::
 

--- a/qiskit_experiments/framework/composite/batch_experiment.py
+++ b/qiskit_experiments/framework/composite/batch_experiment.py
@@ -15,6 +15,7 @@ Batch Experiment class.
 
 from typing import List, Optional, Dict
 from collections import OrderedDict, defaultdict
+import warnings
 
 from qiskit import QuantumCircuit
 from qiskit.providers import Job, Backend, Options
@@ -46,7 +47,7 @@ class BatchExperiment(CompositeExperiment):
         self,
         experiments: List[BaseExperiment],
         backend: Optional[Backend] = None,
-        flatten_results: bool = False,
+        flatten_results: bool = None,
         analysis: Optional[CompositeAnalysis] = None,
     ):
         """Initialize a batch experiment.
@@ -64,6 +65,16 @@ class BatchExperiment(CompositeExperiment):
                       provided this will be initialized automatically from the
                       supplied experiments.
         """
+        if flatten_results is None:
+            # Backward compatibility for 0.6
+            # This if-clause will be removed in 0.7 and flatten_result=True is set in arguments.
+            warnings.warn(
+                "Default value of flatten_results will be turned to True in Qiskit Experiments 0.7. "
+                "If you want child experiment data for each subset experiment, "
+                "set 'flatten_results=False' explicitly.",
+                DeprecationWarning,
+            )
+            flatten_results = False
 
         # Generate qubit map
         self._qubit_map = OrderedDict()

--- a/qiskit_experiments/framework/composite/composite_analysis.py
+++ b/qiskit_experiments/framework/composite/composite_analysis.py
@@ -14,6 +14,7 @@ Composite Experiment Analysis class.
 """
 
 from typing import List, Dict, Union, Optional, Tuple
+import warnings
 import numpy as np
 from qiskit.result import marginal_distribution
 from qiskit.result.postprocess import format_counts_memory
@@ -51,7 +52,7 @@ class CompositeAnalysis(BaseAnalysis):
         experiment data.
     """
 
-    def __init__(self, analyses: List[BaseAnalysis], flatten_results: bool = False):
+    def __init__(self, analyses: List[BaseAnalysis], flatten_results: bool = None):
         """Initialize a composite analysis class.
 
         Args:
@@ -62,6 +63,16 @@ class CompositeAnalysis(BaseAnalysis):
                              component experiment results as a separate child
                              ExperimentData container.
         """
+        if flatten_results is None:
+            # Backward compatibility for 0.6
+            # This if-clause will be removed in 0.7 and flatten_result=True is set in arguments.
+            warnings.warn(
+                "Default value of flatten_results will be turned to True in Qiskit Experiments 0.7. "
+                "If you want child experiment data for each subset experiment, "
+                "set 'flatten_results=False' explicitly.",
+                DeprecationWarning,
+            )
+            flatten_results = False
         super().__init__()
         self._analyses = analyses
         self._flatten_results = False

--- a/qiskit_experiments/framework/composite/composite_experiment.py
+++ b/qiskit_experiments/framework/composite/composite_experiment.py
@@ -33,7 +33,7 @@ class CompositeExperiment(BaseExperiment):
         physical_qubits: Sequence[int],
         backend: Optional[Backend] = None,
         experiment_type: Optional[str] = None,
-        flatten_results: bool = False,
+        flatten_results: bool = None,
         analysis: Optional[CompositeAnalysis] = None,
     ):
         """Initialize the composite experiment object.
@@ -57,6 +57,17 @@ class CompositeExperiment(BaseExperiment):
             QiskitError: If the provided analysis class is not a CompositeAnalysis
                          instance.
         """
+        if flatten_results is None:
+            # Backward compatibility for 0.6
+            # This if-clause will be removed in 0.7 and flatten_result=True is set in arguments.
+            warnings.warn(
+                "Default value of flatten_results will be turned to True in Qiskit Experiments 0.7. "
+                "If you want child experiment data for each subset experiment, "
+                "set 'flatten_results=False' explicitly.",
+                DeprecationWarning,
+            )
+            flatten_results = False
+
         self._experiments = experiments
         self._num_experiments = len(experiments)
         if analysis is None:

--- a/qiskit_experiments/framework/composite/parallel_experiment.py
+++ b/qiskit_experiments/framework/composite/parallel_experiment.py
@@ -13,6 +13,7 @@
 Parallel Experiment class.
 """
 from typing import List, Optional
+import warnings
 import numpy as np
 
 from qiskit import QuantumCircuit, ClassicalRegister
@@ -46,7 +47,7 @@ class ParallelExperiment(CompositeExperiment):
         self,
         experiments: List[BaseExperiment],
         backend: Optional[Backend] = None,
-        flatten_results: bool = False,
+        flatten_results: bool = None,
         analysis: Optional[CompositeAnalysis] = None,
     ):
         """Initialize the analysis object.
@@ -64,6 +65,16 @@ class ParallelExperiment(CompositeExperiment):
                       provided this will be initialized automatically from the
                       supplied experiments.
         """
+        if flatten_results is None:
+            # Backward compatibility for 0.6
+            # This if-clause will be removed in 0.7 and flatten_result=True is set in arguments.
+            warnings.warn(
+                "Default value of flatten_results will be turned to True in Qiskit Experiments 0.7. "
+                "If you want child experiment data for each subset experiment, "
+                "set 'flatten_results=False' explicitly.",
+                DeprecationWarning,
+            )
+            flatten_results = False
         qubits = []
         for exp in experiments:
             qubits += exp.physical_qubits

--- a/qiskit_experiments/library/characterization/tphi.py
+++ b/qiskit_experiments/library/characterization/tphi.py
@@ -120,7 +120,12 @@ class Tphi(BatchExperiment):
         analysis = TphiAnalysis([exp_t1.analysis, exp_t2.analysis])
 
         # Create batch experiment
-        super().__init__([exp_t1, exp_t2], backend=backend, analysis=analysis)
+        super().__init__(
+            [exp_t1, exp_t2],
+            flatten_results=True,
+            backend=backend,
+            analysis=analysis,
+        )
         self.set_experiment_options(**exp_options)
 
     def set_experiment_options(self, **fields):

--- a/releasenotes/notes/deprecate-flatten-result-false-026a89c09cc7a004.yaml
+++ b/releasenotes/notes/deprecate-flatten-result-false-026a89c09cc7a004.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    Executing composite experiment and composite analysis with ``flatten_results=False``
+    by default was deprecated. To create child experiment data, please explicitly 
+    set ``flatten_results=False``. The default value of ``flatten_results`` will be
+    turned to True in the future release.

--- a/test/calibration/test_base_calibration_experiment.py
+++ b/test/calibration/test_base_calibration_experiment.py
@@ -239,7 +239,7 @@ class TestBaseCalibrationClass(QiskitExperimentsTestCase):
             param_name="to_calibrate2",
             sched_name="test",
         )
-        batch_exp = BatchExperiment([exp1, exp2], backend=backend)
+        batch_exp = BatchExperiment([exp1, exp2], flatten_results=False, backend=backend)
         batch_exp.run(backend).block_for_results()
 
         # Get new value
@@ -309,7 +309,7 @@ class TestBaseCalibrationClass(QiskitExperimentsTestCase):
             param_name="to_calibrate2",
             sched_name="test2",
         )
-        batch_exp = ParallelExperiment([exp1, exp2], backend=backend)
+        batch_exp = ParallelExperiment([exp1, exp2], flatten_results=False, backend=backend)
         batch_exp.run(backend).block_for_results()
 
         # Get new value

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -61,7 +61,7 @@ class TestComposite(QiskitExperimentsTestCase):
         exp2.set_transpile_options(optimization_level=1)
         exp2.analysis.set_options(dummyoption="test")
 
-        par_exp = ParallelExperiment([exp0, exp2])
+        par_exp = ParallelExperiment([exp0, exp2], flatten_results=False)
 
         self.assertEqual(par_exp.experiment_options, par_exp._default_experiment_options())
         self.assertEqual(par_exp.run_options, Options(meas_level=2))
@@ -80,8 +80,14 @@ class TestComposite(QiskitExperimentsTestCase):
         exp3 = FakeExperiment([3])
         comp_exp = ParallelExperiment(
             [
-                BatchExperiment(2 * [ParallelExperiment([exp0, exp1])]),
-                BatchExperiment(3 * [ParallelExperiment([exp2, exp3])]),
+                BatchExperiment(
+                    2 * [ParallelExperiment([exp0, exp1], flatten_results=False)],
+                    flatten_results=False,
+                ),
+                BatchExperiment(
+                    3 * [ParallelExperiment([exp2, exp3], flatten_results=False)],
+                    flatten_results=False,
+                ),
             ],
             flatten_results=True,
         )
@@ -103,6 +109,7 @@ class TestComposite(QiskitExperimentsTestCase):
                 ParallelExperiment([exp0, exp1, exp2], flatten_results=True),
                 ParallelExperiment([exp2, exp3], flatten_results=True),
             ],
+            flatten_results=False,
         )
         expdata = comp_exp.run(FakeBackend())
         self.assertExperimentDone(expdata)
@@ -126,7 +133,7 @@ class TestComposite(QiskitExperimentsTestCase):
         exp2 = FakeExperiment([2])
         exp2.set_run_options(shots=2000)
 
-        exp = BatchExperiment([exp1, exp2])
+        exp = BatchExperiment([exp1, exp2], flatten_results=False)
 
         loaded_exp = BatchExperiment.from_config(exp.config())
         self.assertNotEqual(exp, loaded_exp)
@@ -139,7 +146,7 @@ class TestComposite(QiskitExperimentsTestCase):
         exp2 = FakeExperiment([2])
         exp2.set_run_options(shots=2000)
 
-        exp = BatchExperiment([exp1, exp2])
+        exp = BatchExperiment([exp1, exp2], flatten_results=False)
 
         self.assertRoundTripSerializable(exp, self.json_equiv)
 
@@ -158,9 +165,9 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
 
         exp1 = FakeExperiment([0, 2])
         exp2 = FakeExperiment([1, 3])
-        par_exp = ParallelExperiment([exp1, exp2])
+        par_exp = ParallelExperiment([exp1, exp2], flatten_results=False)
         exp3 = FakeExperiment([0, 1, 2, 3])
-        batch_exp = BatchExperiment([par_exp, exp3])
+        batch_exp = BatchExperiment([par_exp, exp3], flatten_results=False)
 
         self.rootdata = batch_exp.run(backend=self.backend)
         self.assertExperimentDone(self.rootdata)
@@ -259,7 +266,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         exp2.analysis = Analysis()
 
         # Generate a copy
-        par_exp = ParallelExperiment([exp1, exp2]).copy()
+        par_exp = ParallelExperiment([exp1, exp2], flatten_results=False).copy()
         comp_exp0 = par_exp.component_experiment(0)
         comp_exp1 = par_exp.component_experiment(1)
         comp_an0 = par_exp.analysis.component_analysis(0)
@@ -275,10 +282,10 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         """
         exp1 = FakeExperiment([0, 2])
         exp2 = FakeExperiment([1, 3])
-        exp3 = ParallelExperiment([exp1, exp2])
-        exp4 = BatchExperiment([exp3, exp1])
-        exp5 = ParallelExperiment([exp4, FakeExperiment([4])])
-        nested_exp = BatchExperiment([exp5, exp3])
+        exp3 = ParallelExperiment([exp1, exp2], flatten_results=False)
+        exp4 = BatchExperiment([exp3, exp1], flatten_results=False)
+        exp5 = ParallelExperiment([exp4, FakeExperiment([4])], flatten_results=False)
+        nested_exp = BatchExperiment([exp5, exp3], flatten_results=False)
         expdata = nested_exp.run(FakeBackend())
         self.assertExperimentDone(expdata)
 
@@ -288,7 +295,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         """
         exp1 = FakeExperiment([0, 2])
         exp2 = FakeExperiment([1, 3])
-        par_exp = ParallelExperiment([exp1, exp2])
+        par_exp = ParallelExperiment([exp1, exp2], flatten_results=False)
         data1 = par_exp.run(FakeBackend())
         self.assertExperimentDone(data1)
 
@@ -312,7 +319,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         """
         exp1 = FakeExperiment([0, 2])
         exp2 = FakeExperiment([1, 3])
-        par_exp = BatchExperiment([exp1, exp2])
+        par_exp = BatchExperiment([exp1, exp2], flatten_results=False)
         data1 = par_exp.run(FakeBackend())
         self.assertExperimentDone(data1)
 
@@ -336,7 +343,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         """
         exp1 = FakeExperiment([0, 2])
         exp2 = FakeExperiment([1, 3])
-        par_exp = BatchExperiment([exp1, exp2])
+        par_exp = BatchExperiment([exp1, exp2], flatten_results=False)
         expdata = par_exp.run(FakeBackend())
         self.assertExperimentDone(expdata)
         data1 = expdata.child_data(0)
@@ -491,7 +498,14 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         exp3 = Experiment([3], 2)
         exp4 = Experiment([1, 3], 3)
         par_exp = ParallelExperiment(
-            [exp1, BatchExperiment([ParallelExperiment([exp2, exp3]), exp4])]
+            [
+                exp1,
+                BatchExperiment(
+                    [ParallelExperiment([exp2, exp3], flatten_results=False), exp4],
+                    flatten_results=False,
+                ),
+            ],
+            flatten_results=False,
         )
         expdata = par_exp.run(Backend(num_qubits=4))
         self.assertExperimentDone(expdata)
@@ -567,7 +581,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         exp1.analysis = Analysis()
         exp2 = FakeExperiment([1])
         exp2.analysis = Analysis()
-        par_exp = ParallelExperiment([exp1, exp2])
+        par_exp = ParallelExperiment([exp1, exp2], flatten_results=False)
 
         # Set new analysis classes to component exp objects
         opt1_val = 9000
@@ -607,7 +621,9 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
 
         test_data.add_data(datum)
 
-        sub_data = CompositeAnalysis([])._marginalized_component_data(test_data.data())
+        sub_data = CompositeAnalysis([], flatten_results=False)._marginalized_component_data(
+            test_data.data()
+        )
         expected = [
             [
                 {
@@ -657,7 +673,9 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
 
         test_data.add_data(datum)
 
-        all_sub_data = CompositeAnalysis([])._marginalized_component_data(test_data.data())
+        all_sub_data = CompositeAnalysis([], flatten_results=False)._marginalized_component_data(
+            test_data.data()
+        )
         for idx, sub_data in enumerate(all_sub_data):
             expected = {
                 "metadata": {"experiment_type": "FineXAmplitude", "qubits": [idx]},
@@ -699,7 +717,9 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
 
         test_data.add_data(datum)
 
-        all_sub_data = CompositeAnalysis([])._marginalized_component_data(test_data.data())
+        all_sub_data = CompositeAnalysis([], flatten_results=False)._marginalized_component_data(
+            test_data.data()
+        )
         for idx, sub_data in enumerate(all_sub_data):
             expected = {
                 "metadata": {"experiment_type": "FineXAmplitude", "qubits": [idx]},
@@ -778,8 +798,8 @@ class TestBatchTranspileOptions(QiskitExperimentsTestCase):
         exp1 = self.SimpleExperiment(range(4))
         exp2 = self.SimpleExperiment(range(4))
         exp3 = self.SimpleExperiment(range(4))
-        batch1 = BatchExperiment([exp2, exp3])
-        self.batch2 = BatchExperiment([exp1, batch1])
+        batch1 = BatchExperiment([exp2, exp3], flatten_results=False)
+        self.batch2 = BatchExperiment([exp1, batch1], flatten_results=False)
 
         exp1.set_transpile_options(coupling_map=[[0, 1], [1, 3], [3, 2]])
         exp2.set_transpile_options(coupling_map=[[0, 1], [1, 2], [2, 3]])
@@ -832,7 +852,7 @@ class TestBatchTranspileOptions(QiskitExperimentsTestCase):
         exp = Experiment([0])
 
         # test separate_jobs=False
-        batch_exp = BatchExperiment([exp, exp])
+        batch_exp = BatchExperiment([exp, exp], flatten_results=False)
         batch_data = batch_exp.run(backend)
         self.assertExperimentDone(batch_data)
         job_ids = batch_data.job_ids
@@ -847,7 +867,7 @@ class TestBatchTranspileOptions(QiskitExperimentsTestCase):
 
         # test a forbidden nested case, where a parent sets separate_jobs
         # to False while the child sets it to True
-        meta_exp = BatchExperiment([batch_exp])
+        meta_exp = BatchExperiment([batch_exp], flatten_results=False)
         with self.assertRaises(QiskitError):
             meta_exp.run(backend)
 

--- a/test/library/calibration/test_rabi.py
+++ b/test/library/calibration/test_rabi.py
@@ -292,7 +292,7 @@ class TestCompositeExperiment(QiskitExperimentsTestCase):
 
             experiments.append(Rabi([qubit], sched, amplitudes=[0.5]))
 
-        par_exp = ParallelExperiment(experiments)
+        par_exp = ParallelExperiment(experiments, flatten_results=False)
         par_circ = par_exp.circuits()[0]
 
         # If the calibrations are not there we will not be able to transpile

--- a/test/library/characterization/test_qubit_spectroscopy.py
+++ b/test/library/characterization/test_qubit_spectroscopy.py
@@ -266,7 +266,9 @@ class TestQubitSpectroscopy(QiskitExperimentsTestCase):
         parallel_backend.experiment_helper = parallel_helper
 
         # initializing parallel experiment
-        par_experiment = ParallelExperiment(exp_list, backend=parallel_backend)
+        par_experiment = ParallelExperiment(
+            exp_list, flatten_results=False, backend=parallel_backend
+        )
         par_experiment.set_run_options(meas_level=MeasLevel.KERNELED, meas_return="single")
 
         par_data = par_experiment.run().block_for_results()

--- a/test/library/characterization/test_readout_error.py
+++ b/test/library/characterization/test_readout_error.py
@@ -179,7 +179,7 @@ class TestReadoutError(QiskitExperimentsTestCase):
         backend = FakeParisV2()
         exp1 = CorrelatedReadoutError([0, 2])
         exp2 = CorrelatedReadoutError([1, 3])
-        exp = ParallelExperiment([exp1, exp2])
+        exp = ParallelExperiment([exp1, exp2], flatten_results=False)
         expdata = exp.run(backend=backend).block_for_results()
         mit1 = expdata.child_data(0).analysis_results(0).value
         mit2 = expdata.child_data(1).analysis_results(0).value

--- a/test/library/characterization/test_resonator_spectroscopy.py
+++ b/test/library/characterization/test_resonator_spectroscopy.py
@@ -224,7 +224,9 @@ class TestResonatorSpectroscopy(QiskitExperimentsTestCase):
         # setting the helper into the backend
         parallel_backend.experiment_helper = parallel_helper
 
-        par_experiment = ParallelExperiment(exp_list, backend=parallel_backend)
+        par_experiment = ParallelExperiment(
+            exp_list, flatten_results=False, backend=parallel_backend
+        )
         par_experiment.set_run_options(meas_level=MeasLevel.KERNELED, meas_return="single")
 
         par_data = par_experiment.run().block_for_results()

--- a/test/library/characterization/test_t1.py
+++ b/test/library/characterization/test_t1.py
@@ -122,7 +122,7 @@ class TestT1(QiskitExperimentsTestCase):
         exp0 = T1(physical_qubits=[qubit0], delays=delays)
         exp2 = T1(physical_qubits=[qubit2], delays=delays)
 
-        par_exp = ParallelExperiment([exp0, exp2])
+        par_exp = ParallelExperiment([exp0, exp2], flatten_results=False)
         res = par_exp.run(backend=backend, shots=10000, seed_simulator=1).block_for_results()
         self.assertExperimentDone(res)
 
@@ -170,7 +170,7 @@ class TestT1(QiskitExperimentsTestCase):
         exp2.analysis = T1KerneledAnalysis()
 
         par_exp_list = [exp0, exp2]
-        par_exp = ParallelExperiment([exp0, exp2])
+        par_exp = ParallelExperiment([exp0, exp2], flatten_results=False)
 
         # Helpers
         exp_helper = [
@@ -236,7 +236,7 @@ class TestT1(QiskitExperimentsTestCase):
         exp1 = T1([1], delays)
         exp1.analysis.set_options(p0={"tau": 1000000})
 
-        par_exp = ParallelExperiment([exp0, exp1])
+        par_exp = ParallelExperiment([exp0, exp1], flatten_results=False)
         res = par_exp.run(backend=backend, seed_simulator=4)
         self.assertExperimentDone(res)
 
@@ -338,7 +338,7 @@ class TestT1(QiskitExperimentsTestCase):
 
         exp1 = T1([1], delays=[50e-9, 100e-9, 160e-9])
         exp2 = T1([3], delays=[40e-9, 80e-9, 190e-9])
-        parexp = ParallelExperiment([exp1, exp2])
+        parexp = ParallelExperiment([exp1, exp2], flatten_results=False)
         parexp.set_transpile_options(
             basis_gates=basis_gates,
             instruction_durations=instruction_durations,

--- a/test/library/characterization/test_t2hahn.py
+++ b/test/library/characterization/test_t2hahn.py
@@ -94,7 +94,7 @@ class TestT2Hahn(QiskitExperimentsTestCase):
         exp0.analysis.set_options(p0={"amp": 0.5, "tau": t2hahn[0], "base": 0.5}, plot=True)
         exp2.analysis.set_options(p0={"amp": 0.5, "tau": t2hahn[1], "base": 0.5}, plot=True)
 
-        par_exp = ParallelExperiment([exp0, exp2])
+        par_exp = ParallelExperiment([exp0, exp2], flatten_results=False)
 
         p0 = {
             "A": [0.5, None, 0.5],

--- a/test/library/characterization/test_t2ramsey.py
+++ b/test/library/characterization/test_t2ramsey.py
@@ -116,7 +116,7 @@ class TestT2Ramsey(QiskitExperimentsTestCase):
             [par_exp_qubits[1]], delays[1], osc_freq=osc_freq[par_exp_qubits[1]], backend=backend
         )
 
-        par_exp = ParallelExperiment([exp0, exp2])
+        par_exp = ParallelExperiment([exp0, exp2], flatten_results=False)
 
         exp0_p0 = {
             "A": 0.5,

--- a/test/library/randomized_benchmarking/test_standard_rb.py
+++ b/test/library/randomized_benchmarking/test_standard_rb.py
@@ -399,7 +399,7 @@ class TestRunStandardRB(QiskitExperimentsTestCase, RBTestMixin):
             exp.analysis.set_options(gate_error_ratio=None, plot_raw_data=False)
             exps.append(exp)
 
-        par_exp = ParallelExperiment(exps)
+        par_exp = ParallelExperiment(exps, flatten_results=False)
         par_exp.set_transpile_options(**self.transpiler_options)
 
         par_expdata = par_exp.run(backend=self.backend)
@@ -421,7 +421,7 @@ class TestRunStandardRB(QiskitExperimentsTestCase, RBTestMixin):
             exp.analysis.set_options(gate_error_ratio=None, plot_raw_data=False)
             exps.append(exp)
 
-        par_exp = ParallelExperiment(exps)
+        par_exp = ParallelExperiment(exps, flatten_results=False)
         par_exp.set_transpile_options(**self.transpiler_options)
 
         par_expdata = par_exp.run(backend=self.backend)

--- a/test/library/tomography/test_composite_tomography.py
+++ b/test/library/tomography/test_composite_tomography.py
@@ -46,7 +46,7 @@ class TestCompositeTomography(QiskitExperimentsTestCase):
 
         # Run batch experiments
         backend = AerSimulator(seed_simulator=9000)
-        batch_exp = BatchExperiment(exps)
+        batch_exp = BatchExperiment(exps, flatten_results=False)
         batch_data = batch_exp.run(backend)
         self.assertExperimentDone(batch_data)
 
@@ -85,7 +85,7 @@ class TestCompositeTomography(QiskitExperimentsTestCase):
 
         # Run batch experiments
         backend = AerSimulator(seed_simulator=9000)
-        par_exp = ParallelExperiment(exps)
+        par_exp = ParallelExperiment(exps, flatten_results=False)
         par_data = par_exp.run(backend)
         self.assertExperimentDone(par_data)
 
@@ -130,7 +130,7 @@ class TestCompositeTomography(QiskitExperimentsTestCase):
 
         # Run batch experiments
         backend = AerSimulator(seed_simulator=9000)
-        batch_exp = BatchExperiment(exps)
+        batch_exp = BatchExperiment(exps, flatten_results=False)
         batch_data = batch_exp.run(backend)
         self.assertExperimentDone(batch_data)
 
@@ -167,7 +167,7 @@ class TestCompositeTomography(QiskitExperimentsTestCase):
 
         # Run batch experiments
         backend = AerSimulator(seed_simulator=9000)
-        par_exp = ParallelExperiment(exps)
+        par_exp = ParallelExperiment(exps, flatten_results=False)
         par_data = par_exp.run(backend)
         self.assertExperimentDone(par_data)
 
@@ -199,7 +199,7 @@ class TestCompositeTomography(QiskitExperimentsTestCase):
 
         state_exp = StateTomography(state_op)
         chan_exp = ProcessTomography(chan_op)
-        batch_exp = BatchExperiment([state_exp, chan_exp])
+        batch_exp = BatchExperiment([state_exp, chan_exp], flatten_results=False)
 
         # Run batch experiments
         backend = AerSimulator(seed_simulator=9000)


### PR DESCRIPTION
### Summary

This PR deprecates `flatten_results=False` in composite experiment and composite analysis. The goal of this is to upgrade the default value to `True`, however, since now we must conform to the standard Qiskit deprecation policy, deprecation must be issued at least for one release cycle.