### PR TITLE
Update docs theme version and minor fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,6 +151,8 @@ html_context = {
     "expandable_sidebar": True,
 }
 
+docs_url_prefix = "ecosystem/experiments"
+
 html_last_updated_fmt = "%Y/%m/%d"
 
 html_theme_options = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ author = "Qiskit Development Team"
 # -- General configuration ---------------------------------------------------
 
 extensions = [
+    "qiskit_sphinx_theme",
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",

--- a/docs/howtos/experiment_times.rst
+++ b/docs/howtos/experiment_times.rst
@@ -29,7 +29,7 @@ are all of type ``datetime.datetime`` and in your local timezone:
 - :attr:`.ExperimentData.creation_datetime` is the time when the experiment data was saved via the
   service. This defaults to ``None`` if experiment data has not yet been saved.
 
-- :attr:`.ExperimentData.update_datetime` is the time the experiment data entry in the service was
+- :attr:`.ExperimentData.updated_datetime` is the time the experiment data entry in the service was
   last updated. This defaults to ``None`` if experiment data has not yet been saved.
 
 Discussion

--- a/qiskit_experiments/framework/configs.py
+++ b/qiskit_experiments/framework/configs.py
@@ -22,15 +22,12 @@ from qiskit_experiments.version import __version__
 
 @dataclasses.dataclass(frozen=True)
 class ExperimentConfig:
-    """Store configuration settings for an Experiment
+    """Store configuration settings for an Experiment class.
 
-    This stores the current configuration of a
-    :class:~qiskit_experiments.framework.BaseExperiment` and
-    can be used to reconstruct the experiment using either the
-    :meth:`experiment` property if the experiment class type is
-    currently stored, or the
-    :meth:~qiskit_experiments.framework.BaseExperiment.from_config`
-    class method of the appropriate experiment.
+    This stores the current configuration of a :class:`.BaseExperiment` and can be used to
+    reconstruct the experiment using either the :meth:`experiment` property if the experiment class
+    type is currently stored, or the :meth:`~.BaseExperiment.from_config` class method of the
+    appropriate experiment.
     """
 
     cls: type = None
@@ -75,15 +72,12 @@ class ExperimentConfig:
 
 @dataclasses.dataclass(frozen=True)
 class AnalysisConfig:
-    """Store configuration settings for Analysis
+    """Store configuration settings for an Analysis class.
 
-    This stores the current configuration of a
-    :class:~qiskit_experiments.framework.BaseAnalysis` and
-    can be used to reconstruct the analysis class using either the
-    :meth:`analysis` property if the analysis class type is
-    currently stored, or the
-    :meth:~qiskit_experiments.framework.BaseAnalysis.from_config`
-    class method of the appropriate experiment.
+    This stores the current configuration of a :class:`.BaseAnalysis` and can be used to reconstruct
+    the analysis class using either the :meth:`analysis` property if the analysis class type is
+    currently stored, or the :meth:`~.BaseAnalysis.from_config` class method of the appropriate
+    experiment.
     """
 
     cls: type = None

--- a/qiskit_experiments/library/__init__.py
+++ b/qiskit_experiments/library/__init__.py
@@ -19,7 +19,7 @@ Experiment Library (:mod:`qiskit_experiments.library`)
 
 A library of of quantum characterization, calibration and verification
 experiments for calibrating and benchmarking quantum devices. See
-:mod:`qiskit_experiments.framework` for general information the framework
+:mod:`qiskit_experiments.framework` for general information on the framework
 for running experiments.
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ astroid~=2.14.2  # Must be kept aligned to what pylint wants
 jinja2==3.0.3
 sphinx~=5.0
 jupyter-sphinx>=0.4.0
-qiskit-sphinx-theme~=1.11.0rc2
+qiskit-sphinx-theme~=1.12.0rc1
 sphinx-design==0.3.0
 pygments>=2.4
 reno>=4.0.0


### PR DESCRIPTION
### Summary

This PR bumps our `qiskit-sphinx-theme` version to 1.12.0rc1, which should fix our previous releases links. It also fixes some typos in the docs.