### PR TITLE
Address compatibility issues with Sphinx 9

### DIFF
--- a/docs/_ext/custom_styles/option_parser.py
+++ b/docs/_ext/custom_styles/option_parser.py
@@ -17,6 +17,7 @@ A class to recursively collect option documentation from current class.
 import copy
 import inspect
 import re
+from itertools import chain
 from typing import Any
 
 import numpy as np
@@ -24,47 +25,85 @@ from sphinx.application import Sphinx
 from sphinx.ext.autodoc import Options as SphinxOptions
 from sphinx.ext.napoleon import Config as NapoleonConfig
 from sphinx.ext.napoleon import GoogleDocstring
+from qiskit.providers import Options
 
 
 _parameter_doc_regex = re.compile(r"(.+?)\(\s*(.*[^\s]+)\s*\):(.*[^\s]+)")
 
 
-class QiskitExperimentsOptionsDocstring(GoogleDocstring):
-    """GoogleDocstring with updated parameter field formatter.
-
-    This docstring parser may take options mapping in the Sphinx option
-    and inject :default_val: role to the restructured text to manage default value.
-
-    Since this class overrides a protected member, it might be sensitive to napoleon version.
+def _inject_roles(
+    lines: list[str],
+    default_opt_values: Options = None,
+    desc_sources: dict[str, str] | None = None,
+) -> list[str]:
+    """Post-process GoogleDocstring output to inject custom roles.
+    
+    This function loops through a Sphinx reStructuredText function signature docstring
+    and adds extra :default_val: and :source: roles at the end of each parameter's group.
+    
+    Example:
+        Input lines::
+        
+            :param delay: Delay times
+            :type delay: float
+            :param shots: Number of shots
+            :type shots: int
+        
+        Output lines::
+        
+            :param delay: Delay time
+            :type delay: float
+            :default_val delay: 1.0
+            :source delay: :class:`~.MyClass`
+            :param shots: Number of shots
+            :type shots: int
+            :default_val shots: 1024
+            :source shots: :class:`~.MyClass`
+    
+    Args:
+        lines: Sphinx reStructuredText function argument docstring lines from
+            (such as output by GoogleDocstring.lines()).
+        default_opt_values: Options object containing default values for parameters.
+        desc_sources: Dictionary mapping parameter names to their fully qualified source class
+            names.
+        
+    Returns:
+        Modified list of lines with custom roles injected.
     """
-
-    def _format_docutils_params(
-        self,
-        fields: list[tuple[str, str, list[str]]],
-        field_role: str = "param",
-        type_role: str = "type",
-        default_role: str = "default_val",
-        source_role: str = "source",
-    ) -> list[str]:
-        lines = []
-        for _name, _type, _desc in fields:
-            _desc = self._strip_empty(_desc)
-            if any(_desc):
-                _desc = self._fix_field_desc(_desc)[0]
-                lines.append(f":{field_role} {_name}: {_desc}")
-            else:
-                lines.append(f":{field_role} {_name}: ")
-            if _type:
-                lines.append(f":{type_role} {_name}: {_type}")
-            if "default_opt_values" in self._opt:
-                value = _value_repr(self._opt["default_opt_values"].get(_name, None))
-                lines.append(f":{default_role} {_name}: {value}")
-            if "desc_sources" in self._opt and _name in self._opt["desc_sources"]:
-                source = self._opt["desc_sources"][_name]
-                lines.append(f":{source_role} {_name}: :class:`~.{source}`")
-            else:
-                lines.append(f":{source_role} {_name}: Unknown class")
-        return lines + [""]
+    # Pattern to match :param lines
+    param_pattern = re.compile(r'^:param\s+(\w+):')
+    
+    result = []
+    current_param = None
+    
+    # Use chain to append None as sentinel value to trigger last parameter processing
+    for line in chain(lines, [None]):
+        end_of_docstring = line is None
+        
+        # Check if this is a :param line (None won't match)
+        param_match = param_pattern.match(line) if not end_of_docstring else None
+        
+        if param_match or end_of_docstring:
+            # If we already have a current_param, inject its custom roles first
+            if current_param is not None:
+                if default_opt_values is not None:
+                    value = _value_repr(default_opt_values.get(current_param, None))
+                    result.append(f":default_val {current_param}: {value}")
+                
+                if desc_sources is not None and current_param in desc_sources:
+                    source = desc_sources[current_param]
+                    result.append(f":source {current_param}: :class:`~.{source}`")
+                else:
+                    result.append(f":source {current_param}: Unknown class")
+            
+            # Update current_param to the new parameter (or None if sentinel)
+            current_param = param_match.group(1) if param_match else None
+        
+        # Add the current line to result (skip the sentinel None)
+        if not end_of_docstring:
+            result.append(line)
+    
+    return result
 
 
 def process_default_options(
@@ -109,24 +148,23 @@ def process_default_options(
             "Use Google style docstring. PEP484 type annotations is not supported for options."
         )
 
-    extra_info = {
-        "default_opt_values": default_options,
-        "desc_sources": desc_sources,
-    }
-
-    # Relying on GoogleDocstring to apply typehint automation
-    _options = options.copy()
-    _options.update(extra_info)
+    # Use GoogleDocstring to parse and format the docstring
     _config = copy.copy(config)
     _config.napoleon_use_param = True
-    docstring = QiskitExperimentsOptionsDocstring(
+    docstring = GoogleDocstring(
         docstring=descriptions,
         config=_config,
         app=app,
         obj=current_class,
-        options=_options,
+        options=options,
     )
-    return docstring.lines()
+    
+    # Post-process to inject custom roles
+    return _inject_roles(
+        lines=docstring.lines(),
+        default_opt_values=default_options,
+        desc_sources=desc_sources,
+    )
 
 
 def _flatten_option_docs(

--- a/docs/_ext/custom_styles/utils.py
+++ b/docs/_ext/custom_styles/utils.py
@@ -53,7 +53,7 @@ def _generate_analysis_ref(
 
     if not issubclass(current_class, BaseExperiment):
         # check if no more base class
-        raise TypeError("This is not valid experiment class.")
+        raise TypeError(f"{current_class} is not valid experiment class.")
 
     experiment_option_parser = GoogleDocstring(
         docstring=prepare_docstring(current_class.__doc__, tabsize=len(indent)),
@@ -77,7 +77,7 @@ def _generate_analysis_ref(
                 pass
 
     if analysis_ref_start is None:
-        raise Exception(f"Option docstring for analysis_ref is missing.")
+        raise Exception(f"Option docstring for analysis_ref is missing for {current_class}.")
 
     analysis_ref_lines = []
     for line in lines[analysis_ref_start + 1:]:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -199,9 +199,34 @@ def _get_version_label(current_version):
         return "Development"
 
 
+def convert_type_alias_docstrings(app, what, name, obj, options, lines):
+    """Check objects marked as type aliases, which we handle in a custom way
+
+    Sphinx autodoc does not handle type aliases well so we bypass its system
+    and just use our own system of saving descriptions next to the aliases in
+    the code and retrieving those descriptions here.
+    """
+    mod_name, _, _ = name.rpartition(".")
+    mod = sys.modules.get(mod_name)
+    if mod is None:
+        return
+
+    aliases_mapping = getattr(mod, "__type_aliases__", None)
+    if aliases_mapping is None:
+        return
+
+    if name not in aliases_mapping:
+        return
+
+    description = aliases_mapping[name]
+    lines.clear()
+    lines.append(description)
+
+
 def setup(app):
     app.connect("config-inited", _get_versions)
     app.connect("autodoc-skip-member", maybe_skip_member)
+    app.connect("autodoc-process-docstring", convert_type_alias_docstrings)
     # Explicitly add nbsphinx-gallery.css to the app because it otherwise does
     # not get added to the output html pages. Debugging shows that nbsphinx
     # does call app.add_css_file itself but perhaps it calls it too late and

--- a/qiskit_experiments/framework/__init__.py
+++ b/qiskit_experiments/framework/__init__.py
@@ -171,6 +171,7 @@ from .provider_interfaces import (
     MeasLevel,
     MeasReturnType,
     Provider,
+    __local_type_aliases__ as _provider_type_aliases,
 )
 
 from .base_analysis import BaseAnalysis
@@ -198,3 +199,11 @@ from .backend_partition import (
     partition_qubit_pairs,
 )
 from .json import ExperimentEncoder, ExperimentDecoder
+
+
+def _promote_type_aliases(module_name: str, alias_dict: dict[str, str]):
+    """Helper to promote type aliases to fully qualified names for convert_type_alias_docstrings"""
+    return {f"{module_name}.{name}": value for name, value in alias_dict.items()}
+
+
+__type_aliases__ = _promote_type_aliases(__name__, _provider_type_aliases)

--- a/qiskit_experiments/framework/provider_interfaces.py
+++ b/qiskit_experiments/framework/provider_interfaces.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from enum import Enum, IntEnum
 from json import JSONEncoder, JSONDecoder
-from typing import Protocol, TYPE_CHECKING
+from typing import Annotated, Protocol, TYPE_CHECKING, TypeAlias
 
 from qiskit.result import Result
 from qiskit.primitives import PrimitiveResult
@@ -32,6 +32,12 @@ from qiskit.providers import Backend, JobStatus
 
 if TYPE_CHECKING:
     from qiskit_experiments.database_service import DbExperimentData, DbAnalysisResultData
+
+
+# Local type aliases for convert_type_alias_docstrings. The keys are simple
+# type names that will need to be promoted to fully qualified names in the
+# module documenting the aliases as public
+__local_type_aliases__ = {}
 
 
 class BaseJob(Protocol):
@@ -66,8 +72,8 @@ class ExtendedJob(BaseJob, Protocol):
         raise NotImplementedError
 
 
-Job = BaseJob | ExtendedJob
-"""Union type of job interfaces supported by Qiskit Experiments"""
+Job: TypeAlias = BaseJob | ExtendedJob
+__local_type_aliases__["Job"] = "Union type of job interfaces supported by Qiskit Experiments"
 
 
 class BaseProvider(Protocol):
@@ -85,8 +91,12 @@ class BaseProvider(Protocol):
         raise NotImplementedError
 
 
-Provider = BaseProvider
-"""Type alias of provider interface supported by Qiskit Experiments"""
+# Wrap with Annotated to bypass Sphinx alias detection so that our custom
+# docstring is used
+Provider: TypeAlias = Annotated[BaseProvider, "Provider"]
+__local_type_aliases__["Provider"] = (
+    "Type alias of provider interfaces supported by Qiskit Experiments"
+)
 
 
 class MeasReturnType(str, Enum):

--- a/qiskit_experiments/test/noisy_delay_aer_simulator.py
+++ b/qiskit_experiments/test/noisy_delay_aer_simulator.py
@@ -57,7 +57,7 @@ class NoisyDelayAerBackend(AerSimulator):
 
         Args:
             run_input: List of circuit to run.
-            run_options (kwargs): additional run time backend options.
+            run_options: additional run time backend options.
 
         Returns:
             AerJob: A job that contains the simulated data.


### PR DESCRIPTION
* Address references to private class attributes (like `GoogleDocstring._opt`) that were removed in Sphinx 9 by refactoring the custom option docstring code to work differently. Instead of subclassing `GoogleDocstring` and modifying its private methods, the code now runs `GoogleDocstring` and then post-processes its output to add in the custom roles related to qiskit-experiments options (marking the default value and source of the output in the class hierarchy).
* Remove stray `kwargs` type annotation. This didn't make sense as a type and became a problem with Sphinx 9 because it tried to look up a reference for `kwargs` and found multiple classes with a `kwargs` attribute and could not determine which one to use.
* Make documentation of type aliases more explicit. The `Provider` type alias to `BaseProvider` became a problem because it was being detected by Sphinx as both a class and a variable and both docstring paths seemed to be executed resulting in a combined docstring with mismatched indentation. Here `Annotated` was used to break the detection of `Provider` as a class, `TypeAlias` was used to help hint to Sphinx that these assignments are not simple module variables, and a new `__type_aliases__` system was added for passing explicit descriptions of the type aliases to Sphinx instead of relying on the default "alias of ..." generated docstring which does not convey the purpose of the alias (combining multiple types into one to indicate where the code allows the different types as a single kind of type conceptually rather than just happening to handle some assortment of unrelated types).
* Add class name to some docs code errors so it is easier to tell what is going wrong.