### PR TITLE
Avoid division by zero error in RB analysis classes

### DIFF
--- a/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/interleaved_rb_analysis.py
@@ -142,12 +142,26 @@ class InterleavedRBAnalysis(curve.CurveAnalysis):
         # for standard RB curve
         std_curve = curve_data.filter(series="standard")
         alpha_std = curve.guess.rb_decay(std_curve.x, std_curve.y, b=b_guess)
-        a_std = (std_curve.y[0] - b_guess) / (alpha_std ** std_curve.x[0])
+        if alpha_std < 0.6:
+            # Don't account for decay in estimating a if decay appears to be
+            # very strong
+            a_std = std_curve.y[0] - b_guess
+        else:
+            a_std = (std_curve.y[0] - b_guess) / (alpha_std ** std_curve.x[0])
+        # Make sure a is in the default (0, 1) bounds
+        a_std = max(0, a_std)
 
         # for interleaved RB curve
         int_curve = curve_data.filter(series="interleaved")
         alpha_int = curve.guess.rb_decay(int_curve.x, int_curve.y, b=b_guess)
-        a_int = (int_curve.y[0] - b_guess) / (alpha_int ** int_curve.x[0])
+        if alpha_int < 0.6:
+            # Don't account for decay in estimating a if decay appears to be
+            # very strong
+            a_int = int_curve.y[0] - b_guess
+        else:
+            a_int = (int_curve.y[0] - b_guess) / (alpha_int ** int_curve.x[0])
+        # Make sure a is in the default (0, 1) bounds
+        a_int = max(0, a_int)
 
         alpha_c = min(alpha_int / alpha_std, 1.0)
 

--- a/qiskit_experiments/library/randomized_benchmarking/layer_fidelity_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/layer_fidelity_analysis.py
@@ -124,7 +124,14 @@ class _ProcessFidelityAnalysis(curve.CurveAnalysis):
 
         b_guess = 1 / 2 ** len(self._physical_qubits)
         alpha_guess = curve.guess.rb_decay(curve_data.x, curve_data.y, b=b_guess)
-        a_guess = (curve_data.y[0] - b_guess) / (alpha_guess ** curve_data.x[0])
+        if alpha_guess < 0.6:
+            # Don't account for decay in estimating a if decay appears to be
+            # very strong
+            a_guess = curve_data.y[0] - b_guess
+        else:
+            a_guess = (curve_data.y[0] - b_guess) / (alpha_guess ** curve_data.x[0])
+        # Make sure a is in the default (0, 1) bounds
+        a_guess = max(0, a_guess)
 
         user_opt.p0.set_if_empty(
             b=b_guess,

--- a/qiskit_experiments/library/randomized_benchmarking/purity_rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/purity_rb_analysis.py
@@ -230,9 +230,13 @@ class PurityRBAnalysis(RBAnalysis):
         alpha_guess = alpha_guess**2
 
         if alpha_guess < 0.6:
+            # Don't account for decay in estimating a if decay appears to be
+            # very strong
             a_guess = curve_data.y[0] - b_guess
         else:
             a_guess = (curve_data.y[0] - b_guess) / (alpha_guess ** curve_data.x[0])
+        # Make sure a is in the default (0, 1) bounds
+        a_guess = max(0, a_guess)
 
         user_opt.p0.set_if_empty(
             b=b_guess,

--- a/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
+++ b/qiskit_experiments/library/randomized_benchmarking/rb_analysis.py
@@ -147,7 +147,14 @@ class RBAnalysis(curve.CurveAnalysis):
 
         b_guess = 1 / 2 ** len(self._physical_qubits)
         alpha_guess = curve.guess.rb_decay(curve_data.x, curve_data.y, b=b_guess)
-        a_guess = (curve_data.y[0] - b_guess) / (alpha_guess ** curve_data.x[0])
+        if alpha_guess < 0.6:
+            # Don't account for decay in estimating a if decay appears to be
+            # very strong
+            a_guess = curve_data.y[0] - b_guess
+        else:
+            a_guess = (curve_data.y[0] - b_guess) / (alpha_guess ** curve_data.x[0])
+        # Make sure a is in the default (0, 1) bounds
+        a_guess = max(0, a_guess)
 
         user_opt.p0.set_if_empty(
             b=b_guess,

--- a/releasenotes/notes/fix-lf-a-guess-b233965d13ed0492.yaml
+++ b/releasenotes/notes/fix-lf-a-guess-b233965d13ed0492.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The logic for guessing decay curve parameters used by
+    :class:`.LayerFidelityAnalysis`, :class:`.RBAnalysis`, and
+    :class:`.InterleavedRBAnalysis` has been updated to avoid a division by
+    zero when processing poor data. :class:`.PurityRBAnalysis` already had a
+    mitigation for the error in place and that mitigation was propagated to the
+    other analysis classes.


### PR DESCRIPTION
The logic for guessing decay curve parameters used by `LayerFidelityAnalysis`, `RBAnalysis`, and `InterleavedRBAnalysis` is updated here to avoid a division by zero when processing poor data. `PurityRBAnalysis` already had a mitigation for the error in place and that mitigation was propagated to the other analysis classes. `PurityRBAnalysis` was updated slightly to keep its guess for `a` within the default parameter bounds.

Here is a short description of what would lead to the division by zero error. The RB fit model is `a * alpha ** x + b`. To guess `alpha`, the analysis code takes all the data greater than the guess for `b` (0.25 for two qubit RB), subtracts `b`, and then divides adjacent points (to remove `alpha`). When there are no points greater than `b`, it guess 0 for `alpha`. The guess for `alpha` is then used to guess `a` by inverting the model and that involves dividing by `alpha`, which would lead to the divide by 0 error. Here the case of small `alpha` now avoids division by `alpha`. The small `alpha` case is taken as less than 0.6 (what `PurityRBAnalysis` had already been using). With `alpha` coming out less than 0.6, it is unlikely the data are going to give a useful fit any way.