### PR TITLE
Avoid setting auto save triggering save for children in a composite experiment

### DIFF
--- a/docs/howtos/cloud_service.rst
+++ b/docs/howtos/cloud_service.rst
@@ -144,8 +144,8 @@ The :meth:`~.ExperimentData.auto_save` feature automatically saves changes to th
 
 Setting ``auto_save = True`` works by triggering :meth:`.ExperimentData.save`.
 
-When working with composite experiments, setting `auto_save` will affect this
-setting for the child experiments.
+When working with composite experiments, setting ``auto_save`` will propagate this
+setting to the child experiments.
 
 Deleting an experiment
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/howtos/cloud_service.rst
+++ b/docs/howtos/cloud_service.rst
@@ -142,12 +142,10 @@ The :meth:`~.ExperimentData.auto_save` feature automatically saves changes to th
     You can view the experiment online at https://quantum-computing.ibm.com/experiments/cdaff3fa-f621-4915-a4d8-812d05d9a9ca
     <ExperimentData[T1], backend: ibmq_lima, status: ExperimentStatus.DONE, experiment_id: cdaff3fa-f621-4915-a4d8-812d05d9a9ca>
 
-Setting `auto_save = True` will trigger :meth:`~.ExperimentData.save` unless it was
-already `True`.
+Setting `auto_save = True` will trigger :meth:`~.ExperimentData.save`.
 
-When working with composite experiments, setting `auto_save = True` will not affect this
-setting for the child experiments. However, when auto saving the parent experiment,
-the children will be saved as well.
+When working with composite experiments, setting `auto_save` will affect this
+setting for the child experiments.
 
 Deleting an experiment
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/howtos/cloud_service.rst
+++ b/docs/howtos/cloud_service.rst
@@ -142,7 +142,7 @@ The :meth:`~.ExperimentData.auto_save` feature automatically saves changes to th
     You can view the experiment online at https://quantum-computing.ibm.com/experiments/cdaff3fa-f621-4915-a4d8-812d05d9a9ca
     <ExperimentData[T1], backend: ibmq_lima, status: ExperimentStatus.DONE, experiment_id: cdaff3fa-f621-4915-a4d8-812d05d9a9ca>
 
-Setting `auto_save = True` will trigger :meth:`~.ExperimentData.save`.
+Setting ``auto_save = True`` works by triggering :meth:`.ExperimentData.save`.
 
 When working with composite experiments, setting `auto_save` will affect this
 setting for the child experiments.

--- a/docs/howtos/cloud_service.rst
+++ b/docs/howtos/cloud_service.rst
@@ -142,6 +142,13 @@ The :meth:`~.ExperimentData.auto_save` feature automatically saves changes to th
     You can view the experiment online at https://quantum-computing.ibm.com/experiments/cdaff3fa-f621-4915-a4d8-812d05d9a9ca
     <ExperimentData[T1], backend: ibmq_lima, status: ExperimentStatus.DONE, experiment_id: cdaff3fa-f621-4915-a4d8-812d05d9a9ca>
 
