### PR TITLE
Suppress new scs warning from docs output

### DIFF
--- a/docs/manuals/verification/state_tomography.rst
+++ b/docs/manuals/verification/state_tomography.rst
@@ -128,6 +128,16 @@ details). For example, if ``cvxpy`` is installed we can use the
 PSD without requiring rescaling.
 
 .. jupyter-execute::
+    :hide-code:
+
+    import warnings
+    # Hide warning from scs from output; is there a way to avoid the warning?
+    # Full warning line:
+    #   /.tox/docs/lib/python3.13/site-packages/scs/__init__.py:83: UserWarning: 
+    #   Converting A to a CSC (compressed sparse column) matrix; may take a while.
+    warnings.filterwarnings("ignore", module=r"scs", message="Converting A to a CSC")
+
+.. jupyter-execute::
 
     try:
         import cvxpy


### PR DESCRIPTION
jupyter-sphinx causes the docs build to fail for any warning so we need to suppress warnings for the docs to build. I am not sure if there is something we should be doing in this specific warning's case. The warning text is:

> `/.tox/docs/lib/python3.13/site-packages/scs/__init__.py:83: UserWarning: `
> `Converting A to a CSC (compressed sparse column) matrix; may take a while.`

The code emitting the warning in scs has not changed recently but something else in the pipeline must have changed to generate a matrix differently than it did before.