### PR TITLE
Change `qiskit-dynamics` to an optional dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,6 +172,7 @@ intersphinx_mapping = {
     "uncertainties": ("https://pythonhosted.org/uncertainties", None),
     "qiskit_ibm_provider": ("https://qiskit.org/ecosystem/ibm-provider/", None),
     "qiskit_aer": ("https://qiskit.org/ecosystem/aer", None),
+    "qiskit_dynamics": ("https://qiskit.org/documentation/dynamics", None),
 }
 
 

--- a/docs/tutorials/calibrations.rst
+++ b/docs/tutorials/calibrations.rst
@@ -30,6 +30,10 @@ Note that the values of the parameters stored in the instance of the :class:`.Ca
 will automatically be updated by the calibration experiments. 
 This automatic updating can also be disabled using the ``auto_update`` flag.
 
+.. note::
+    This tutorial requires the :mod:`qiskit_dynamics` package to run simulations.
+    You can install it with ``python -m pip install qiskit-dynamics``.
+
 .. jupyter-execute::
 
     import pandas as pd

--- a/docs/tutorials/data_processor.rst
+++ b/docs/tutorials/data_processor.rst
@@ -1,10 +1,6 @@
 Data Processor: Wrangling data
 ==============================
 
-.. note::
-    This tutorial requires the :mod:`qiskit_dynamics` package to run simulations.
-    You can install it with ``python -m pip install qiskit-dynamics``.
-
 Data processing is the act of taking the data returned by the backend and
 converting it into a format that can be analyzed.
 It is implemented as a chain of data processing steps that transform various input data,
@@ -68,6 +64,9 @@ To illustrate the data processing module, we consider an example
 in which we measure a rabi oscillation with different data levels.
 The code below sets up the Rabi experiment.
 
+.. note::
+    This tutorial requires the :mod:`qiskit_dynamics` package to run simulations.
+    You can install it with ``python -m pip install qiskit-dynamics``.
 
 .. jupyter-execute::
 

--- a/docs/tutorials/data_processor.rst
+++ b/docs/tutorials/data_processor.rst
@@ -1,6 +1,10 @@
 Data Processor: Wrangling data
 ==============================
 
+.. note::
+    This tutorial requires the :mod:`qiskit_dynamics` package to run simulations.
+    You can install it with ``python -m pip install qiskit-dynamics``.
+
 Data processing is the act of taking the data returned by the backend and
 converting it into a format that can be analyzed.
 It is implemented as a chain of data processing steps that transform various input data,

--- a/docs/tutorials/visualization.rst
+++ b/docs/tutorials/visualization.rst
@@ -28,12 +28,14 @@ implemented by users to use alternative backends. As long as the backend is a su
 generate figures with the alternative backend.
 
 
-
-
 Generating and customizing a figure using a plotter
 ---------------------------------------------------
 
 First, we display the default figure from a :class:`.Rabi` experiment as a starting point:
+
+.. note::
+    This tutorial requires the :mod:`qiskit_dynamics` package to run simulations.
+    You can install it with ``python -m pip install qiskit-dynamics``.
 
 .. jupyter-execute::
 

--- a/qiskit_experiments/library/quantum_volume/qv_experiment.py
+++ b/qiskit_experiments/library/quantum_volume/qv_experiment.py
@@ -17,12 +17,7 @@ from typing import Union, Sequence, Optional, List
 from numpy.random import Generator, default_rng
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 
-try:
-    from qiskit import Aer
-
-    HAS_SIMULATION_BACKEND = True
-except ImportError:
-    HAS_SIMULATION_BACKEND = False
+from qiskit.utils.optionals import HAS_AER
 
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import QuantumVolume as QuantumVolumeCircuit
@@ -103,7 +98,9 @@ class QuantumVolume(BaseExperiment):
         # Set configurable options
         self.set_experiment_options(trials=trials, seed=seed)
 
-        if not simulation_backend and HAS_SIMULATION_BACKEND:
+        if not simulation_backend and HAS_AER:
+            from qiskit import Aer
+
             self._simulation_backend = Aer.get_backend("aer_simulator")
         else:
             self._simulation_backend = simulation_backend

--- a/qiskit_experiments/library/quantum_volume/qv_experiment.py
+++ b/qiskit_experiments/library/quantum_volume/qv_experiment.py
@@ -99,7 +99,7 @@ class QuantumVolume(BaseExperiment):
         self.set_experiment_options(trials=trials, seed=seed)
 
         if not simulation_backend and HAS_AER:
-            from qiskit import Aer
+            from qiskit_aer import Aer
 
             self._simulation_backend = Aer.get_backend("aer_simulator")
         else:

--- a/qiskit_experiments/test/pulse_backend.py
+++ b/qiskit_experiments/test/pulse_backend.py
@@ -35,14 +35,13 @@ from qiskit.quantum_info.states import DensityMatrix, Statevector
 from qiskit.result import Result, Counts
 from qiskit.transpiler import InstructionProperties, Target
 
-from qiskit_dynamics import Solver
-from qiskit_dynamics.pulse import InstructionToSignals
-
+from qiskit_experiments.warnings import HAS_DYNAMICS
 from qiskit_experiments.data_processing.discriminator import BaseDiscriminator
 from qiskit_experiments.exceptions import QiskitError
 from qiskit_experiments.test.utils import FakeJob
 
 
+@HAS_DYNAMICS.require_in_instance
 class PulseBackend(BackendV2):
     r"""Abstract base class for pulse simulation backends in Qiskit Experiments.
 
@@ -87,6 +86,8 @@ class PulseBackend(BackendV2):
             seed: An optional seed given to the random number generator. If this argument is not
                 set then the seed defaults to 0.
         """
+        from qiskit_dynamics import Solver
+
         super().__init__(
             None,
             name="PulseBackendV2",
@@ -430,6 +431,7 @@ class PulseBackend(BackendV2):
         return FakeJob(self, Result.from_dict(result))
 
 
+@HAS_DYNAMICS.require_in_instance
 class SingleTransmonTestBackend(PulseBackend):
     r"""A backend that corresponds to a three level anharmonic transmon qubit.
 
@@ -465,6 +467,8 @@ class SingleTransmonTestBackend(PulseBackend):
             noise: Defaults to True. If True then T1 dissipation is included in the pulse-simulation.
                 The strength is given by ``gamma_1``.
         """
+        from qiskit_dynamics.pulse import InstructionToSignals
+
         qubit_frequency_02 = 2 * qubit_frequency + anharmonicity
         ket0 = np.array([[1, 0, 0]]).T
         ket1 = np.array([[0, 1, 0]]).T

--- a/qiskit_experiments/warnings.py
+++ b/qiskit_experiments/warnings.py
@@ -254,3 +254,7 @@ HAS_SKLEARN = LazyImportTester(
     name="scikit-learn",
     install="pip install scikit-learn",
 )
+
+HAS_DYNAMICS = LazyImportTester(
+    "qiskit_dynamics", name="qiskit-dynamics", install="pip install qiskit-dynamics"
+)

--- a/releasenotes/notes/dynamics-requirement-6109a8846c0f88c2.yaml
+++ b/releasenotes/notes/dynamics-requirement-6109a8846c0f88c2.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Qiskit Dynamics has been removed as a requirement and is now an optional developer-only dependency.

--- a/releasenotes/notes/dynamics-requirement-6109a8846c0f88c2.yaml
+++ b/releasenotes/notes/dynamics-requirement-6109a8846c0f88c2.yaml
@@ -1,4 +1,5 @@
 ---
 other:
   - |
-    Qiskit Dynamics has been removed as a requirement and is now an optional developer-only dependency.
+    Qiskit Dynamics has been removed as a requirement and is now an optional
+    dependency for running the tutorials and tests.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ nbsphinx
 arxiv
 ddt>=1.6.0
 qiskit-aer>=0.11.0
+qiskit_dynamics>=0.3.0
 pandas>=1.1.5
 cvxpy>=1.1.15
 pylatexenc

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ numpy>=1.17
 scipy>=1.4
 qiskit-terra>=0.24
 qiskit-ibm-experiment>=0.3.1
-qiskit_dynamics>=0.3.0
 matplotlib>=3.4
 uncertainties
 lmfit


### PR DESCRIPTION
### Summary

This PR adds a `HAS_DYNAMICS` checker for mock backends dependent on `qiskit-dynamics` and moves the package to `requirements-dev.txt`. The QV experiment has also been updated to use the `HAS_AER` checker in Terra. Both of these imports have been moved inside the relevant classes. This will close #1165.