+Setting `auto_save = True` will trigger :meth:`~.ExperimentData.save` unless it was
+already `True`.
+
+When working with composite experiments, setting `auto_save = True` will not affect this
+setting for the child experiments. However, when auto saving the parent experiment,
+the children will be saved as well.
+
 Deleting an experiment
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1528,8 +1528,9 @@ class ExperimentData:
                 raise ExperimentDataSaveFailed("No service found")
         if max_workers > self._max_workers_cap:
             LOG.warning(
-                f"max_workers cannot be larger than {self._max_workers_cap}. "
-                f"Setting max_workers = {self._max_workers_cap} now."
+                f"max_workers cannot be larger than %s. " f"Setting max_workers = %s now.",
+                self._max_workers_cap,
+                self._max_workers_cap,
             )
             max_workers = self._max_workers_cap
         self._save_experiment_metadata(suppress_errors=suppress_errors)

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1445,7 +1445,6 @@ class ExperimentData:
             See :meth:`qiskit.providers.experiment.IBMExperimentService.create_experiment`
             for fields that are saved.
         """
-        print("_save_experiment_metadata called for", self.experiment_id)
         if not self._service:
             LOG.warning(
                 "Experiment cannot be saved because no experiment service is available. "
@@ -1725,7 +1724,6 @@ class ExperimentData:
 
         # Wait for futures
         self._wait_for_futures(job_futs + analysis_futs, name="jobs and analysis", timeout=timeout)
-
         # Clean up done job futures
         num_jobs = len(job_ids)
         for jid, fut in zip(job_ids, job_futs):

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -216,6 +216,7 @@ class ExperimentData:
     _json_decoder = ExperimentDecoder
 
     _metadata_filename = "metadata.json"
+    _max_workers_cap = 10
 
     def __init__(
         self,
@@ -1525,7 +1526,12 @@ class ExperimentData:
                 return
             else:
                 raise ExperimentDataSaveFailed("No service found")
-
+        if max_workers > self._max_workers_cap:
+            LOG.warning(
+                f"max_workers cannot be larger than {self._max_workers_cap}."
+                f"Setting max_workers = {self._max_workers_cap} now."
+            )
+            max_workers = self._max_workers_cap
         self._save_experiment_metadata(suppress_errors=suppress_errors)
         if not self._created_in_db:
             LOG.warning("Could not save experiment metadata to DB, aborting experiment save")

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1489,7 +1489,7 @@ class ExperimentData:
     def save(
         self,
         suppress_errors: bool = True,
-        max_workers: int = 100,
+        max_workers: int = 3,
         save_figures: bool = True,
         save_children: bool = True,
     ) -> None:

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1176,6 +1176,7 @@ class ExperimentData:
             # check whether the figure is already wrapped, meaning it came from a sub-experiment
             if isinstance(figure, FigureData):
                 figure_data = figure.copy(new_name=fig_name)
+                figure = figure_data.figure
 
             else:
                 figure_metadata = {"qubits": self.metadata.get("physical_qubits")}

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1528,7 +1528,7 @@ class ExperimentData:
                 raise ExperimentDataSaveFailed("No service found")
         if max_workers > self._max_workers_cap:
             LOG.warning(
-                "max_workers cannot be larger than %s. " f"Setting max_workers = %s now.",
+                "max_workers cannot be larger than %s. Setting max_workers = %s now.",
                 self._max_workers_cap,
                 self._max_workers_cap,
             )

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1528,7 +1528,7 @@ class ExperimentData:
                 raise ExperimentDataSaveFailed("No service found")
         if max_workers > self._max_workers_cap:
             LOG.warning(
-                f"max_workers cannot be larger than %s. " f"Setting max_workers = %s now.",
+                "max_workers cannot be larger than %s. " f"Setting max_workers = %s now.",
                 self._max_workers_cap,
                 self._max_workers_cap,
             )

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -724,8 +724,6 @@ class ExperimentData:
             # Setting private variable directly to avoid duplicate save. This
             # can be removed when we start tracking changes.
             res._auto_save = save_val
-        for data in self.child_data():
-            data.auto_save = save_val
 
     @property
     def source(self) -> Dict:
@@ -1443,6 +1441,7 @@ class ExperimentData:
             See :meth:`qiskit.providers.experiment.IBMExperimentService.create_experiment`
             for fields that are saved.
         """
