### PR TITLE
Remove save/load part from T1 tests

### DIFF
--- a/test/library/characterization/test_t1.py
+++ b/test/library/characterization/test_t1.py
@@ -217,15 +217,6 @@ class TestT1(QiskitExperimentsTestCase):
             self.assertEqual(sub_res.quality, "good")
             self.assertAlmostEqual(sub_res.value.n, t1[qb], delta=3)
 
-        res.service = IBMExperimentService(local=True, local_save=False)
-        res.save()
-        loaded_data = ExperimentData.load(res.experiment_id, res.service)
-
-        for i in range(2):
-            sub_res = res.child_data(i).analysis_results("T1")
-            sub_loaded = loaded_data.child_data(i).analysis_results("T1")
-            self.assertEqual(repr(sub_res), repr(sub_loaded))
-
     def test_t1_parallel_different_analysis_options(self):
         """
         Test parallel experiments of T1 using a simulator, for the case where

--- a/test/library/characterization/test_t1.py
+++ b/test/library/characterization/test_t1.py
@@ -17,7 +17,6 @@ from test.base import QiskitExperimentsTestCase
 import numpy as np
 from qiskit.qobj.utils import MeasLevel
 from qiskit.providers.fake_provider import FakeAthensV2
-from qiskit_ibm_experiment import IBMExperimentService
 from qiskit_experiments.test.noisy_delay_aer_simulator import NoisyDelayAerBackend
 from qiskit_experiments.framework import ExperimentData, ParallelExperiment
 from qiskit_experiments.library import T1
@@ -50,23 +49,6 @@ class TestT1(QiskitExperimentsTestCase):
         self.assertEqual(res.quality, "good")
         self.assertAlmostEqual(res.value.n, t1, delta=3)
         self.assertEqual(res.extra["unit"], "s")
-
-        exp_data.service = IBMExperimentService(local=True, local_save=False)
-        exp_data.save()
-        loaded_data = ExperimentData.load(exp_data.experiment_id, exp_data.service)
-
-        # By default, server result is sorted by creation_datetime and result_id.
-        # In some test environment datetime sorting may not keep original element ordering.
-        exp_results = sorted(
-            exp_data.analysis_results(),
-            key=lambda r: r.name,
-        )
-        load_results = sorted(
-            loaded_data.analysis_results(),
-            key=lambda r: r.name,
-        )
-        for exp_res, load_res in zip(exp_results, load_results):
-            self.assertEqualExtended(exp_res, load_res)
 
     def test_t1_measurement_level_1(self):
         """
@@ -139,15 +121,6 @@ class TestT1(QiskitExperimentsTestCase):
             sub_res = res.child_data(i).analysis_results("T1")
             self.assertEqual(sub_res.quality, "good")
             self.assertAlmostEqual(sub_res.value.n, t1[qb], delta=3)
-
-        res.service = IBMExperimentService(local=True, local_save=False)
-        res.save()
-        loaded_data = ExperimentData.load(res.experiment_id, res.service)
-
-        for i in range(2):
-            sub_res = res.child_data(i).analysis_results("T1")
-            sub_loaded = loaded_data.child_data(i).analysis_results("T1")
-            self.assertEqual(repr(sub_res), repr(sub_loaded))
 
     def test_t1_parallel_measurement_level_1(self):
         """


### PR DESCRIPTION
### Summary

This PR removes the save/load portion of the `TestT1` tests.

### Details and comments

We encounter repeated errors with the save/load part of `TestT1`, probably resulting from an error in the way the experiment service handles data. We have not been able to reliably reproduce the problem yet, and so for now we will move this part of the test into the `qiskit-ibm-experiment` repository until it is fixed.