### PR TITLE
Suppress Samplomatic warning about being in beta

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ setenv =
   QISKIT_PARALLEL={env:QISKIT_PARALLEL:FALSE}
   RAYON_NUM_THREADS={env:RAYON_NUM_THREADS:1}
   PYTHONSAFEPATH=1
+  SAMPLOMATIC_SUPPRESS_BETA_WARNING=YES
 deps =
 dependency_groups =
   testing
@@ -100,6 +101,7 @@ dependency_groups =
     docs
 setenv = 
   PYDEVD_DISABLE_FILE_VALIDATION = 1
+  SAMPLOMATIC_SUPPRESS_BETA_WARNING=YES
 commands =
   sphinx-build -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 
@@ -113,6 +115,7 @@ dependency_groups =
     docs
 setenv = 
   PYDEVD_DISABLE_FILE_VALIDATION = 1
+  SAMPLOMATIC_SUPPRESS_BETA_WARNING=YES
 commands =
   sphinx-build -j auto -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 
@@ -127,6 +130,7 @@ dependency_groups =
 setenv = 
   QISKIT_DOCS_SKIP_EXECUTE = 1
   PYDEVD_DISABLE_FILE_VALIDATION = 1
+  SAMPLOMATIC_SUPPRESS_BETA_WARNING=YES
 commands =
   sphinx-build -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 
@@ -143,6 +147,7 @@ dependency_groups =
     docs
 setenv =
   PYDEVD_DISABLE_FILE_VALIDATION = 1
+  SAMPLOMATIC_SUPPRESS_BETA_WARNING=YES
 commands =
   sphinx-build -j auto -T -W --keep-going -b html {posargs} docs/ docs/_build/html
 


### PR DESCRIPTION
This warning causes the docs CI to fail because jupyter sphinx has only two options -- fail for any output to stderr or don't fail -- and we need to fail if there is an error in the docs output from jupyter sphinx, so we have to make sure there are no other unexpected warnings.