+        print("_save_experiment_metadata called for", self.experiment_id)
         if not self._service:
             LOG.warning(
                 "Experiment cannot be saved because no experiment service is available. "

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1528,7 +1528,7 @@ class ExperimentData:
                 raise ExperimentDataSaveFailed("No service found")
         if max_workers > self._max_workers_cap:
             LOG.warning(
-                f"max_workers cannot be larger than {self._max_workers_cap}."
+                f"max_workers cannot be larger than {self._max_workers_cap}. "
                 f"Setting max_workers = {self._max_workers_cap} now."
             )
             max_workers = self._max_workers_cap

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1491,7 +1491,7 @@ class ExperimentData:
         suppress_errors: bool = True,
         max_workers: int = 100,
         save_figures: bool = True,
-        save_children=True,
+        save_children: bool = True,
     ) -> None:
         """Save the experiment data to a database service.
 

--- a/qiskit_experiments/framework/experiment_data.py
+++ b/qiskit_experiments/framework/experiment_data.py
@@ -1499,7 +1499,7 @@ class ExperimentData:
         Args:
             suppress_errors: should the method catch exceptions (true) or
             pass them on, potentially aborting the experiemnt (false)
-            max_workers: Maximum number of concurrent worker threads
+            max_workers: Maximum number of concurrent worker threads (capped by 10)
             save_figures: Whether to save figures in the database or not
             save_children: For composite experiments, whether to save children as well
 

--- a/releasenotes/notes/experiment_data_save_bugfixes-48fe62bf2bfe38b8.yaml
+++ b/releasenotes/notes/experiment_data_save_bugfixes-48fe62bf2bfe38b8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :meth:`ExperimentData.auto_save` setter no longer saves sub-experiments twice.
+  - |
+    :meth:`ExperimentData.save` now handles correctly figures in sub-experiments when `flatten_results=True`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.17
 scipy>=1.4
 qiskit-terra>=0.24
-qiskit-ibm-experiment>=0.3.2
+qiskit-ibm-experiment>=0.3.3
 matplotlib>=3.4
 uncertainties
 lmfit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.17
 scipy>=1.4
 qiskit-terra>=0.24
-qiskit-ibm-experiment>=0.3.1
+qiskit-ibm-experiment>=0.3.2
 matplotlib>=3.4
 uncertainties
 lmfit

--- a/test/fake_experiment.py
+++ b/test/fake_experiment.py
@@ -13,6 +13,7 @@
 """A FakeExperiment for testing."""
 
 import numpy as np
+from matplotlib.figure import Figure as MatplotlibFigure
 from qiskit_experiments.framework import BaseExperiment, BaseAnalysis, Options, AnalysisResultData
 
 
@@ -25,13 +26,17 @@ class FakeAnalysis(BaseAnalysis):
         super().__init__()
         self._kwargs = kwargs
 
-    def _run_analysis(self, experiment_data, **options):
-        seed = options.get("seed", None)
+    def _run_analysis(self, experiment_data):
+        seed = self.options.get("seed", None)
         rng = np.random.default_rng(seed=seed)
         analysis_results = [
             AnalysisResultData(f"result_{i}", value) for i, value in enumerate(rng.random(3))
         ]
-        return analysis_results, None
+        figures = None
+        add_figures = self.options.get("add_figures", False)
+        if add_figures:
+            figures = [MatplotlibFigure()]
+        return analysis_results, figures
 
 
 class FakeExperiment(BaseExperiment):

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -365,6 +365,22 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         self.assertEqual(sorted(data1.tags), ["c", "d"])
         self.assertEqual(sorted(data2.tags), ["c", "d"])
 
+    def test_composite_figures(self):
+        """
+        Test adding figures from composite experiments
+        """
+        exp1 = FakeExperiment([0, 2])
+        exp2 = FakeExperiment([1, 3])
+        exp1.analysis.set_options(add_figures=True)
+        exp2.analysis.set_options(add_figures=True)
+        par_exp = BatchExperiment([exp1, exp2], flatten_results=True)
+        expdata = par_exp.run(FakeBackend())
+        expdata.service = IBMExperimentService(local=True, local_save=False)
+        expdata.auto_save = True
+        expdata.block_for_results()
+        self.assertExperimentDone(expdata)
+
+
     def test_composite_subexp_data(self):
         """
         Verify that sub-experiment data of parallel and batch

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -19,7 +19,7 @@ from test.fake_experiment import FakeExperiment, FakeAnalysis
 from test.base import QiskitExperimentsTestCase
 from unittest import mock
 from ddt import ddt, data
-
+from matplotlib.figure import Figure as MatplotlibFigure
 
 from qiskit import QuantumCircuit, Aer
 from qiskit.result import Result
