### PR TITLE
Added experiment timestamp how-to

### DIFF
--- a/docs/howtos/experiment_times.rst
+++ b/docs/howtos/experiment_times.rst
@@ -1,0 +1,39 @@
+Get experiment timing information 
+=================================
+
+Problem
+-------
+
+You want to know when an experiment started and finished running.
+
+Solution
+--------
+
+The :class:`.ExperimentData` class contains timing information in the following attributes, which
+are all of type ``datetime.datetime`` and in your local timezone:
+
+- :attr:`.ExperimentData.start_datetime` is when the :class:`.ExperimentData` was instantiated,
+  which is also when the experiment began running in the typical workflow by calling
+  ``experiment_data = exp.run()``.
+
+- :attr:`.ExperimentData.end_datetime` is the time the most recently completed job was successfully
+  added to the :class:`.ExperimentData` object. If a job was canceled, did not run successfully, or
+  could not be added to the :class:`.ExperimentData` object for some other reason,
+  :attr:`.ExperimentData.end_datetime` will not update.
+
+.. note::
+    The below attributes are only relevant for those who have access to the cloud service. You can 
+    check whether you do by logging into the IBM Quantum interface 
+    and seeing if you can see the `database <https://quantum-computing.ibm.com/experiments>`__.
+
+- :attr:`.ExperimentData.creation_datetime` is the time when the experiment data was saved via the
+  service. This defaults to ``None`` if experiment data has not yet been saved.
+
+- :attr:`.ExperimentData.update_datetime` is the time the experiment data entry in the service was
+  last updated. This defaults to ``None`` if experiment data has not yet been saved.
+
+Discussion
+----------
+
+:attr:`.ExperimentData.start_datetime` can also be set to a custom timestamp when instantiating an
+:class:`.ExperimentData` object by passing a value to the ``start_datetime`` field.

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -188,6 +188,11 @@ class FigureData:
 class ExperimentData:
     """Experiment data container class.
 
+    .. note::
+        Saving experiment data to the cloud database is currently a limited access feature. You can
+        check whether you have access by logging into the IBM Quantum interface
+        and seeing if you can see the `database <https://quantum-computing.ibm.com/experiments>`__.
+
     This class handles the following:
 
     1. Storing the data related to an experiment: raw data, metadata, analysis results,
@@ -242,13 +247,14 @@ class ExperimentData:
             verbose: Whether to print messages.
             db_data: A prepared ExperimentDataclass of the experiment info.
                 This overrides other db parameters.
-            start_datetime: The time when the experiment was started.
-                If none, defaults to the current time
+            start_datetime: The time when the experiment started running.
+                If none, defaults to the current time.
 
         Additional info:
             In order to save the experiment data to the cloud service, the class
             needs access to the experiment service provider. It can be obtained
             via three different methods, given here by priority:
+
             1. Passing it directly via the ``service`` parameter.
             2. Implicitly obtaining it from the ``provider`` parameter.
             3. Implicitly obtaining it from the ``backend`` parameter, using that backend's provider.
@@ -395,7 +401,8 @@ class ExperimentData:
         """Return the creation datetime of this experiment data.
 
         Returns:
-            The creation datetime of this experiment data in the local timezone.
+            The timestamp when this experiment data was saved to the cloud service
+            in the local timezone.
 
         """
         return utc_to_local(self._db_data.creation_datetime)
@@ -405,7 +412,7 @@ class ExperimentData:
         """Return the start datetime of this experiment data.
 
         Returns:
-            The start datetime of this experiment data.
+            The timestamp when this experiment began running in the local timezone.
 
         """
         return utc_to_local(self._db_data.start_datetime)
@@ -419,7 +426,8 @@ class ExperimentData:
         """Return the update datetime of this experiment data.
 
         Returns:
-            The update datetime of this experiment data.
+            The timestamp when this experiment data was last updated in the service
+            in the local timezone.
 
         """
         return utc_to_local(self._db_data.updated_datetime)
@@ -431,7 +439,8 @@ class ExperimentData:
         added without errors; this can change as more jobs finish.
 
         Returns:
-            The end datetime of this experiment data.
+            The timestamp when the last job of this experiment finished
+            in the local timezone.
 
         """
         return utc_to_local(self._db_data.end_datetime)


### PR DESCRIPTION
### Summary

Added a how-to explaining the different timestamps tracked in `ExperimentData` and updated the docstrings with more details.