@@ -379,7 +379,8 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         expdata = par_exp.run(FakeBackend())
         expdata.service = IBMExperimentService(local=True, local_save=False)
         expdata.auto_save = True
-        expdata.block_for_results()
+        new_figure = MatplotlibFigure()
+        expdata.add_figures([new_figure])
         self.assertExperimentDone(expdata)
 
     def test_composite_auto_save(self):
@@ -392,7 +393,7 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         par_exp = BatchExperiment([exp1, exp2], flatten_results=False)
         expdata = par_exp.run(FakeBackend())
         expdata.service = service
-        expdata.block_for_results()
+        self.assertExperimentDone(expdata)
         expdata.auto_save = True
         self.assertEqual(service.create_or_update_experiment.call_count, 3)
 

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -17,7 +17,9 @@ import uuid
 
 from test.fake_experiment import FakeExperiment, FakeAnalysis
 from test.base import QiskitExperimentsTestCase
+from unittest import mock
 from ddt import ddt, data
+
 
 from qiskit import QuantumCircuit, Aer
 from qiskit.result import Result
@@ -379,6 +381,22 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         expdata.auto_save = True
         expdata.block_for_results()
         self.assertExperimentDone(expdata)
+
+    def test_composite_auto_save(self):
+        """
+        Test setting autosave when using composite experiments
+        """
+        service = mock.create_autospec(IBMExperimentService, instance=True)
+        exp1 = FakeExperiment([0, 2])
+        exp2 = FakeExperiment([1, 3])
+        par_exp = BatchExperiment([exp1, exp2], flatten_results=False)
+        expdata = par_exp.run(FakeBackend())
+        expdata.service = service
+        expdata.block_for_results()
+        expdata.auto_save = True
+        self.assertEqual(service.create_or_update_experiment.call_count, 3)
+
+
 
 
     def test_composite_subexp_data(self):

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -19,7 +19,6 @@ from test.fake_experiment import FakeExperiment, FakeAnalysis
 from test.base import QiskitExperimentsTestCase
 from unittest import mock
 from ddt import ddt, data
-from matplotlib.figure import Figure as MatplotlibFigure
 
 from qiskit import QuantumCircuit, Aer
 from qiskit.result import Result
@@ -375,12 +374,12 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         exp2 = FakeExperiment([1, 3])
         exp1.analysis.set_options(add_figures=True)
         exp2.analysis.set_options(add_figures=True)
-        par_exp = BatchExperiment([exp1, exp2], flatten_results=True)
+        par_exp = BatchExperiment([exp1, exp2], flatten_results=False)
         expdata = par_exp.run(FakeBackend())
+        self.assertExperimentDone(expdata)
         expdata.service = IBMExperimentService(local=True, local_save=False)
         expdata.auto_save = True
-        new_figure = MatplotlibFigure()
-        expdata.add_figures([new_figure])
+        par_exp.analysis.run(expdata)
         self.assertExperimentDone(expdata)
 
     def test_composite_auto_save(self):

--- a/test/framework/test_composite.py
+++ b/test/framework/test_composite.py
@@ -396,9 +396,6 @@ class TestCompositeExperimentData(QiskitExperimentsTestCase):
         expdata.auto_save = True
         self.assertEqual(service.create_or_update_experiment.call_count, 3)
 
-
-
-
     def test_composite_subexp_data(self):
         """
         Verify that sub-experiment data of parallel and batch


### PR DESCRIPTION
### Summary

This PR changes the behavior of `ExprimentData.auto_save` such that setting this field in the parent of a composite experiment does not trigger the `save` method in the children experiments.

An unrelated change in this PR is setting a hard coded cap of 10 on the numbers of workers that can be used in experiment saving.

### Details and comments

Currently setting `auto_save = True` triggers a save of the parent, including the children. If in addition to that the `auto_save` field is set to `True` in the children it triggers another save; this is usually harmless, but it is an unexpected behavior which led to #1184.

This PR changes this. Children will save along with the parents' initial save. This is done by adding a switch to save (which is on by default but off when saving from the `auto_save` setter)
